### PR TITLE
feat(api)!: Send media files as URI instead of base 64 encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ All notable changes to Pixano will be documented in this file.
 
 ### Changed
 
-- **Breaking:** Send media files as URI instead of a base 64 encodings in Pixano API. Allows for better speed and flexibility for more complex dataset, but drops support for datasets imported without copying media files (`portable=False`)
-- **Breaking:** Remove the `portable=False` option from importers. Instead users can choose to either **copy or move the media files** to the dataset directory
+- **Breaking:** Send media files as URI instead of base 64 encodings in Pixano API. Allows for better speed and flexibility for more complex dataset, but drops support for datasets imported without copying media files (`portable=False`)
+- Remove the `portable=False` option from importers. Instead users can choose to either **copy or move the media files** to the dataset directory
 - Update README with a small header description listing main features
 - Update documentation website accent color to match with the new theme of the Pixano apps
 - Update API reference generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to Pixano will be documented in this file.
 
 ### Changed
 
+- **Breaking:** Send media files as URI instead of a base 64 encodings in Pixano API. Allows for better speed and flexibility for more complex dataset, but drops support for datasets imported without copying media files (`portable=False`)
+- **Breaking:** Remove the `portable=False` option from importers. Instead users can choose to either **copy or move the media files** to the dataset directory
 - Update README with a small header description listing main features
 - Update documentation website accent color to match with the new theme of the Pixano apps
 - Update API reference generation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 Pixano is an open-source tool by CEA List for exploring and annotating your dataset using AI features:
 
 - **Fast dataset navigation** using the the modern storage format _Lance_
-- **Multi-view datasets** support for images, and soon for _3D point clouds_ and _videos_.
+- **Multi-view datasets** support for images, and soon for _3D point clouds_ and _videos_
 - **Import and export** support for dataset formats like _COCO_
 - **Semantic search** using models like _CLIP_
 - **Smart segmentation** using models like _SAM_

--- a/notebooks/datasets/export_dataset.ipynb
+++ b/notebooks/datasets/export_dataset.ipynb
@@ -99,9 +99,11 @@
    "metadata": {},
    "source": [
     "#### Export dataset\n",
-    "Set `portable=True` to copy or download the media files to the export directory and use relative paths to look for them, or leave it to `False` to keep the files in place and refer to them using absolute paths.\n",
+    "**Media files** will be referred to using **absolute paths**.\n",
+    "- Use `copy=True` to copy the media files to the export directory and refer to those.\n",
+    "- Use `copy=False` to refer to the media files in the input directory directly.\n",
     "\n",
-    "You can use `splits` and `objects_sources` to specify which parts of your dataset you want to export."
+    "You can also use `splits` and `objects_sources` to specify which parts of your dataset you want to export."
    ]
   },
   {
@@ -120,7 +122,7 @@
    "outputs": [],
    "source": [
     "exporter = COCOExporter()\n",
-    "exporter.export_dataset(input_dir, export_dir, portable=False)"
+    "exporter.export_dataset(input_dir, export_dir, copy=True)"
    ]
   }
  ],

--- a/notebooks/datasets/import_dataset.ipynb
+++ b/notebooks/datasets/import_dataset.ipynb
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,8 +79,8 @@
     "- Annotations will be **transformed to Pixano format** and stored in a database while **keeping the original files intact**.\n",
     "\n",
     "How Pixano handles **media files**:\n",
