### PR TITLE
fix(back): use uuid instead of imported id, for items and objects. keep original id

### DIFF
--- a/pixano/data/importers/dota_importer.py
+++ b/pixano/data/importers/dota_importer.py
@@ -52,10 +52,14 @@ class DOTAImporter(Importer):
         tables = super().create_tables(
             media_fields={"image": "image"},
             object_fields={
+                "original_id": "str",
                 "bbox": "bbox",
                 "category": "str",
             },
         )
+
+        # Add original id in main table
+        tables["main"][0].fields["original_id"] = "str"
 
         # Create categories
         categories = [
@@ -117,12 +121,16 @@ class DOTAImporter(Importer):
                 # Set image URI
                 im_uri = f"image/{split}/{im_path.name}"
 
+                # Set unique item id
+                item_id = shortuuid.uuid()
+
                 # Return rows
                 rows = {
                     "main": {
                         "db": [
                             {
-                                "id": im_path.stem,
+                                "id": item_id,
+                                "original_id": im_path.stem,
                                 "views": ["image"],
                                 "split": split,
                             }
@@ -131,7 +139,7 @@ class DOTAImporter(Importer):
                     "media": {
                         "image": [
                             {
-                                "id": im_path.stem,
+                                "id": item_id,
                                 "image": Image(im_uri, None, im_thumb).to_dict(),
                             }
                         ]
@@ -140,7 +148,7 @@ class DOTAImporter(Importer):
                         "objects": [
                             {
                                 "id": shortuuid.uuid(),
-                                "item_id": im_path.stem,
+                                "item_id": item_id,
                                 "view_id": "image",
                                 "bbox": BBox.from_xyxy(
                                     [

--- a/pixano/data/importers/image_importer.py
+++ b/pixano/data/importers/image_importer.py
@@ -15,6 +15,8 @@ import glob
 from collections.abc import Iterator
 from pathlib import Path
 
+import shortuuid
+
 from pixano.core import Image
 from pixano.data.importers.importer import Importer
 from pixano.utils import image_to_thumbnail, natural_key
@@ -48,6 +50,9 @@ class ImageImporter(Importer):
 
         # Create dataset tables
         tables = super().create_tables(media_fields)
+
+        # Add original id in main table
+        tables["main"][0].fields["original_id"] = "str"
 
         # Create splits
         if splits is None:
@@ -88,12 +93,16 @@ class ImageImporter(Importer):
                     else f"image/{split}/{im_path.name}"
                 )
 
+                # Set unique item id
+                item_id = shortuuid.uuid()
+
                 # Return rows
                 rows = {
                     "main": {
                         "db": [
                             {
-                                "id": im_path.name,
+                                "id": item_id,
+                                "original_id": im_path.name,
                                 "views": ["image"],
                                 "split": split,
                                 "label": "",
@@ -103,7 +112,7 @@ class ImageImporter(Importer):
                     "media": {
                         "image": [
                             {
-                                "id": im_path.name,
+                                "id": item_id,
                                 "image": Image(im_uri, None, im_thumb).to_dict(),
                             }
                         ]

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -56,11 +56,11 @@ class AppTestCase(unittest.TestCase):
             input_dirs=input_dirs,
             splits=["val"],
         )
-        dataset = importer.import_dataset(import_dir, copy=True)
+        self.dataset = importer.import_dataset(import_dir, copy=True)
 
         # Set dataset ID
-        dataset.info.id = "coco_dataset"
-        dataset.save_info()
+        self.dataset.info.id = "coco_dataset"
+        self.dataset.save_info()
 
         # Create dataset stats
         stats = [
@@ -199,7 +199,9 @@ class AppTestCase(unittest.TestCase):
     def test_get_dataset_item(self):
         """Test /datasets/{dataset_id}/items/{item_id} endpoint (GET)"""
 
-        response = self.client.get("/datasets/coco_dataset/items/139")
+        # get item uuid from original id
+        item_uuid = self.dataset.get_item_uuid("139")
+        response = self.client.get(f"/datasets/coco_dataset/items/{item_uuid}")
         output = response.json()
 
         self.assertEqual(response.status_code, 200)
@@ -210,7 +212,9 @@ class AppTestCase(unittest.TestCase):
     def test_post_dataset_item(self):
         """Test /datasets/{dataset_id}/items/{item_id} endpoint (POST)"""
 
-        response_1 = self.client.get("/datasets/coco_dataset/items/139")
+        # get item uuid from original id
+        item_uuid = self.dataset.get_item_uuid("139")
+        response_1 = self.client.get(f"/datasets/coco_dataset/items/{item_uuid}")
         output = response_1.json()
 
         ds_item = DatasetItem.model_validate(output)

--- a/tests/data/exporters/test_coco_exporter.py
+++ b/tests/data/exporters/test_coco_exporter.py
@@ -41,7 +41,7 @@ class COCOExporterTestCase(unittest.TestCase):
                 input_dirs=input_dirs,
                 splits=["val"],
             )
-            importer.import_dataset(import_dir)
+            imported_dataset = importer.import_dataset(import_dir)
 
             # Export dataset
             exporter = COCOExporter(input_dir=import_dir)
@@ -78,7 +78,7 @@ class COCOExporterTestCase(unittest.TestCase):
                     )
                     for i in range(len(imported_ann["images"])):
                         self.assertEqual(
-                            imported_ann["images"][i]["id"],
+                            imported_dataset.get_item_uuid(imported_ann["images"][i]["id"]),
                             exported_ann["images"][i]["id"],
                         )
                         self.assertEqual(
@@ -101,11 +101,11 @@ class COCOExporterTestCase(unittest.TestCase):
                     )
                     for i in range(len(imported_ann["annotations"])):
                         self.assertEqual(
-                            imported_ann["annotations"][i]["id"],
+                            imported_dataset.get_object_uuid(imported_ann["annotations"][i]["id"]),
                             exported_ann["annotations"][i]["id"],
                         )
                         self.assertEqual(
-                            imported_ann["annotations"][i]["image_id"],
+                            imported_dataset.get_item_uuid(imported_ann["annotations"][i]["image_id"]),
                             exported_ann["annotations"][i]["image_id"],
                         )
 

--- a/tests/data/exporters/test_coco_exporter.py
+++ b/tests/data/exporters/test_coco_exporter.py
@@ -78,7 +78,9 @@ class COCOExporterTestCase(unittest.TestCase):
                     )
                     for i in range(len(imported_ann["images"])):
                         self.assertEqual(
-                            imported_dataset.get_item_uuid(imported_ann["images"][i]["id"]),
+                            imported_dataset.get_item_uuid(
+                                imported_ann["images"][i]["id"]
+                            ),
                             exported_ann["images"][i]["id"],
                         )
                         self.assertEqual(
@@ -101,11 +103,15 @@ class COCOExporterTestCase(unittest.TestCase):
                     )
                     for i in range(len(imported_ann["annotations"])):
                         self.assertEqual(
-                            imported_dataset.get_object_uuid(imported_ann["annotations"][i]["id"]),
+                            imported_dataset.get_object_uuid(
+                                imported_ann["annotations"][i]["id"]
+                            ),
                             exported_ann["annotations"][i]["id"],
                         )
                         self.assertEqual(
-                            imported_dataset.get_item_uuid(imported_ann["annotations"][i]["image_id"]),
+                            imported_dataset.get_item_uuid(
+                                imported_ann["annotations"][i]["image_id"]
+                            ),
                             exported_ann["annotations"][i]["image_id"],
                         )
 


### PR DESCRIPTION
This is a draft for using shortuuid instead of original id in coco_importer, to ensure id unicity

- [x] keep original id
- [x] ensure objects id unicity too
- [x] apply to all importers
- [x] fix tests

should fix #50 