### PR TITLE
feat: Update InferenceModel and pixano-inference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
-          python -m pip install pixano-inference@git+https://github.com/pixano/pixano-inference
+          python -m pip install pixano-inference@git+https://github.com/pixano/pixano-inference@v0.3.0b1
 
       - name: Test with unittest
         run: |

--- a/notebooks/models/pre_annotation.ipynb
+++ b/notebooks/models/pre_annotation.ipynb
@@ -64,7 +64,7 @@
       "source": [
         "from pathlib import Path\n",
         "\n",
-        "from pixano_inference import pytorch_models, segment_anything, tensorflow_models\n",
+        "from pixano_inference import pytorch, segment_anything, tensorflow\n",
         "\n",
         "from pixano.app import App"
       ]
@@ -89,14 +89,14 @@
         "### Select a model\n",
         "- Loading a model:\n",
         "    - Object Detection (COCO labels):\n",
-        "        - `model = pytorch_models.YOLOv5(size=\"m\")`\n",
-        "        - `model = tensorflow_models.FasterRCNN()`\n",
-        "        - `model = tensorflow_models.EfficientDet()`\n",
+        "        - `model = pytorch.YOLOv5(size=\"m\")`\n",
+        "        - `model = tensorflow.FasterRCNN()`\n",
+        "        - `model = tensorflow.EfficientDet()`\n",
         "    - Instance Segmentation (COCO labels):\n",
-        "        - `model = pytorch_models.MaskRCNNv2()`\n",
+        "        - `model = pytorch.MaskRCNNv2()`\n",
         "\n",
         "    - Semantic Segmentation (VOC labels):\n",
-        "        - `model = pytorch_models.DeepLabV3()`\n",
+        "        - `model = pytorch.DeepLabV3()`\n",
         "\n",
         "    - Segment Anything Model (No labels):\n",
         "        - `model = segment_anything.SAM(checkpoint_path=Path(\"sam_vit_b_01ec64.pth\"), size=\"b\")`\n",
@@ -112,7 +112,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "model = pytorch_models.MaskRCNNv2()"
+        "model = pytorch.MaskRCNNv2()"
       ]
     },
     {

--- a/pixano/models/inference_model.py
+++ b/pixano/models/inference_model.py
@@ -24,17 +24,13 @@ from tqdm.auto import tqdm
 
 from pixano.data import Dataset, DatasetTable, Fields
 
-# Disable warning for InferenceModel "id" attribute
-# NOTE: Rename attribute? Will need to update Pixano Inference
-# pylint: disable=redefined-builtin
-
 
 class InferenceModel(ABC):
     """Abstract parent class for OfflineModel and OnlineModel
 
     Attributes:
         name (str): Model name
-        id (str): Model ID
+        model_id (str): Model ID
         device (str): Model GPU or CPU device
         description (str): Model description
     """
@@ -42,7 +38,7 @@ class InferenceModel(ABC):
     def __init__(
         self,
         name: str,
-        id: str = "",
+        model_id: str = "",
         device: str = "",
         description: str = "",
     ) -> None:
@@ -50,16 +46,16 @@ class InferenceModel(ABC):
 
         Args:
             name (str): Model name
-            id (str, optional): Model ID. Defaults to "".
+            model_id (str, optional): Model ID. Defaults to "".
             device (str, optional): Model GPU or CPU device. Defaults to "".
             description (str, optional): Model description. Defaults to "".
         """
 
         self.name = name
-        if id == "":
-            self.id = f"{datetime.now().strftime('%y%m%d_%H%M%S')}_{name}"
+        if model_id == "":
+            self.model_id = f"{datetime.now().strftime('%y%m%d_%H%M%S')}_{name}"
         else:
-            self.id = id
+            self.model_id = model_id
         self.device = device
         self.description = description
 
@@ -84,7 +80,9 @@ class InferenceModel(ABC):
         """
 
         # Inference table filename
-        table_filename = f"emb_{self.id}" if "emb" in process_type else f"obj_{self.id}"
+        table_filename = (
+            f"emb_{self.model_id}" if "emb" in process_type else f"obj_{self.model_id}"
+        )
 
         # Objects preannotation schema
         if process_type == "obj":


### PR DESCRIPTION
## Description

Fixes pixano/pixano-project-manager#19

**Warning:** As Pixano 0.5.0b1 introduces breaking changes, in GitHub action `test.yml`, Pixano Inference is explicitly set to the matching 0.3.0b1 for Python unit tests to pass. This should be removed once the stable versions of Pixano 0.5.0 and Pixano Inference 0.3.0 are released.