-    "- By default, media files such as images and videos will be **referred to using their current path or URL**. This is the best option for **large datasets** and datasets on **remote servers** and **S3 buckets**, for which the media paths won't change.\n",
-    "- You can use the `portable=True` option to **copy or download the media files** inside the Pixano format dataset, and use relative paths. This is the best option for **smaller datasets**, for which you want to be able to move the media files with them. Otherwise, Pixano will use absolute paths to look for media files.\n",
+    "- By default, **media files will be copied** to the target directory (`copy=True`).\n",
+    "- You can also **move the media files** instead of copying them (`copy=False`).\n",
     "\n",
     "### Import from image-only dataset\n",
     "If your dataset contains only images, you can use our predefined ImageImporter to import it to Pixano format.\n",
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,8 @@
    "metadata": {},
    "source": [
     "#### Import dataset\n",
-    "Set `portable=True` to copy or download the media files to the Pixano dataset and use relative paths to look for them, or leave it to `False` to keep the files in place and refer to them using absolute paths."
+    "- Use `copy=True` to copy the media files to the Pixano dataset and keep the original files in place\n",
+    "- Use `copy=False` to move the media files inside the Pixano dataset"
    ]
   },
   {
@@ -163,12 +164,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "importer = ImageImporter(name, description, splits)\n",
-    "importer.import_dataset(input_dirs, import_dir, portable=False)"
+    "importer.import_dataset(input_dirs, import_dir, copy=True)"
    ]
   },
   {
@@ -240,7 +241,8 @@
    "metadata": {},
    "source": [
     "#### Import dataset\n",
-    "Set `portable=True` to copy or download the media files to the Pixano dataset and use relative paths to look for them, or leave it to `False` to keep the files in place and refer to them using absolute paths."
+    "- Use `copy=True` to copy the media files to the Pixano dataset and keep the original files in place\n",
+    "- Use `copy=False` to move the media files inside the Pixano dataset"
    ]
   },
   {
@@ -259,7 +261,7 @@
    "outputs": [],
    "source": [
     "importer = COCOImporter(name, description, splits)\n",
-    "importer.import_dataset(input_dirs, import_dir, portable=False)"
+    "importer.import_dataset(input_dirs, import_dir, copy=True)"
    ]
   },
   {

--- a/notebooks/datasets/template_importer.py
+++ b/notebooks/datasets/template_importer.py
@@ -15,11 +15,8 @@ import glob
 from collections.abc import Iterator
 from pathlib import Path
 
-import pyarrow as pa
-import shortuuid
-
 from pixano.core import BBox, CompressedRLE, Image
-from pixano.data import Fields, Importer
+from pixano.data import Importer
 from pixano.utils import coco_names_91, image_to_thumbnail
 
 
@@ -89,13 +86,11 @@ class TemplateImporter(Importer):
     def import_rows(
         self,
         input_dirs: dict[str, Path],
-        portable: bool = False,
     ) -> Iterator:
         """Process dataset rows for import
 
         Args:
             input_dirs (dict[str, Path]): Input directories
-            portable (bool, optional): True to move or download media files inside dataset. Defaults to False.
 
         Yields:
             Iterator: Processed rows
@@ -113,11 +108,7 @@ class TemplateImporter(Importer):
                 # Create image thumbnail
                 im_thumb = image_to_thumbnail(im_path.read_bytes())
                 # Set image URI
-                im_uri = (
-                    f"image/{split}/{im_path.name}"
-                    if portable
-                    else im_path.absolute().as_uri()
-                )
+                im_uri = f"image/{split}/{im_path.name}"
                 # Load image
                 image = Image(im_uri, None, im_thumb)
                 w, h = image.size

--- a/notebooks/models/interactive_annotation.ipynb
+++ b/notebooks/models/interactive_annotation.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
     "library_dir = Path(\"my_datasets/\")\n",
     "dataset_dir = library_dir / \"coco_instances\"\n",
     "\n",
-    "views = [\"image\"]\n",
+    "views = []\n",
     "splits = []"
    ]
   },

--- a/pixano/api/items.py
+++ b/pixano/api/items.py
@@ -14,6 +14,7 @@
 import base64
 from collections import defaultdict
 from typing import Any
+from urllib.parse import urlparse
 
 import duckdb
 import lancedb
@@ -275,9 +276,14 @@ def load_item_details(dataset: Dataset, item_id: str) -> dict:
                 item[field.name] = Image.from_dict(item[field.name])
             image = item[field.name]
             image.uri_prefix = dataset.media_dir.absolute().as_uri()
+            image_uri = (
+                f"data/{dataset.path.name}/media/{image.uri}"
+                if urlparse(image.uri).scheme == ""
+                else image.uri
+            )
             item_details["itemData"]["views"][field.name] = {
                 "id": field.name,
-                "url": image.url,
+                "uri": image_uri,
                 "height": image.size[1],
                 "width": image.size[0],
             }

--- a/pixano/apps/main.py
+++ b/pixano/apps/main.py
@@ -62,10 +62,16 @@ def create_app(settings: Settings = Settings()) -> FastAPI:
             f"Dataset library '{settings.data_dir.absolute()}' not found"
         )
 
-    # Create models folder
+    # Create models directory
     model_dir = settings.data_dir / "models"
     model_dir.mkdir(exist_ok=True)
-    app.mount("/models", StaticFiles(directory=model_dir), name="models")
+
+    # Mount data directory (datasets + models)
+    app.mount(
+        "/data",
+        StaticFiles(directory=settings.data_dir),
+        name="data",
+    )
 
     @app.get("/datasets", response_model=list[DatasetInfo])
     async def get_dataset_list():

--- a/pixano/core/image.py
+++ b/pixano/core/image.py
@@ -117,7 +117,7 @@ class Image(PixanoType, BaseModel):
                 return parsed_uri.geturl()
             # No URI prefix
             else:
-                raise Exception("Need Uri prefix for relative uri")
+                raise Exception("Need URI prefix for relative URI")
         # Complete URI
         else:
             return self.uri

--- a/pixano/data/exporters/coco_exporter.py
+++ b/pixano/data/exporters/coco_exporter.py
@@ -48,14 +48,10 @@ class COCOExporter(Exporter):
             portable (bool, optional): True to copy or download files to export directory and use relative paths. Defaults to False.
         """
 
-        # Create URI prefix
-        media_dir = input_dir / "media"
-        uri_prefix = media_dir.absolute().as_uri()
-        export_uri_prefix = (export_dir / "media").absolute().as_uri()
-
         # Load dataset
         dataset = Dataset(input_dir)
         ds = dataset.connect()
+
         main_table: lancedb.db.LanceTable = ds.open_table("db")
 
         image_table: dict[str, lancedb.db.LanceTable]
@@ -85,6 +81,11 @@ class COCOExporter(Exporter):
                         raise FileNotFoundError(f"Objects table not found: {e}") from e
         else:
             raise Exception("No objects table to export")
+
+        # Create URI prefix
+        media_dir = dataset.media_dir
+        uri_prefix = media_dir.absolute().as_uri()
+        export_uri_prefix = (export_dir / "media").absolute().as_uri()
 
         # Create export directory
         ann_dir = export_dir / f"annotations [{', '.join(list(obj_tables.keys()))}]"

--- a/pixano/data/exporters/coco_exporter.py
+++ b/pixano/data/exporters/coco_exporter.py
@@ -36,7 +36,7 @@ class COCOExporter(Exporter):
         export_dir: Path,
         splits: list[str] = None,
         objects_sources: list[str] = None,
-        portable: bool = False,
+        copy: bool = True,
     ):
         """Export dataset back to original format
 
@@ -45,7 +45,7 @@ class COCOExporter(Exporter):
             export_dir (Path): Export directory
             splits (list[str], optional): Dataset splits to export, all if None. Defaults to None.
             objects_sources (list[str], optional): Objects sources to export, all if None. Defaults to None.
-            portable (bool, optional): True to copy or download files to export directory and use relative paths. Defaults to False.
+            copy (bool, optional): True to copy files to export directory. Defaults to True.
         """
 
         # Load dataset
