### PR TITLE
feat(api): Add support for S3 datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Pixano will be documented in this file.
 
 ### Added
 
+- Add **S3** compatible storage access
 - Select **interactive segmentation models** with **dropdown menu** based on models found in directory (pixano#12)
 - Select **semantic search models** with **dropdown menu** based on embeddings found in dataset (pixano#12)
 - Add loading animation in frontend UI when loading or saving takes time (pixano#15)

--- a/docs/user/launch.md
+++ b/docs/user/launch.md
@@ -14,6 +14,17 @@ pixano-annotator <path/to/your/datasets>
 
 You will then be provided with a URL to open in your browser to use the app.
 
+### With S3 compatible storage
+
+You can connect to a S3 compatible storage, by providing a S3 path instead of local path to your datasets
+
+The followings environ variables have to be set:
+- AWS_ENDPOINT : S3 Compatible Storage endpoint
+- AWS_ACCESS_KEY_ID : access key credentials
+- AWS_SECRET_ACCESS_KEY : secret access credentials
+- AWS_REGION (optionnal): S3 region if relevant
+- LOCAL_MODEL_DIR: local path to model directory
+
 ## From a notebook
 
 If you are in a Jupyter or Google Colab notebook, you can start the Explorer and Annotator apps by running the following cells:

--- a/docs/user/launch.md
+++ b/docs/user/launch.md
@@ -19,6 +19,7 @@ You will then be provided with a URL to open in your browser to use the app.
 You can connect to a S3 compatible storage, by providing a S3 path instead of local path to your datasets
 
 The followings environ variables have to be set:
+
 - AWS_ENDPOINT : S3 Compatible Storage endpoint
 - AWS_ACCESS_KEY_ID : access key credentials
 - AWS_SECRET_ACCESS_KEY : secret access credentials

--- a/pixano/apps/main.py
+++ b/pixano/apps/main.py
@@ -62,11 +62,13 @@ def create_app(settings: Settings = Settings()) -> FastAPI:
         # don't need to mount dataset, but still need to mount model
         if settings.local_model_dir is None:
             # try to get model from S3 /models
-            #TODO
+            # TODO
             # list models in settings.data_dir / "models"
             # dl them locally (where ??) and use this as mount point
             # settings.local_model_dir = (settings.data_dir / "models").open()
-            raise Exception("download models from S3 not implemented yet, please set LOCAL_MODEL_DIR env var to a path with /models/<sam_model.onnx>)")
+            raise Exception(
+                "download models from S3 not implemented yet, please set LOCAL_MODEL_DIR env var to a path with /models/<sam_model.onnx>)"
+            )
         else:
             # use local model
             app.mount(

--- a/pixano/apps/main.py
+++ b/pixano/apps/main.py
@@ -59,22 +59,11 @@ def create_app(settings: Settings = Settings()) -> FastAPI:
         )
     else:
         # don't need to mount dataset, but still need to mount model
-        if settings.local_model_dir is None:
-            # try to get model from S3 /models
-            # TODO
-            # list models in settings.data_dir / "models"
-            # dl them locally (where ??) and use this as mount point
-            # settings.local_model_dir = (settings.data_dir / "models").open()
-            raise Exception(
-                "download models from S3 not implemented yet, please set LOCAL_MODEL_DIR env var to a path with /models/<sam_model.onnx>)"
-            )
-        else:
-            # use local model
-            app.mount(
-                "/data",
-                StaticFiles(directory=settings.local_model_dir),
-                name="data",
-            )
+        app.mount(
+            "/data",
+            StaticFiles(directory=settings.local_model_dir),
+            name="data",
+        )
 
     app.include_router(datasets.router)
     app.include_router(items.router)

--- a/pixano/apps/main.py
+++ b/pixano/apps/main.py
@@ -11,12 +11,11 @@
 #
 # http://www.cecill.info
 
-from s3path import S3Path
-
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi_pagination.api import add_pagination
+from s3path import S3Path
 
 from pixano.apps.api import datasets, items, models
 from pixano.data import Settings

--- a/pixano/core/image.py
+++ b/pixano/core/image.py
@@ -12,6 +12,7 @@
 # http://www.cecill.info
 
 from pathlib import Path
+from s3path import S3Path
 from typing import IO, Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -174,7 +175,12 @@ class Image(PixanoType, BaseModel):
             IO: Opened image
         """
 
-        return urlopen(self.get_uri())
+        uri = self.get_uri()
+        if urlparse(uri).scheme == "s3":
+            presigned_url = S3Path.from_uri(uri).get_presigned_url()
+            return urlopen(presigned_url)
+        else:
+            return urlopen(uri)
 
     def as_pillow(self) -> PILImage.Image:
         """Open image as Pillow

--- a/pixano/core/image.py
+++ b/pixano/core/image.py
@@ -12,7 +12,6 @@
 # http://www.cecill.info
 
 from pathlib import Path
-from s3path import S3Path
 from typing import IO, Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -23,6 +22,7 @@ import pyarrow as pa
 from IPython.core.display import Image as IPyImage
 from PIL import Image as PILImage
 from pydantic import BaseModel
+from s3path import S3Path
 
 from pixano.core.pixano_type import PixanoType, create_pyarrow_type
 from pixano.utils import binary_to_url

--- a/pixano/data/dataset/dataset.py
+++ b/pixano/data/dataset/dataset.py
@@ -13,6 +13,7 @@
 
 from collections import defaultdict
 from pathlib import Path
+from s3path import S3Path
 from typing import Optional
 
 import duckdb
@@ -123,7 +124,10 @@ class Dataset(BaseModel):
             lancedb.DBConnection: Dataset LanceDB connection
         """
 
-        return lancedb.connect(self.path)
+        if isinstance(self.path, S3Path):
+            return lancedb.connect(self.path.as_uri())
+        else:
+            return lancedb.connect(self.path)
 
     def open_tables(self) -> dict[str, dict[str, lancedb.db.LanceTable]]:
         """Open dataset tables with LanceDB

--- a/pixano/data/dataset/dataset.py
+++ b/pixano/data/dataset/dataset.py
@@ -13,7 +13,6 @@
 
 from collections import defaultdict
 from pathlib import Path
-from s3path import S3Path
 from typing import Optional
 
 import duckdb
@@ -21,6 +20,7 @@ import lancedb
 import pyarrow as pa
 import pyarrow.dataset as pa_ds
 from pydantic import BaseModel
+from s3path import S3Path
 
 from pixano.core import Image
 from pixano.data.dataset.dataset_info import DatasetInfo

--- a/pixano/data/dataset/dataset_info.py
+++ b/pixano/data/dataset/dataset_info.py
@@ -13,10 +13,10 @@
 
 import json
 from pathlib import Path
-from s3path import S3Path
 from typing import Optional
 
 from pydantic import BaseModel
+from s3path import S3Path
 
 from pixano.core import Image
 from pixano.data.dataset.dataset_category import DatasetCategory

--- a/pixano/data/dataset/dataset_stat.py
+++ b/pixano/data/dataset/dataset_stat.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseModel
+from s3path import S3Path
 
 
 class DatasetStat(BaseModel):
@@ -44,7 +45,11 @@ class DatasetStat(BaseModel):
             list[DatasetStats]: List of DatasetStat
         """
 
-        with open(json_fp) as json_file:
-            stats_json = json.load(json_file)
+        if isinstance(json_fp, S3Path):
+            with json_fp.open() as json_file:
+                stats_json = json.load(json_file)
+        else:
+            with open(json_fp) as json_file:
+                stats_json = json.load(json_file)
 
         return [DatasetStat.model_validate(stat) for stat in stats_json]

--- a/pixano/data/item/item_view.py
+++ b/pixano/data/item/item_view.py
@@ -12,12 +12,12 @@
 # http://www.cecill.info
 
 from pathlib import Path
-from s3path import S3Path
 from typing import Optional
 from urllib.parse import urlparse
 
 import pyarrow as pa
 from pydantic import BaseModel
+from s3path import S3Path
 
 from pixano.core import Image, is_image_type
 from pixano.data.item.item_feature import ItemFeature

--- a/pixano/data/settings.py
+++ b/pixano/data/settings.py
@@ -13,15 +13,58 @@
 
 
 from pathlib import Path
+from s3path import S3Path, register_configuration_parameter
+import boto3
+from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings
+from typing import Optional
 
 
 class Settings(BaseSettings):
     """Dataset library settings
 
     Attributes:
-        data_dir (Path): Dataset library directory
+        data_dir (Path): Dataset library directory, or url to S3 path (eg. "s3://<bucket>[/<key>]")
+
+        If data_dir is a S3 url, the following environment variables can be provided
+            aws_endpoint (str (Optional)): <S3 compatible storage url>. Use AWS if not provided
+            aws_access_key_id (str (Optional)): <access key>
+            aws_secret_access_key (str (Optional)): <secret key>
+            aws_region (str (Optional)): <region> Not always required for private S3 storages
+            local_model_dir (str (Optional)): Path to model (local) if not on S3 storage (in data_dir / models)
     """
 
     data_dir: Path = Path.cwd() / "library"
+
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+    aws_region: Optional[str] = None
+    aws_endpoint: Optional[str] = None
+    local_model_dir: Optional[Path] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if urlparse(str(self.data_dir)).scheme == "s3":
+            try:
+                aws_ressource = boto3.resource(
+                    "s3",
+                    region_name=self.aws_region,
+                    endpoint_url=self.aws_endpoint,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                self.data_dir = S3Path.from_uri(
+                    str(self.data_dir).replace("s3:/", "s3://")
+                )
+                register_configuration_parameter(self.data_dir, resource=aws_ressource)
+            except Exception as e:
+                raise Exception(
+                    "ERROR Could not register S3 compatible storage.\n"
+                    "You have to set the following environment variables:\n"
+                    "- AWS_ENDPOINT : S3 Compatible Storage endpoint\n"
+                    "- AWS_ACCESS_KEY_ID : access key credentials\n"
+                    "- AWS_SECRET_ACCESS_KEY : secret access credentials\n"
+                    "- AWS_REGION (optionnal)",
+                    e,
+                )

--- a/pixano/data/settings.py
+++ b/pixano/data/settings.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     """Dataset library settings
 
     Attributes:
-        data_dir (Path): Dataset library directory, or url to S3 path (eg. "s3://<bucket>[/<key>]")
+        data_dir (Path | S3Path): Dataset library directory, or url to S3 path (eg. "s3://<bucket>[/<key>]")
 
         If data_dir is a S3 url, the following environment variables can be provided
             aws_endpoint (str, optional): S3 compatible storage url. Use AWS if not provided
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
             local_model_dir (str, optional): Path to model (local) if not on S3 storage (in data_dir / models)
     """
 
-    data_dir: Path = Path.cwd() / "library"
+    data_dir: Path | S3Path = Path.cwd() / "library"
 
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None

--- a/pixano/data/settings.py
+++ b/pixano/data/settings.py
@@ -24,14 +24,12 @@ class Settings(BaseSettings):
     """Dataset library settings
 
     Attributes:
-        data_dir (Path | S3Path): Dataset library directory, or url to S3 path (eg. "s3://<bucket>[/<key>]")
-
-        If data_dir is a S3 url, the following environment variables can be provided
-            aws_endpoint (str, optional): S3 compatible storage url. Use AWS if not provided
-            aws_access_key_id (str, optional): access key
-            aws_secret_access_key (str, optional): secret key
-            aws_region (str, optional): region. Not always required for private S3 storages
-            local_model_dir (str, optional): Path to model (local) if not on S3 storage (in data_dir / models)
+        data_dir (Path | S3Path): Dataset library directory, or url to S3 path
+        aws_endpoint (str, optional): S3 compatible storage url. Used if data_dir is a S3 path. Use AWS if not provided
+        aws_access_key_id (str, optional): Access key. Used if data_dir is a S3 path
+        aws_secret_access_key (str, optional): Secret key. Used if data_dir is a S3 path
+        aws_region (str, optional): Region. Used if data_dir is a S3 path. Not always required for private S3 storages
+        local_model_dir (str, optional): Path to model (local). Required if data_dir is a S3 path
     """
 
     data_dir: Path | S3Path = Path.cwd() / "library"

--- a/pixano/data/settings.py
+++ b/pixano/data/settings.py
@@ -11,14 +11,13 @@
 #
 # http://www.cecill.info
 
-
 from pathlib import Path
-from s3path import S3Path, register_configuration_parameter
-import boto3
+from typing import Optional
 from urllib.parse import urlparse
 
+import boto3
 from pydantic_settings import BaseSettings
-from typing import Optional
+from s3path import S3Path, register_configuration_parameter
 
 
 class Settings(BaseSettings):

--- a/pixano/data/settings.py
+++ b/pixano/data/settings.py
@@ -67,3 +67,8 @@ class Settings(BaseSettings):
                     "- AWS_REGION (optionnal)",
                     e,
                 )
+            # if S3, local_model_dir have to be set (maybe we could download it from S3 into a defined local dir?)
+            if self.local_model_dir is None:
+                raise Exception(
+                    "Runtime model (.onnx) must be local, LOCAL_MODEL_DIR must be provided"
+                )

--- a/pixano/data/settings.py
+++ b/pixano/data/settings.py
@@ -27,11 +27,11 @@ class Settings(BaseSettings):
         data_dir (Path): Dataset library directory, or url to S3 path (eg. "s3://<bucket>[/<key>]")
 
         If data_dir is a S3 url, the following environment variables can be provided
-            aws_endpoint (str (Optional)): <S3 compatible storage url>. Use AWS if not provided
-            aws_access_key_id (str (Optional)): <access key>
-            aws_secret_access_key (str (Optional)): <secret key>
-            aws_region (str (Optional)): <region> Not always required for private S3 storages
-            local_model_dir (str (Optional)): Path to model (local) if not on S3 storage (in data_dir / models)
+            aws_endpoint (str, optional): S3 compatible storage url. Use AWS if not provided
+            aws_access_key_id (str, optional): access key
+            aws_secret_access_key (str, optional): secret key
+            aws_region (str, optional): region. Not always required for private S3 storages
+            local_model_dir (str, optional): Path to model (local) if not on S3 storage (in data_dir / models)
     """
 
     data_dir: Path = Path.cwd() / "library"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "importlib-resources ~= 5.12.0",
   "ipywidgets ~= 8.0.0",
   "jinja2 ~= 3.1.2",
-  "lancedb ~= 0.3.3",
+  "lancedb == 0.3.3",
   "numpy >= 1.23.0",
   "onnx ~= 1.13.0",
   "onnxruntime ~= 1.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "pydantic ~= 2.4.0",
   "pydantic-settings ~= 2.0.0",
   "pylance ~= 0.8.10",
+  "s3path ~= 0.5.0",
   "setuptools ~= 65.6.0",
   "shortuuid ~= 1.0.0",
   "tqdm ~= 4.64.0",


### PR DESCRIPTION
## Description

Add support for datasets on S3 cloud storage using the following settings:
- `data_dir` as an `S3Path` instead of a regular `Path` 
- `aws_endpoint`: S3 Endpoint
- `aws_access_key_id`: S3 Access key
- `aws_secret_access_key`: S3 Secret key
- `aws_region`: S3 Region
- `local_model_dir`: Local path to models directory when using S3

## Changes

### Added

- Add support for S3 datasets in API
- Add support for S3 files in Dataset, DatasetInfo, DatasetStats, and Image