### PR TITLE
fix(back): Fix getting category name in COCO Importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Pixano will be documented in this file.
 - Fix pip commands in notebooks for Google Colab (pixano#11)
 - Fix broken link in CHANGELOG (pixano#4)
 - Fix documentation website API reference generation
+- Fix the COCO Importer to get the category name from the "categories" field as it does not always exist in the "annotations" field.
 
 ## [0.4.1] - 2023-11-13
 

--- a/pixano/data/importers/coco_importer.py
+++ b/pixano/data/importers/coco_importer.py
@@ -135,6 +135,11 @@ class COCOImporter(Importer):
             for ann in coco_instances["annotations"]:
                 annotations[ann["image_id"]].append(ann)
 
+            # Create a COCO category id to COCO category dictionary
+            categories = {}
+            for cat in coco_instances["categories"]:
+                categories[cat["id"]] = cat
+
             # Process rows
             for im in sorted(
                 coco_instances["images"], key=lambda x: natural_key(str(x["id"]))
@@ -190,7 +195,9 @@ class COCOImporter(Importer):
                                 if ann["segmentation"]
                                 else None,
                                 "category_id": int(ann["category_id"]),
-                                "category_name": str(ann["category_name"]),
+                                "category_name": str(
+                                    categories[ann["category_id"]]["name"]
+                                ),
                             }
                             for ann in im_anns
                         ]


### PR DESCRIPTION
The category_name field does not always exist in an annotation object.