@@ -84,8 +84,11 @@ class COCOExporter(Exporter):
 
         # Create URI prefix
         media_dir = dataset.media_dir
-        uri_prefix = media_dir.absolute().as_uri()
-        export_uri_prefix = (export_dir / "media").absolute().as_uri()
+        uri_prefix = (
+            (export_dir / "media").absolute().as_uri()
+            if copy
+            else media_dir.absolute().as_uri()
+        )
 
         # Create export directory
         ann_dir = export_dir / f"annotations [{', '.join(list(obj_tables.keys()))}]"
@@ -153,9 +156,7 @@ class COCOExporter(Exporter):
                         for field_name in image_field_names:
                             # Open image
                             ims[field_name] = Image.from_dict(row[field_name])
-                            ims[field_name].uri_prefix = (
-                                export_uri_prefix if portable else uri_prefix
-                            )
+                            ims[field_name].uri_prefix = uri_prefix
                             im_filename = Path(
                                 urlparse(ims[field_name].get_uri()).path
                             ).name
@@ -242,12 +243,7 @@ class COCOExporter(Exporter):
                 with open(ann_dir / f"instances_{split}.json", "w") as f:
                     json.dump(coco_json, f)
 
-        # Copy media directory if portable
-        if portable:
-            if media_dir.exists():
-                if media_dir != export_dir / "media":
-                    shutil.copytree(media_dir, export_dir / "media", dirs_exist_ok=True)
-            else:
-                raise Exception(
-                    f"Activated portable option for export but {media_dir} does not exist."
-                )
+        # Copy media directory
+        if copy:
+            if media_dir.exists() and media_dir != export_dir / "media":
+                shutil.copytree(media_dir, export_dir / "media", dirs_exist_ok=True)

--- a/pixano/data/importers/coco_importer.py
+++ b/pixano/data/importers/coco_importer.py
@@ -100,13 +100,11 @@ class COCOImporter(Importer):
     def import_rows(
         self,
         input_dirs: dict[str, Path],
-        portable: bool = False,
     ) -> Iterator:
         """Process dataset rows for import
 
         Args:
             input_dirs (dict[str, Path]): Input directories
-            portable (bool, optional): True to move or download media files inside dataset. Defaults to False.
 
         Yields:
             Iterator: Processed rows
@@ -140,11 +138,7 @@ class COCOImporter(Importer):
                 im_thumb = image_to_thumbnail(im_path.read_bytes())
 
                 # Set image URI
-                im_uri = (
-                    f"image/{split}/{im_path.name}"
-                    if portable
-                    else im_path.absolute().as_uri()
-                )
+                im_uri = f"image/{split}/{im_path.name}"
 
                 # Return rows
                 rows = {

--- a/pixano/data/importers/dota_importer.py
+++ b/pixano/data/importers/dota_importer.py
@@ -86,13 +86,11 @@ class DOTAImporter(Importer):
     def import_rows(
         self,
         input_dirs: dict[str, Path],
-        portable: bool = False,
     ) -> Iterator:
         """Process dataset rows for import
 
         Args:
             input_dirs (dict[str, Path]): Input directories
-            portable (bool, optional): True to move or download media files inside dataset. Defaults to False.
 
         Yields:
             Iterator: Processed rows
@@ -123,11 +121,7 @@ class DOTAImporter(Importer):
                     im_thumb = image_to_thumbnail(im)
 
                 # Set image URI
-                im_uri = (
-                    f"image/{split}/{im_path.name}"
-                    if portable
-                    else im_path.absolute().as_uri()
-                )
+                im_uri = f"image/{split}/{im_path.name}"
 
                 # Return rows
                 rows = {

--- a/pixano/data/importers/image_importer.py
+++ b/pixano/data/importers/image_importer.py
@@ -87,13 +87,11 @@ class ImageImporter(Importer):
     def import_rows(
         self,
         input_dirs: dict[str, Path],
-        portable: bool = False,
     ) -> Iterator:
         """Process dataset rows for import
 
         Args:
             input_dirs (dict[str, Path]): Input directories
-            portable (bool, optional): True to move or download media files inside dataset. Defaults to False.
 
         Yields:
             Iterator: Processed rows
@@ -117,14 +115,11 @@ class ImageImporter(Importer):
                 im_thumb = image_to_thumbnail(im_path.read_bytes())
 
                 # Set image URI
-                if portable:
-                    im_uri = (
-                        f"image/{im_path.name}"
-                        if split == "dataset"
-                        else f"image/{split}/{im_path.name}"
-                    )
-                else:
-                    im_uri = im_path.absolute().as_uri()
+                im_uri = (
+                    f"image/{im_path.name}"
+                    if split == "dataset"
+                    else f"image/{split}/{im_path.name}"
+                )
 
                 # Return rows
                 rows = {

--- a/tests/apps/test_main.py
+++ b/tests/apps/test_main.py
@@ -41,7 +41,7 @@ class AppTestCase(unittest.TestCase):
             description="COCO dataset",
             splits=["val"],
         )
-        dataset = importer.import_dataset(input_dirs, import_dir, portable=False)
+        dataset = importer.import_dataset(input_dirs, import_dir, copy=True)
 
         # Set dataset ID
         dataset.info.id = "coco_dataset"

--- a/tests/data/importers/test_coco_importer.py
+++ b/tests/data/importers/test_coco_importer.py
@@ -42,7 +42,7 @@ class COCOImporterTestCase(unittest.TestCase):
             dataset = self.importer.import_dataset(
                 self.input_dirs,
                 import_dir,
-                portable=False,
+                copy=True,
             )
 
             # Check that db.json exists

--- a/tests/data/importers/test_dota_importer.py
+++ b/tests/data/importers/test_dota_importer.py
@@ -42,7 +42,7 @@ class DOTAImporterTestCase(unittest.TestCase):
             dataset = self.importer.import_dataset(
                 self.input_dirs,
                 import_dir,
-                portable=False,
+                copy=True,
             )
 
             # Check that db.json exists

--- a/tests/data/importers/test_image_importer.py
+++ b/tests/data/importers/test_image_importer.py
@@ -39,7 +39,7 @@ class ImageImporterTestCase(unittest.TestCase):
             dataset = self.importer.import_dataset(
                 self.input_dirs,
                 import_dir,
-                portable=False,
+                copy=True,
             )
 
             # Check that db.json exists

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -36,7 +36,7 @@ class DatasetTestCase(unittest.TestCase):
             splits=["val"],
         )
         self.dataset: Dataset = importer.import_dataset(
-            input_dirs, self.path, portable=False
+            input_dirs, self.path, copy=True
         )
 
         # Set dataset ID

--- a/ui/apps/annotator/src/AnnotationWorkspace.svelte
+++ b/ui/apps/annotator/src/AnnotationWorkspace.svelte
@@ -273,7 +273,7 @@
       if (itemFeature.dtype === "image") {
         selectedItem.views[itemFeature.name] = {
           id: itemFeature.name,
-          url: itemFeature.value as string,
+          uri: itemFeature.value as string,
         };
       }
     }

--- a/ui/apps/annotator/vite.config.ts
+++ b/ui/apps/annotator/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
-      "/models": {
+      "/data": {
         target: "http://127.0.0.1:8000",
         changeOrigin: true,
         secure: false,

--- a/ui/apps/explorer/vite.config.ts
+++ b/ui/apps/explorer/vite.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      "/data": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
 });

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -144,7 +144,7 @@
     for (const view of Object.values(selectedItem.views)) {
       zoomFactor[view.id] = 1;
       images[view.id] = new Image();
-      images[view.id].src = view.url;
+      images[view.id].src = view.uri;
       images[view.id].onload = () => {
         // Find existing Konva elements in case a previous item was already loaded
         if (currentId) {

--- a/ui/components/core/src/interfaces.ts
+++ b/ui/components/core/src/interfaces.ts
@@ -32,7 +32,7 @@ export interface ItemData {
 
 export interface ViewData {
   id: string;
-  url: string;
+  uri: string;
   height?: number;
   width?: number;
 }

--- a/ui/tools/storybook/stories/apps/annotator/AnnotationWorkspace.stories.ts
+++ b/ui/tools/storybook/stories/apps/annotator/AnnotationWorkspace.stories.ts
@@ -70,7 +70,7 @@ export const Base: Story = {
       views: {
         view: {
           id: "view",
-          url: "img-02.jpg",
+          uri: "img-02.jpg",
         },
       },
       features: [

--- a/ui/tools/storybook/stories/apps/explorer/ExplorationWorkspace.stories.ts
+++ b/ui/tools/storybook/stories/apps/explorer/ExplorationWorkspace.stories.ts
@@ -35,7 +35,7 @@ export const Base: Story = {
       views: {
         view: {
           id: "view",
-          url: "img-02.jpg",
+          uri: "img-02.jpg",
         },
       },
       features: [

--- a/ui/tools/storybook/stories/components/canvas2d/Canvas2D.stories.ts
+++ b/ui/tools/storybook/stories/components/canvas2d/Canvas2D.stories.ts
@@ -43,7 +43,7 @@ export const CanvasWithoutSelectedTool: Story = {
       views: {
         view: {
           id: "view",
-          url: "img-02.jpg",
+          uri: "img-02.jpg",
         },
       },
       features: [
@@ -71,7 +71,7 @@ export const CanvasWithLabeledPointTool: Story = {
       views: {
         view: {
           id: "view",
-          url: "img-02.jpg",
+          uri: "img-02.jpg",
         },
       },
       features: [
@@ -98,7 +98,7 @@ export const CanvasWithRectangleTool: Story = {
       views: {
         view: {
           id: "view",
-          url: "img-02.jpg",
+          uri: "img-02.jpg",
         },
       },
       features: [

--- a/ui/tools/storybook/stories/components/canvas2d/LabelPanel.stories.ts
+++ b/ui/tools/storybook/stories/components/canvas2d/LabelPanel.stories.ts
@@ -38,7 +38,7 @@ export const Base: Story = {
       views: {
         view: {
           id: "view",
-          url: "img-02.jpg",
+          uri: "img-02.jpg",
         },
       },
       features: [


### PR DESCRIPTION
- **Breaking:** Send media files as URI instead of base 64 encodings in Pixano API. Allows for better speed and flexibility for more complex dataset, but drops support for datasets imported without copying media files (`portable=False`)
- Remove the `portable=False` option from importers. Instead users can choose to either **copy or move the media files** to the dataset directory