### PR TITLE
feat(front): Create pre-annotation

### DIFF
--- a/pixano/data/dataset/dataset.py
+++ b/pixano/data/dataset/dataset.py
@@ -293,9 +293,7 @@ class Dataset(BaseModel):
                     none_value = (
                         False
                         if feat.dtype == "bool"
-                        else 0
-                        if feat.dtype in ("int", "float")
-                        else None
+                        else 0 if feat.dtype in ("int", "float") else None
                     )
                     feat_array = pa.array(
                         [none_value] * len(table),

--- a/pixano/data/dataset/dataset.py
+++ b/pixano/data/dataset/dataset.py
@@ -288,13 +288,17 @@ class Dataset(BaseModel):
                 new_feats_table = table.to_lance().to_table(columns=["id"])
                 # Create new feature columns
                 for feat in new_feats:
-                    # None is not supported for booleans yet (should be fixed in pylance 0.9.1)
+                    # None should be suported for booleans with pylance 0.9.1
+                    # None is not supported for integers and floats yet
+                    none_value = (
+                        False
+                        if feat.dtype == "bool"
+                        else 0
+                        if feat.dtype in ("int", "float")
+                        else None
+                    )
                     feat_array = pa.array(
-                        (
-                            [False] * len(table)
-                            if feat.dtype == "bool"
-                            else [None] * len(table)
-                        ),
+                        [none_value] * len(table),
                         type=field_to_pyarrow(feat.dtype),
                     )
                     new_feats_table = new_feats_table.append_column(

--- a/pixano/data/item/item_feature.py
+++ b/pixano/data/item/item_feature.py
@@ -49,7 +49,14 @@ class ItemFeature(BaseModel):
 
         item = table.to_pylist()[0]
         features = {}
-        ignored_fields = ["id", "item_id", "view_id", "source_id", "split"]
+        ignored_fields = [
+            "id",
+            "item_id",
+            "view_id",
+            "source_id",
+            "split",
+            "review_state",
+        ]
 
         # Iterate on fields
         for field in schema:

--- a/pixano/data/item/item_object.py
+++ b/pixano/data/item/item_object.py
@@ -110,7 +110,9 @@ class ItemBBox(BaseModel):
         return (
             BBox.from_dict(self.model_dump())
             if self.coords != [0.0, 0.0, 0.0, 0.0]
-            else BBox.from_rle(mask.to_pyarrow()) if mask else None
+            else BBox.from_rle(mask.to_pyarrow())
+            if mask
+            else None
         )
 
 
@@ -123,6 +125,7 @@ class ItemObject(BaseModel):
         item_id (str): Object item ID
         view_id (str): Object view ID
         source_id (str): Object source ID
+        review_state (str, optional): Object review state ("accepted", "rejected", None)
         bbox (ItemBBox, optional): Object bounding box
         mask (ItemURLE, optional): Object mask
         features (dict[str, ItemFeature], optional): Object features
@@ -133,6 +136,7 @@ class ItemObject(BaseModel):
     item_id: str
     view_id: str
     source_id: str
+    review_state: Optional[str] = None
     bbox: Optional[ItemBBox] = None
     mask: Optional[ItemURLE] = None
     features: Optional[dict[str, ItemFeature]] = None
@@ -166,8 +170,11 @@ class ItemObject(BaseModel):
                 view_id=item["view_id"],
                 source_id=source_id,
             )
-            # Add bbox and mask
+
+            # Add other base fields (review state, bbox, mask)
             for field in schema:
+                if field.name == "review_state" and item["review_state"]:
+                    obj.review_state = item["review_state"]
                 if field.name == "bbox" and item["bbox"]:
                     obj.bbox = ItemBBox.from_pyarrow(item["bbox"])
                 elif field.name == "mask" and item["mask"]:
@@ -188,12 +195,14 @@ class ItemObject(BaseModel):
 
         pyarrow_object = {}
 
-        # ID
+        # IDs
         pyarrow_object["id"] = self.id
         pyarrow_object["item_id"] = self.item_id
         pyarrow_object["view_id"] = self.view_id
 
-        # BBox and Mask
+        # Base fields (review state, bbox, mask)
+        pyarrow_object["review_state"] = self.review_state
+
         pyarrow_mask = self.mask.to_pyarrow() if self.mask else None
         pyarrow_bbox = self.bbox.to_pyarrow(self.mask) if self.bbox else None
 

--- a/pixano/data/item/item_object.py
+++ b/pixano/data/item/item_object.py
@@ -110,9 +110,7 @@ class ItemBBox(BaseModel):
         return (
             BBox.from_dict(self.model_dump())
             if self.coords != [0.0, 0.0, 0.0, 0.0]
-            else BBox.from_rle(mask.to_pyarrow())
-            if mask
-            else None
+            else BBox.from_rle(mask.to_pyarrow()) if mask else None
         )
 
 

--- a/ui/apps/pixano/src/components/dashboard/Dashboard.svelte
+++ b/ui/apps/pixano/src/components/dashboard/Dashboard.svelte
@@ -27,7 +27,7 @@
 </script>
 
 {#if selectedDataset.page}
-  <div class="h-full flex flex-row bg-slate-50 p-20 gap-4">
+  <div class="h-full flex flex-row bg-slate-50 p-20 gap-4 text-slate-800">
     <div class="bg-white min-h-[70%] shadow-md flex flex-col w-[30%]">
       {#each dashboardTabs as tab}
         <button

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -217,7 +217,7 @@
                 height="48"
                 viewBox="0 -960 960 960"
                 width="48"
-                class="absolute left-2 h-5 w-5 text-slate-500 pointer-events-none"
+                class="absolute left-2 h-5 w-5 text-slate-800 pointer-events-none"
               >
                 <path d={svg_search} fill="currentcolor" />
               </svg>
@@ -231,7 +231,7 @@
                     height="48"
                     viewBox="0 -960 960 960"
                     width="48"
-                    class="h-5 w-5 text-slate-500"
+                    class="h-5 w-5 text-slate-800"
                   >
                     <path d={svg_clear} fill="currentcolor" />
                   </svg>

--- a/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
@@ -56,7 +56,7 @@
       height="48"
       viewBox="0 -960 960 960"
       width="48"
-      class="absolute right-5 h-8 w-8 mx-auto p-1 border text-slate-500 rounded-full border-slate-300 transition-colors hover:bg-slate-200"
+      class="absolute right-5 h-8 w-8 mx-auto p-1 border text-slate-800 rounded-full border-slate-300 transition-colors hover:bg-slate-200"
     >
       <path d={svg_right_arrow} fill="currentcolor" />
     </svg>

--- a/ui/apps/pixano/src/components/layout/MainHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/MainHeader.svelte
@@ -68,7 +68,7 @@
               height="48"
               viewBox="0 -960 960 960"
               width="48"
-              class="absolute left-3 h-5 w-5 pointer-events-none text-slate-500"
+              class="absolute left-3 h-5 w-5 pointer-events-none text-slate-800"
             >
               <path d={svg_search} fill="currentcolor" />
             </svg>

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -357,6 +357,9 @@
             //update visibility & opacity
             bboxKonva.visible(bboxes[i].visible);
             bboxKonva.opacity(bboxes[i].opacity);
+            const rect: Konva.Rect = bboxKonva.findOne(`#rect${bboxes[i].id}`);
+            const currentStrokeWidth = rect.strokeWidth();
+            rect.strokeWidth(bboxes[i].strokeFactor * currentStrokeWidth);
             //update color
             const style = new Option().style;
             style.color = colorScale(bboxes[i].id);

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1073,7 +1073,7 @@
 </script>
 
 <div
-  class={cn("flex h-full w-full bg-slate-100 transition-opacity duration-300 delay-100", {
+  class={cn("flex h-full w-full bg-gray-900 transition-opacity duration-300 delay-100", {
     "opacity-0": !isReady,
   })}
   bind:this={stageContainer}

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1081,7 +1081,7 @@
 </script>
 
 <div
-  class={cn("flex h-full w-full bg-gray-900 transition-opacity duration-300 delay-100", {
+  class={cn("flex h-full w-full bg-slate-800 transition-opacity duration-300 delay-100", {
     "opacity-0": !isReady,
   })}
   bind:this={stageContainer}

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -358,8 +358,7 @@
             bboxKonva.visible(bboxes[i].visible);
             bboxKonva.opacity(bboxes[i].opacity);
             const rect: Konva.Rect = bboxKonva.findOne(`#rect${bboxes[i].id}`);
-            const currentStrokeWidth = rect.strokeWidth();
-            rect.strokeWidth(bboxes[i].strokeFactor * currentStrokeWidth);
+            rect.strokeWidth(bboxes[i].strokeFactor * (BBOX_STROKEWIDTH / zoomFactor[viewId]));
             //update color
             const style = new Option().style;
             style.color = colorScale(bboxes[i].id);

--- a/ui/components/canvas2d/src/api/boundingBoxesApi.ts
+++ b/ui/components/canvas2d/src/api/boundingBoxesApi.ts
@@ -303,6 +303,7 @@ export function mapMaskPointsToLineCoordinates(masks: Mask[]): PolygonGroupDetai
         id: mask.id,
         status: mask?.id ? "created" : "creating",
         svg: mask?.svg,
+        opacity: mask.opacity || 1,
         viewId: mask.viewId,
         points: points.reduce((acc, val, i) => {
           if (i % 2 === 0) {
@@ -330,6 +331,7 @@ export function mapMaskPointsToLineCoordinates(masks: Mask[]): PolygonGroupDetai
     editing: false,
     id: "creating",
     viewId: undefined,
+    opacity: 1,
   };
   mappedMasks.push(emptyMask);
   return mappedMasks;

--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -141,7 +141,14 @@
   }
 </script>
 
-<Group config={{ id: "polygon", draggable: canEdit, visible: polygonDetails.visible }}>
+<Group
+  config={{
+    id: "polygon",
+    draggable: canEdit,
+    visible: polygonDetails.visible,
+    opacity: polygonDetails.opacity,
+  }}
+>
   {#if canEdit}
     {#if polygonDetails.id === "creating"}
       <Path

--- a/ui/components/canvas2d/src/lib/types/canvas2dTypes.ts
+++ b/ui/components/canvas2d/src/lib/types/canvas2dTypes.ts
@@ -16,4 +16,5 @@ export type PolygonGroupDetails = {
   status: PolygonGroupStatus;
   id: string;
   viewId: string | undefined;
+  opacity: number;
 };

--- a/ui/components/core/src/components/ui/molecules/PrimaryButton.svelte
+++ b/ui/components/core/src/components/ui/molecules/PrimaryButton.svelte
@@ -20,9 +20,11 @@
   import Button from "../button/button.svelte";
 
   export let isSelected: boolean = false;
+  export let disabled: boolean = false;
 </script>
 
 <Button
+  {disabled}
   class={cn("font-medium h-10 px-6 border rounded-full transition-colors flex gap-2 ", {
     "bg-primary hover:bg-primary-foreground border-primary hover:border-primary-foreground text-slate-50":
       isSelected,

--- a/ui/components/core/src/components/ui/molecules/TooltipIconButton.svelte
+++ b/ui/components/core/src/components/ui/molecules/TooltipIconButton.svelte
@@ -26,7 +26,7 @@
   <Tooltip.Trigger tabindex={-1}>
     <Button
       size="icon"
-      class={cn("bg-transparent text-gray-800 hover:bg-primary-light relative", {
+      class={cn("bg-transparent text-slate-800 hover:bg-primary-light relative", {
         "bg-primary text-white": selected,
       })}
       on:click

--- a/ui/components/core/src/components/ui/slider/SliderRoot.svelte
+++ b/ui/components/core/src/components/ui/slider/SliderRoot.svelte
@@ -11,6 +11,7 @@
   let isMouseOverThumb: boolean = false;
 
   $: pourcentage = Math.round(((value?.[0] || 0) / $$restProps.max) * 100);
+  $: displayedValue = `${pourcentage / 100}`;
 </script>
 
 <div class="flex gap-4">
@@ -35,11 +36,11 @@
       data-melt-slider-thumb=""
       class={cn(
         "block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
-        { "h-8 w-8": isMouseOverThumb },
+        { "h-10 w-10": isMouseOverThumb },
       )}
       data-bits-slider-thumb=""
       style={`position: absolute; left: ${pourcentage}%; translate: -50%;`}
-      >{#if isMouseOverThumb && pourcentage > 0 && pourcentage < $$restProps.max}{pourcentage}
+      >{#if isMouseOverThumb && pourcentage > 0 && pourcentage < $$restProps.max * 100}{displayedValue}
       {/if}</button
     >
   </SliderPrimitive.Root>

--- a/ui/components/core/src/components/ui/slider/SliderRoot.svelte
+++ b/ui/components/core/src/components/ui/slider/SliderRoot.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { Slider as SliderPrimitive } from "bits-ui";
+  import { cn } from "../../../lib/utils/styleUtils";
+
+  type $$Props = SliderPrimitive.Props;
+
+  let className: $$Props["class"] = undefined;
+  export let value: $$Props["value"] = [0];
+  export { className as class };
+
+  let isMouseOverThumb: boolean = false;
+
+  $: pourcentage = Math.round(((value?.[0] || 0) / $$restProps.max) * 100);
+</script>
+
+<div class="flex gap-4">
+  <span>0</span>
+  <SliderPrimitive.Root
+    bind:value
+    class={cn(" relative flex w-full touch-none select-none items-center", className)}
+    {...$$restProps}
+  >
+    <span class="relative h-2 w-full grow overflow-hidden rounded-full bg-white">
+      <SliderPrimitive.Range class="absolute h-full bg-primary" />
+    </span>
+    <button
+      on:mouseenter={() => (isMouseOverThumb = true)}
+      on:mouseleave={() => (isMouseOverThumb = false)}
+      role="slider"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow={pourcentage}
+      data-melt-part="thumb"
+      tabindex="0"
+      data-melt-slider-thumb=""
+      class={cn(
+        "block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+        { "h-8 w-8": isMouseOverThumb },
+      )}
+      data-bits-slider-thumb=""
+      style={`position: absolute; left: ${pourcentage}%; translate: -50%;`}
+      >{#if isMouseOverThumb && pourcentage > 0 && pourcentage < $$restProps.max}{pourcentage}
+      {/if}</button
+    >
+  </SliderPrimitive.Root>
+  <span>{$$restProps.max}</span>
+</div>

--- a/ui/components/core/src/components/ui/slider/index.ts
+++ b/ui/components/core/src/components/ui/slider/index.ts
@@ -1,0 +1,7 @@
+import Root from "./SliderRoot.svelte";
+
+export {
+  Root,
+  //
+  Root as Slider,
+};

--- a/ui/components/core/src/components/ui/switch/SwitchRoot.svelte
+++ b/ui/components/core/src/components/ui/switch/SwitchRoot.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { Switch as SwitchPrimitive } from "bits-ui";
+  import { cn } from "../../../lib/utils/styleUtils";
+
+  type $$Props = SwitchPrimitive.Props;
+
+  let className: $$Props["class"] = undefined;
+  export let checked: $$Props["checked"] = undefined;
+  export { className as class };
+</script>
+
+<SwitchPrimitive.Root
+  bind:checked
+  class={cn(
+    "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+    className,
+  )}
+  {...$$restProps}
+>
+  <SwitchPrimitive.Thumb
+    class={cn(
+      "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+    )}
+  />
+</SwitchPrimitive.Root>

--- a/ui/components/core/src/components/ui/switch/index.ts
+++ b/ui/components/core/src/components/ui/switch/index.ts
@@ -1,0 +1,7 @@
+import Root from "./SwitchRoot.svelte";
+
+export {
+  Root,
+  //
+  Root as Switch,
+};

--- a/ui/components/core/src/components/ui/tabs/tabs-list.svelte
+++ b/ui/components/core/src/components/ui/tabs/tabs-list.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <TabsPrimitive.List
-  class={cn(
-    "inline-flex w-full h-10 items-center justify-center p-1 text-muted-foreground",
-    className,
-  )}
+  class={cn("inline-flex w-full h-10 items-center justify-center text-muted-foreground", className)}
   {...$$restProps}
 >
   <slot />

--- a/ui/components/core/src/components/ui/tabs/tabs-trigger.svelte
+++ b/ui/components/core/src/components/ui/tabs/tabs-trigger.svelte
@@ -11,7 +11,7 @@
 
 <TabsPrimitive.Trigger
   class={cn(
-    "inline-flex flex-grow items-center justify-center whitespace-nowrap uppercase font-light text-slate-800 px-3 pt-6 pb-2 ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-transparent border-b-2 data-[state=active]:border-primary",
+    "inline-flex flex-grow items-center justify-center whitespace-nowrap uppercase font-light text-slate-800 px-3 pt-6 pb-2 ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-transparent border-b-2 data-[state=inactive]:bg-white data-[state=active]:font-semibold",
     className,
   )}
   {value}

--- a/ui/components/core/src/index.ts
+++ b/ui/components/core/src/index.ts
@@ -37,6 +37,7 @@ export { Checkbox } from "./components/ui/checkbox";
 export { default as Combobox } from "./components/ui/combobox/combobox.svelte";
 export { Input } from "./components/ui/input";
 export { Slider } from "./components/ui/slider";
+export { Switch } from "./components/ui/switch";
 
 // lib
 // utils

--- a/ui/components/core/src/index.ts
+++ b/ui/components/core/src/index.ts
@@ -36,6 +36,7 @@ export { Skeleton } from "./components/ui/skeleton";
 export { Checkbox } from "./components/ui/checkbox";
 export { default as Combobox } from "./components/ui/combobox/combobox.svelte";
 export { Input } from "./components/ui/input";
+export { Slider } from "./components/ui/slider";
 
 // lib
 // utils

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -106,7 +106,7 @@ export type ItemObject = (BBoxObject | MaskObject) & {
   displayControl?: DisplayControl;
   isManual?: boolean;
   highlighted?: "none" | "self" | "all";
-  preAnnotation?: "accepted" | "rejected";
+  review_state?: "accepted" | "rejected";
 };
 
 export interface ItemRLE {

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -106,6 +106,7 @@ export type ItemObject = (BBoxObject | MaskObject) & {
   displayControl?: DisplayControl;
   isManual?: boolean;
   highlighted?: "none" | "self" | "all";
+  preAnnotation?: "accepted" | "rejected";
 };
 
 export interface ItemRLE {

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -105,6 +105,7 @@ export type ItemObject = (BBoxObject | MaskObject) & {
   features: Record<string, ItemFeature>;
   displayControl?: DisplayControl;
   isManual?: boolean;
+  highlighted?: "none" | "self" | "all";
 };
 
 export interface ItemRLE {
@@ -164,6 +165,7 @@ export interface BBox {
   opacity: number;
   editing?: boolean;
   locked?: boolean;
+  strokeFactor?: number;
 }
 
 // LABELS DATA

--- a/ui/components/imageWorkspace/src/ImageWorkspace.svelte
+++ b/ui/components/imageWorkspace/src/ImageWorkspace.svelte
@@ -109,7 +109,7 @@
 <div class="w-full h-full grid grid-cols-[48px_calc(100%-380px-48px)_380px]">
   {#if isSaving}
     <div
-      class="h-full w-full flex justify-center items-center absolute top-0 left-0 bg-gray-300 z-50 opacity-30"
+      class="h-full w-full flex justify-center items-center absolute top-0 left-0 bg-slate-300 z-50 opacity-30"
     >
       <Loader2Icon class="animate-spin" />
     </div>

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ActionsTabs.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ActionsTabs.svelte
@@ -36,14 +36,14 @@
   });
 </script>
 
-<div class="h-full max-h-screen shadow-sm border-l border-slate-200 bg-popover">
+<div class="h-full max-h-screen shadow-sm border-l border-slate-200 bg-slate-100">
   {#if shape?.status === "inProgress"}
     <SaveShapeForm />
   {:else}
     <Tabs.Root bind:value={currentTab} class="h-full">
       <Tabs.List class="h-[48px]">
-        <Tabs.Trigger value="scene">Scene</Tabs.Trigger>
-        <Tabs.Trigger value="objects">Objects</Tabs.Trigger>
+        <Tabs.Trigger value="scene" class="w-1/2">Scene</Tabs.Trigger>
+        <Tabs.Trigger value="objects" class="w-1/2">Objects</Tabs.Trigger>
       </Tabs.List>
       <div class="h-[calc(100%-48px)] flex flex-col justify-between">
         <Tabs.Content value="scene" class="bg-red max-h-[calc(100vh-200px)] overflow-y-auto">
@@ -57,7 +57,7 @@
             <SceneTabContent />
           {/if}
         </Tabs.Content>
-        <Tabs.Content value="objects" class="bg-red max-h-[calc(100vh-200px)] overflow-y-auto">
+        <Tabs.Content value="objects" class="max-h-[calc(100vh-200px)] overflow-y-auto">
           {#if isLoading}
             <div class="p-4 flex flex-col gap-4">
               <Skeleton class="h-8 w-full" />

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <div class="p-2">
-  <PreAnnotation objectsToAnnotate={allItemsSortedByModel[PRE_ANNOTATION]} />
+  <PreAnnotation objectsToAnnotate={allItemsSortedByModel[PRE_ANNOTATION]} {colorScale} />
   <div>
     <ObjectTabModelContent sectionTitle={"Ground truth"} modelName={GROUND_TRUTH}>
       {#each allItemsSortedByModel[GROUND_TRUTH] as itemObject}

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
@@ -19,7 +19,7 @@
   import ObjectTabFlatItem from "./ObjectTabFlatItem.svelte";
   import ObjectTabModelContent from "./ObjectTabModelContent.svelte";
   import { itemObjects } from "../../lib/stores/imageWorkspaceStores";
-  import { GROUND_TRUTH, MODEL_RUN } from "../../lib/constants";
+  import { GROUND_TRUTH, MODEL_RUN, PRE_ANNOTATION } from "../../lib/constants";
   import { sortObjectsByModel } from "../../lib/api/objectsApi";
   import PreAnnotation from "../PreAnnotation/PreAnnotation.svelte";
   import type { ObjectsSortedByModelType } from "../../lib/types/imageWorkspaceTypes";
@@ -27,6 +27,7 @@
   let allItemsSortedByModel: ObjectsSortedByModelType = {
     [GROUND_TRUTH]: [],
     [MODEL_RUN]: [],
+    [PRE_ANNOTATION]: [],
   };
   let allIds: string[] = [];
 
@@ -39,7 +40,7 @@
 </script>
 
 <div class="p-2">
-  <PreAnnotation />
+  <PreAnnotation objectsToAnnotate={allItemsSortedByModel[PRE_ANNOTATION]} />
   <div>
     <ObjectTabModelContent sectionTitle={"Ground truth"} modelName={GROUND_TRUTH}>
       {#each allItemsSortedByModel[GROUND_TRUTH] as itemObject}

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
@@ -21,6 +21,7 @@
   import { itemObjects } from "../../lib/stores/imageWorkspaceStores";
   import { GROUND_TRUTH, MODEL_RUN } from "../../lib/constants";
   import { sortObjectsByModel } from "../../lib/api/objectsApi";
+  import PreAnnotation from "../PreAnnotation/PreAnnotation.svelte";
   import type { ObjectsSortedByModelType } from "../../lib/types/imageWorkspaceTypes";
 
   let allItemsSortedByModel: ObjectsSortedByModelType = {
@@ -38,6 +39,7 @@
 </script>
 
 <div class="p-2">
+  <PreAnnotation />
   <div>
     <ObjectTabModelContent sectionTitle={"Ground truth"} modelName={GROUND_TRUTH}>
       {#each allItemsSortedByModel[GROUND_TRUTH] as itemObject}

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabContent.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <div class="p-2">
-  <PreAnnotation objectsToAnnotate={allItemsSortedByModel[PRE_ANNOTATION]} {colorScale} />
+  <PreAnnotation {colorScale} />
   <div>
     <ObjectTabModelContent sectionTitle={"Ground truth"} modelName={GROUND_TRUTH}>
       {#each allItemsSortedByModel[GROUND_TRUTH] as itemObject}

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
@@ -113,7 +113,7 @@
   </div>
 </div>
 {#if open}
-  <div class="pl-5 border-b border-b-gray-600 text-slate-800 bg-white">
+  <div class="pl-5 border-b border-b-slate-600 text-slate-800 bg-white">
     <div
       class="border-l-4 border-dashed border-red-400 pl-4 pb-4 pt-4 flex flex-col gap-4"
       style="border-color:{color}"

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
@@ -87,11 +87,7 @@
   };
 </script>
 
-<div
-  class={cn("flex items-center mt-2 hover:bg-gray-100 rounded justify-between text-slate-800", {
-    "bg-gray-100": open,
-  })}
->
+<div class={cn("flex items-center mt-1  rounded justify-between text-slate-800 bg-white")}>
   <div class="flex items-center flex-auto max-w-[50%]">
     <IconButton on:click={() => handleIconClick("hidden", isVisible)}>
       {#if isVisible}
@@ -117,7 +113,7 @@
   </div>
 </div>
 {#if open}
-  <div class="pl-5 border-b border-b-gray-600 text-slate-800">
+  <div class="pl-5 border-b border-b-gray-600 text-slate-800 bg-white">
     <div
       class="border-l-4 border-dashed border-red-400 pl-4 pb-4 pt-4 flex flex-col gap-4"
       style="border-color:{color}"

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
@@ -118,29 +118,27 @@
       class="border-l-4 border-dashed border-red-400 pl-4 pb-4 pt-4 flex flex-col gap-4"
       style="border-color:{color}"
     >
-      <div>
-        <p class="font-medium pb-1">Display</p>
-        <div class="flex flex-col gap-2">
-          {#if itemObject.bbox}
-            <div>
-              <Checkbox
-                handleClick={() => handleIconClick("hidden", boxIsVisible, ["bbox"])}
-                bind:checked={boxIsVisible}
-              />
-              <span class="font-medium">Bounding box</span>
-            </div>
-          {/if}
-          {#if itemObject.mask}
-            <div>
-              <Checkbox
-                bind:checked={maskIsVisible}
-                handleClick={() => handleIconClick("hidden", maskIsVisible, ["mask"])}
-              /> <span class="font-medium">Mask</span>
-            </div>
-          {/if}
-        </div>
-      </div>
-      <div>
+      <div class="flex flex-col gap-2">
+        {#if itemObject.bbox}
+          <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+            <p class="font-medium first-letter:uppercase">Bounding box</p>
+            <Checkbox
+              handleClick={() => handleIconClick("hidden", boxIsVisible, ["bbox"])}
+              bind:checked={boxIsVisible}
+              class="mx-1"
+            />
+          </div>
+        {/if}
+        {#if itemObject.mask}
+          <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+            <p class="font-medium first-letter:uppercase">Mask</p>
+            <Checkbox
+              handleClick={() => handleIconClick("hidden", maskIsVisible, ["mask"])}
+              bind:checked={maskIsVisible}
+              class="mx-1"
+            />
+          </div>
+        {/if}
         <ItemFeatures {features} {isEditing} {saveInputChange} />
       </div>
     </div>

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabLabelsItem.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabLabelsItem.svelte
@@ -23,8 +23,8 @@
 </script>
 
 <div
-  class={cn("flex items-center mt-2 hover:bg-gray-100 rounded justify-between", {
-    "hover:bg-gray-100": open,
+  class={cn("flex items-center mt-2 hover:bg-slate-100 rounded justify-between", {
+    "hover:bg-slate-100": open,
   })}
 >
   <div class="flex items-center">

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabModelContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabModelContent.svelte
@@ -18,7 +18,7 @@
   import { cn, IconButton } from "@pixano/core/src";
 
   import { toggleObjectDisplayControl } from "../../lib/api/objectsApi";
-  import { GROUND_TRUTH, MODEL_RUN } from "../../lib/constants";
+  import { EXISTING_SOURCE_IDS, GROUND_TRUTH, MODEL_RUN } from "../../lib/constants";
   import { itemObjects } from "../../lib/stores/imageWorkspaceStores";
 
   export let sectionTitle: string;
@@ -61,7 +61,7 @@
           visibilityStatus === "hidden",
         );
       }
-      if (modelName === MODEL_RUN && item.source_id !== GROUND_TRUTH) {
+      if (modelName === MODEL_RUN && !EXISTING_SOURCE_IDS.includes(item.source_id)) {
         if (visibilityStatus === "mixed") return item;
         return toggleObjectDisplayControl(
           item,

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/SceneTabContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/SceneTabContent.svelte
@@ -26,6 +26,7 @@
   import { defaultSceneFeatures } from "../../lib/settings/defaultFeatures";
 
   type ImageMeta = {
+    fileName: string;
     width: number;
     height: number;
     format: string;
@@ -38,9 +39,10 @@
 
   itemMetas.subscribe((metas) => {
     imageMeta = Object.values(metas.views || {}).map((view) => ({
+      fileName: view.uri.split("/").at(-1) as string,
       width: view.features.width.value as number,
       height: view.features.height.value as number,
-      format: view.uri.split(".").at(-1) as string,
+      format: view.uri.split(".").at(-1)?.toUpperCase() as string,
       id: view.id,
     }));
     const sceneFeatures = Object.values(metas.features).length
@@ -69,31 +71,37 @@
   };
 </script>
 
-<div class="border-b-2 border-b-slate-500 p-4 mb-4 text-slate-800">
-  <h3 class="uppercase font-light">
-    <span class="mr-4">Features</span>
+<div class="border-b-2 border-b-slate-500 p-4 pb-8 text-slate-800">
+  <h3 class="uppercase font-light h-10">
+    <span>Features</span>
     <IconButton selected={isEditing} on:click={handleEditIconClick}
-      ><Pencil class="h-4" /></IconButton
-    >
+      ><Pencil class="h-4" />
+    </IconButton>
   </h3>
-  <FeatureInputs {features} {isEditing} saveInputChange={handleTextInputChange} />
+  <div class="mx-4">
+    <FeatureInputs {features} {isEditing} saveInputChange={handleTextInputChange} />
+  </div>
 </div>
-{#each imageMeta as meta}
-  <div class="p-4 text-slate-800">
-    <h3 class="uppercase font-light">File {meta.id}</h3>
-    <div class="mt-4 pb-4">
-      <div class="grid gap-4 grid-cols-[100px_auto] mt-2">
-        <p class="font-bold first-letter:uppercase">Width</p>
+<div class="p-4 text-slate-800">
+  {#each imageMeta as meta}
+    <h3 class="uppercase font-light h-10 flex items-center">{meta.id}</h3>
+    <div class="mx-4 mb-4">
+      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+        <p class="font-medium first-letter:uppercase">File name</p>
+        <p class="truncate" title={meta.fileName}>{meta.fileName}</p>
+      </div>
+      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+        <p class="font-medium first-letter:uppercase">Width</p>
         <p>{meta.width}</p>
       </div>
-      <div class="grid gap-4 grid-cols-[100px_auto] mt-2">
-        <p class="font-bold first-letter:uppercase">Height</p>
+      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+        <p class="font-medium first-letter:uppercase">Height</p>
         <p>{meta.height}</p>
       </div>
-      <div class="grid gap-4 grid-cols-[100px_auto] mt-2">
-        <p class="font-bold first-letter:uppercase">Format</p>
+      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+        <p class="font-medium first-letter:uppercase">Format</p>
         <p>{meta.format}</p>
       </div>
     </div>
-  </div>
-{/each}
+  {/each}
+</div>

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/SceneTabContent.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/SceneTabContent.svelte
@@ -69,7 +69,7 @@
   };
 </script>
 
-<div class="border-b-2 border-b-gray-500 p-4 mb-4 text-slate-800">
+<div class="border-b-2 border-b-slate-500 p-4 mb-4 text-slate-800">
   <h3 class="uppercase font-light">
     <span class="mr-4">Features</span>
     <IconButton selected={isEditing} on:click={handleEditIconClick}

--- a/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
@@ -15,7 +15,7 @@
    */
 
   import { Input, Checkbox, Combobox } from "@pixano/core/src";
-  import type { FeatureValues } from "@pixano/core";
+  import type { FeatureValues, ItemFeature } from "@pixano/core";
 
   import { itemMetas } from "../../lib/stores/imageWorkspaceStores";
   import {
@@ -29,6 +29,7 @@
   export let isFormValid: boolean = false;
   export let formInputs: CreateObjectInputs = [];
   export let objectProperties: { [key: string]: FeatureValues } = {};
+  export let initialValues: Record<string, ItemFeature> = {};
 
   let objectValidationSchema: CreateObjectSchema;
 
@@ -50,6 +51,14 @@
   };
 
   $: {
+    Object.values(initialValues).forEach((feature) => {
+      if (typeof feature.value !== "object") {
+        objectProperties[feature.name] = feature.value;
+      }
+    });
+  }
+
+  $: {
     const result = objectValidationSchema.safeParse(objectProperties);
     isFormValid = result.success;
   }
@@ -58,7 +67,10 @@
 {#each formInputs as feature, i}
   {#if feature.type === "bool"}
     <div class="flex gap-4 items-center">
-      <Checkbox handleClick={(checked) => handleInputChange(checked, feature.name)} />
+      <Checkbox
+        handleClick={(checked) => handleInputChange(checked, feature.name)}
+        checked={initialValues[feature.name]?.value === 1}
+      />
       <span
         >{feature.label}
         {#if feature.required}
@@ -86,6 +98,7 @@
         type={feature.type === "str" ? "text" : "number"}
         step={feature.type === "int" ? "1" : "any"}
         autofocus={i === 0 ? true : false}
+        value={initialValues[feature.name]?.value || ""}
         on:keyup={(e) => e.stopPropagation()}
         on:input={(e) =>
           handleInputChange(

--- a/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
@@ -87,7 +87,7 @@
         step={feature.type === "int" ? "1" : "any"}
         autofocus={i === 0 ? true : false}
         on:keyup={(e) => e.stopPropagation()}
-        on:change={(e) =>
+        on:input={(e) =>
           handleInputChange(
             feature.type === "str" ? e.currentTarget.value : Number(e.currentTarget.value),
             feature.name,

--- a/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  /**
+   * @copyright CEA
+   * @author CEA
+   * @license CECILL
+   *
+   * This software is a collaborative computer program whose purpose is to
+   * generate and explore labeled data for computer vision applications.
+   * This software is governed by the CeCILL-C license under French law and
+   * abiding by the rules of distribution of free software. You can use,
+   * modify and/ or redistribute the software under the terms of the CeCILL-C
+   * license as circulated by CEA, CNRS and INRIA at the following URL
+   *
+   * http://www.cecill.info
+   */
+
+  import { Input, Checkbox, Combobox } from "@pixano/core/src";
+  import type { FeatureValues } from "@pixano/core";
+
+  import { itemMetas } from "../../lib/stores/imageWorkspaceStores";
+  import {
+    createObjectInputsSchema,
+    createSchemaFromFeatures,
+  } from "../../lib/settings/objectValidationSchemas";
+  import type { CreateObjectInputs, CreateObjectSchema } from "../../lib/types/imageWorkspaceTypes";
+
+  import { defaultObjectFeatures } from "../../lib/settings/defaultFeatures";
+
+  export let isFormValid: boolean = false;
+  export let formInputs: CreateObjectInputs = [];
+
+  let objectProperties: { [key: string]: FeatureValues } = {};
+  let objectValidationSchema: CreateObjectSchema;
+
+  itemMetas.subscribe((metas) => {
+    const itemFeaturesArray = Object.values(metas.itemFeatures || defaultObjectFeatures).map(
+      (feature) => ({
+        ...feature,
+        label: feature.name,
+        required: true,
+        type: feature.dtype,
+      }),
+    );
+    objectValidationSchema = createSchemaFromFeatures(itemFeaturesArray);
+    formInputs = createObjectInputsSchema.parse(itemFeaturesArray);
+  });
+
+  const handleInputChange = (value: string | number | boolean, propertyLabel: string) => {
+    objectProperties[propertyLabel] = value;
+  };
+
+  $: {
+    const result = objectValidationSchema.safeParse(objectProperties);
+    isFormValid = result.success;
+  }
+</script>
+
+{#each formInputs as feature, i}
+  {#if feature.type === "bool"}
+    <div class="flex gap-4 items-center">
+      <Checkbox handleClick={(checked) => handleInputChange(checked, feature.name)} />
+      <span
+        >{feature.label}
+        {#if feature.required}
+          <span>*</span>
+        {/if}
+      </span>
+    </div>
+  {/if}
+  {#if feature.type === "list"}
+    <Combobox
+      placeholder={`Select a ${feature.label}`}
+      listItems={feature.options}
+      saveValue={(value) => handleInputChange(value, feature.name)}
+    />
+  {/if}
+  {#if ["int", "float", "str"].includes(feature.type)}
+    <div>
+      <span
+        >{feature.label}
+        {#if feature.required}
+          <span>*</span>
+        {/if}
+      </span>
+      <Input
+        type={feature.type === "str" ? "text" : "number"}
+        step={feature.type === "int" ? "1" : "any"}
+        autofocus={i === 0 ? true : false}
+        on:keyup={(e) => e.stopPropagation()}
+        on:change={(e) =>
+          handleInputChange(
+            feature.type === "str" ? e.currentTarget.value : Number(e.currentTarget.value),
+            feature.name,
+          )}
+      />
+    </div>
+  {/if}
+{/each}

--- a/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
@@ -28,8 +28,8 @@
 
   export let isFormValid: boolean = false;
   export let formInputs: CreateObjectInputs = [];
+  export let objectProperties: { [key: string]: FeatureValues } = {};
 
-  let objectProperties: { [key: string]: FeatureValues } = {};
   let objectValidationSchema: CreateObjectSchema;
 
   itemMetas.subscribe((metas) => {

--- a/ui/components/imageWorkspace/src/components/Features/FeatureInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureInputs.svelte
@@ -27,10 +27,11 @@
 </script>
 
 {#each features as feature}
-  <div class="mt-1">
+  <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
     {#if isEditing || feature.value !== undefined}
-      <p class="font-bold first-letter:uppercase pb-1">{feature.label.replace("_", " ")}</p>
+      <p class="font-medium first-letter:uppercase">{feature.label.replace("_", " ")}</p>
     {/if}
+
     {#if feature.type === "bool" && (feature.value !== undefined || isEditing)}
       <Checkbox
         checked={!!feature.value}

--- a/ui/components/imageWorkspace/src/components/Features/ListInputFeature.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/ListInputFeature.svelte
@@ -31,9 +31,7 @@
     value={listFeature.value}
   />
 {:else if listFeature.value}
-  <p
-    class="font-light rounded-xl bg-primary-light first-letter:uppercase flex justify-center items-center h-6 py-1 px-3 w-min"
-  >
+  <p class="first-letter:uppercase">
     {listFeature.value}
   </p>
 {/if}

--- a/ui/components/imageWorkspace/src/components/Features/TextInputFeature.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/TextInputFeature.svelte
@@ -55,9 +55,7 @@
       </span>
     {/if}
   {:else if textFeature.value || textFeature.value === 0}
-    <p
-      class="font-light rounded-xl bg-primary-light first-letter:uppercase flex justify-center items-center h-6 py-1 px-3"
-    >
+    <p class="first-letter:uppercase">
       {textFeature.value}
     </p>
   {/if}

--- a/ui/components/imageWorkspace/src/components/ImageCanvas.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageCanvas.svelte
@@ -56,10 +56,10 @@
   });
 </script>
 
-<div class="max-w-[100%]">
+<div class="max-w-[100%] bg-gray-900">
   {#if isLoading}
     <div class="h-full w-full flex justify-center items-center">
-      <Loader2Icon class="animate-spin" />
+      <Loader2Icon class="animate-spin text-white" />
     </div>
   {:else}
     {#key selectedItem.id}

--- a/ui/components/imageWorkspace/src/components/ImageCanvas.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageCanvas.svelte
@@ -56,7 +56,7 @@
   });
 </script>
 
-<div class="max-w-[100%] bg-gray-900">
+<div class="max-w-[100%] bg-slate-800">
   {#if isLoading}
     <div class="h-full w-full flex justify-center items-center">
       <Loader2Icon class="animate-spin text-white" />

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -22,6 +22,7 @@
   import { GROUND_TRUTH } from "../../lib/constants";
   import { mapObjectWithNewStatus, sortAndFilterObjectsToAnnotate } from "../../lib/api/objectsApi";
   import * as Tooltip from "@pixano/core/src/components/ui/tooltip";
+  import type { ObjectProperties } from "../../lib/types/imageWorkspaceTypes";
 
   export let objectsToAnnotate: ItemObject[] = [];
   export let colorScale: (id: string) => string;
@@ -31,6 +32,7 @@
   let confidenceFilterValue = [0];
   $: objectToAnnotate = objectsToAnnotate[0];
   let color: string;
+  let objectProperties: ObjectProperties = {};
 
   $: color = colorScale(objectToAnnotate?.id || "");
 
@@ -55,7 +57,7 @@
   const handleAcceptItem = () => {
     itemObjects.update((objects) => [
       { ...objectToAnnotate, preAnnotation: "accepted", source_id: GROUND_TRUTH },
-      ...mapObjectWithNewStatus(objects, objectsToAnnotate, "accepted"),
+      ...mapObjectWithNewStatus(objects, objectsToAnnotate, "accepted", objectProperties),
     ]);
   };
 
@@ -102,7 +104,11 @@
           <span>{objectToAnnotate.id}</span>
         </p>
         <div class="flex flex-col gap-4 py-4">
-          <FeatureFormInputs bind:isFormValid initialValues={objectToAnnotate.features} />
+          <FeatureFormInputs
+            bind:isFormValid
+            initialValues={objectToAnnotate.features}
+            bind:objectProperties
+          />
         </div>
         <div class="flex gap-4 mt-4 w-full justify-center">
           <PrimaryButton on:click={handleAcceptItem} isSelected disabled={!isFormValid}

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -81,14 +81,15 @@
   };
 
   const handleAcceptItem = () => {
-    itemObjects.update((objects) =>
-      objects.map((object) => {
+    itemObjects.update((objects) => [
+      ...objects.map((object) => {
         if (object.id === objectToAnnotate.id) {
-          object.source_id = GROUND_TRUTH;
+          object.preAnnotation = "accepted";
         }
         return object;
       }),
-    );
+      { ...objectToAnnotate, preAnnotation: "accepted", source_id: GROUND_TRUTH },
+    ]);
     highlightNextItem();
   };
 

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  /**
+   * @copyright CEA
+   * @author CEA
+   * @license CECILL
+   *
+   * This software is a collaborative computer program whose purpose is to
+   * generate and explore labeled data for computer vision applications.
+   * This software is governed by the CeCILL-C license under French law and
+   * abiding by the rules of distribution of free software. You can use,
+   * modify and/ or redistribute the software under the terms of the CeCILL-C
+   * license as circulated by CEA, CNRS and INRIA at the following URL
+   *
+   * http://www.cecill.info
+   */
+
+  import { Check, BoxSelectIcon, Filter } from "lucide-svelte";
+  import { PrimaryButton, Slider, IconButton } from "@pixano/core";
+</script>
+
+<div class="my-4">
+  <div class="flex justify-between my-4">
+    <h3>PRE ANNOTATION</h3>
+    <span>1 / 5</span>
+  </div>
+  <div class="my-2 flex items-center">
+    <IconButton tooltipContent="confidence slider">
+      <Filter />
+    </IconButton>
+    <div class="px-8 w-full">
+      <Slider value={[0]} max={100} step={1} />
+    </div>
+  </div>
+  <div class="bg-white rounded-sm p-4 mt-4">
+    <p class="flex gap-2">
+      <BoxSelectIcon color="#133AFC" />
+      <span>obj535253453</span>
+    </p>
+    <div>infos diverses</div>
+    <div class="flex gap-4 mt-4 w-full justify-center">
+      <PrimaryButton isSelected><Check />Accept</PrimaryButton>
+      <PrimaryButton>Ignore</PrimaryButton>
+    </div>
+  </div>
+</div>

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -16,6 +16,9 @@
 
   import { Check, BoxSelectIcon, Filter } from "lucide-svelte";
   import { PrimaryButton, Slider, IconButton } from "@pixano/core";
+  import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
+
+  let isFormValid: boolean = false;
 </script>
 
 <div class="my-4">
@@ -36,9 +39,11 @@
       <BoxSelectIcon color="#133AFC" />
       <span>obj535253453</span>
     </p>
-    <div>infos diverses</div>
+    <div class="flex flex-col gap-4 py-4">
+      <FeatureFormInputs bind:isFormValid />
+    </div>
     <div class="flex gap-4 mt-4 w-full justify-center">
-      <PrimaryButton isSelected><Check />Accept</PrimaryButton>
+      <PrimaryButton isSelected disabled={!isFormValid}><Check />Accept</PrimaryButton>
       <PrimaryButton>Ignore</PrimaryButton>
     </div>
   </div>

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -16,10 +16,15 @@
 
   import { Check, BoxSelectIcon, Filter } from "lucide-svelte";
   import { PrimaryButton, Slider, IconButton, Switch } from "@pixano/core";
+  import type { ItemObject } from "@pixano/core";
   import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
+
+  export let objectsToAnnotate: ItemObject[] = [];
 
   let isFormValid: boolean = false;
   let isActive: boolean = false;
+
+  $: console.log({ objectsToAnnotate });
 </script>
 
 <div class="my-4">
@@ -29,7 +34,7 @@
       <h3>PRE ANNOTATION</h3>
     </div>
     {#if isActive}
-      <span>1 / 5</span>
+      <span>1 / {objectsToAnnotate.length}</span>
     {/if}
   </div>
   {#if isActive}

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -19,6 +19,7 @@
   import type { ItemObject } from "@pixano/core";
   import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
   import { itemObjects } from "../../lib/stores/imageWorkspaceStores";
+  import { GROUND_TRUTH } from "../../lib/constants";
 
   export let objectsToAnnotate: ItemObject[] = [];
   export let colorScale: (id: string) => string;
@@ -68,10 +69,19 @@
   };
 
   const handleAcceptItem = () => {
+    itemObjects.update((objects) =>
+      objects.map((object) => {
+        if (object.id === objectToAnnotate.id) {
+          object.source_id = GROUND_TRUTH;
+        }
+        return object;
+      }),
+    );
     highlightNextItem();
   };
 
   const handleRejectItem = () => {
+    itemObjects.update((objects) => objects.filter((object) => object.id !== objectToAnnotate.id));
     highlightNextItem();
   };
 </script>

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -15,36 +15,44 @@
    */
 
   import { Check, BoxSelectIcon, Filter } from "lucide-svelte";
-  import { PrimaryButton, Slider, IconButton } from "@pixano/core";
+  import { PrimaryButton, Slider, IconButton, Switch } from "@pixano/core";
   import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
 
   let isFormValid: boolean = false;
+  let isActive: boolean = false;
 </script>
 
 <div class="my-4">
   <div class="flex justify-between my-4">
-    <h3>PRE ANNOTATION</h3>
-    <span>1 / 5</span>
-  </div>
-  <div class="my-2 flex items-center">
-    <IconButton tooltipContent="confidence slider">
-      <Filter />
-    </IconButton>
-    <div class="px-8 w-full">
-      <Slider value={[0]} max={100} step={1} />
+    <div class="flex gap-4">
+      <Switch bind:checked={isActive} />
+      <h3>PRE ANNOTATION</h3>
     </div>
+    {#if isActive}
+      <span>1 / 5</span>
+    {/if}
   </div>
-  <div class="bg-white rounded-sm p-4 mt-4">
-    <p class="flex gap-2">
-      <BoxSelectIcon color="#133AFC" />
-      <span>obj535253453</span>
-    </p>
-    <div class="flex flex-col gap-4 py-4">
-      <FeatureFormInputs bind:isFormValid />
+  {#if isActive}
+    <div class="my-2 flex items-center">
+      <IconButton tooltipContent="confidence slider">
+        <Filter />
+      </IconButton>
+      <div class="px-8 w-full">
+        <Slider value={[0]} max={100} step={1} />
+      </div>
     </div>
-    <div class="flex gap-4 mt-4 w-full justify-center">
-      <PrimaryButton isSelected disabled={!isFormValid}><Check />Accept</PrimaryButton>
-      <PrimaryButton>Ignore</PrimaryButton>
+    <div class="bg-white rounded-sm p-4 mt-4">
+      <p class="flex gap-2">
+        <BoxSelectIcon color="#133AFC" />
+        <span>obj535253453</span>
+      </p>
+      <div class="flex flex-col gap-4 py-4">
+        <FeatureFormInputs bind:isFormValid />
+      </div>
+      <div class="flex gap-4 mt-4 w-full justify-center">
+        <PrimaryButton isSelected disabled={!isFormValid}><Check />Accept</PrimaryButton>
+        <PrimaryButton>Ignore</PrimaryButton>
+      </div>
     </div>
-  </div>
+  {/if}
 </div>

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -15,10 +15,12 @@
    */
 
   import { Check, BoxSelectIcon, Filter } from "lucide-svelte";
+  import { nanoid } from "nanoid";
+
   import { PrimaryButton, Slider, IconButton, Switch, cn } from "@pixano/core";
   import type { ItemObject } from "@pixano/core";
   import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
-  import { itemObjects } from "../../lib/stores/imageWorkspaceStores";
+  import { canSave, itemObjects } from "../../lib/stores/imageWorkspaceStores";
   import { GROUND_TRUTH } from "../../lib/constants";
   import { mapObjectWithNewStatus, sortAndFilterObjectsToAnnotate } from "../../lib/api/objectsApi";
   import * as Tooltip from "@pixano/core/src/components/ui/tooltip";
@@ -56,13 +58,15 @@
 
   const handleAcceptItem = () => {
     itemObjects.update((objects) => [
-      { ...objectToAnnotate, preAnnotation: "accepted", source_id: GROUND_TRUTH },
+      { ...objectToAnnotate, preAnnotation: "accepted", source_id: GROUND_TRUTH, id: nanoid(10) },
       ...mapObjectWithNewStatus(objects, objectsToAnnotate, "accepted", objectProperties),
     ]);
+    canSave.set(true);
   };
 
   const handleRejectItem = () => {
     itemObjects.update((objects) => mapObjectWithNewStatus(objects, objectsToAnnotate, "rejected"));
+    canSave.set(true);
   };
 </script>
 

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -68,7 +68,7 @@
 
   const handleAcceptItem = () => {
     itemObjects.update((objects) => [
-      { ...objectToAnnotate, preAnnotation: "accepted", source_id: GROUND_TRUTH, id: nanoid(10) },
+      { ...objectToAnnotate, review_state: "accepted", source_id: GROUND_TRUTH, id: nanoid(10) },
       ...mapObjectWithNewStatus(objects, filteredObjectsToAnnotate, "accepted", objectProperties),
     ]);
     canSave.set(true);

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -95,6 +95,14 @@
 
   const handleRejectItem = () => {
     itemObjects.update((objects) => objects.filter((object) => object.id !== objectToAnnotate.id));
+    itemObjects.update((objects) =>
+      objects.map((object) => {
+        if (object.id === objectToAnnotate.id) {
+          object.preAnnotation = "rejected";
+        }
+        return object;
+      }),
+    );
     highlightNextItem();
   };
 </script>

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -37,10 +37,10 @@
   let isFormValid: boolean = false;
   let preAnnotationIsActive: boolean = false;
   let confidenceFilterValue = [0];
-  $: objectToAnnotate = filteredObjectsToAnnotate[0];
   let color: string;
   let objectProperties: ObjectProperties = {};
 
+  $: objectToAnnotate = filteredObjectsToAnnotate[0];
   $: color = colorScale(objectToAnnotate?.id || "");
 
   itemObjects.subscribe((objects) => {
@@ -69,13 +69,15 @@
   const handleAcceptItem = () => {
     itemObjects.update((objects) => [
       { ...objectToAnnotate, preAnnotation: "accepted", source_id: GROUND_TRUTH, id: nanoid(10) },
-      ...mapObjectWithNewStatus(objects, objectsToAnnotate, "accepted", objectProperties),
+      ...mapObjectWithNewStatus(objects, filteredObjectsToAnnotate, "accepted", objectProperties),
     ]);
     canSave.set(true);
   };
 
   const handleRejectItem = () => {
-    itemObjects.update((objects) => mapObjectWithNewStatus(objects, objectsToAnnotate, "rejected"));
+    itemObjects.update((objects) =>
+      mapObjectWithNewStatus(objects, filteredObjectsToAnnotate, "rejected"),
+    );
     canSave.set(true);
   };
 </script>

--- a/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -17,11 +17,11 @@
   import { Button } from "@pixano/core/src";
   import { nanoid } from "nanoid";
 
-  import type { FeatureValues, ItemObject, Shape } from "@pixano/core";
+  import type { ItemObject, Shape } from "@pixano/core";
 
   import { newShape, itemObjects, canSave } from "../../lib/stores/imageWorkspaceStores";
   import { GROUND_TRUTH } from "../../lib/constants";
-  import type { CreateObjectInputs } from "../../lib/types/imageWorkspaceTypes";
+  import type { CreateObjectInputs, ObjectProperties } from "../../lib/types/imageWorkspaceTypes";
   import { mapShapeInputsToFeatures } from "../../lib/api/featuresApi";
   import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
 
@@ -29,7 +29,7 @@
   let isFormValid: boolean = false;
   let formInputs: CreateObjectInputs = [];
 
-  let objectProperties: { [key: string]: FeatureValues } = {};
+  let objectProperties: ObjectProperties = {};
 
   newShape.subscribe((value) => {
     if (value) shape = value;

--- a/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -83,14 +83,14 @@
 
 {#if shape.status === "inProgress"}
   <form class="flex flex-col gap-4 p-4" on:submit|preventDefault={handleFormSubmit}>
-    <p>Sauvegarde {shape.type}</p>
+    <p>Save {shape.type}</p>
     <FeatureFormInputs bind:isFormValid bind:formInputs bind:objectProperties />
     <div class="flex gap-4">
       <Button
         class="text-white"
-        on:click={() => newShape.set({ status: "none", shouldReset: true })}>cancel</Button
+        on:click={() => newShape.set({ status: "none", shouldReset: true })}>Cancel</Button
       >
-      <Button class="text-white" type="submit" disabled={!isFormValid}>confirm</Button>
+      <Button class="text-white" type="submit" disabled={!isFormValid}>Confirm</Button>
     </div>
   </form>
 {/if}

--- a/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -36,20 +36,6 @@
   let formInputs: CreateObjectInputs = [];
 
   let objectProperties: { [key: string]: FeatureValues } = {};
-  // let objectValidationSchema: CreateObjectSchema;
-
-  // itemMetas.subscribe((metas) => {
-  //   const itemFeaturesArray = Object.values(metas.itemFeatures || defaultObjectFeatures).map(
-  //     (feature) => ({
-  //       ...feature,
-  //       label: feature.name,
-  //       required: true,
-  //       type: feature.dtype,
-  //     }),
-  //   );
-  //   objectValidationSchema = createSchemaFromFeatures(itemFeaturesArray);
-  //   formInputs = createObjectInputsSchema.parse(itemFeaturesArray);
-  // });
 
   newShape.subscribe((value) => {
     if (value) shape = value;
@@ -99,61 +85,13 @@
     newShape.set({ status: "none" });
     canSave.set(true);
   };
-
-  // const handleInputChange = (value: string | number | boolean, propertyLabel: string) => {
-  //   objectProperties[propertyLabel] = value;
-  // };
-  // $: {
-  //   const result = objectValidationSchema.safeParse(objectProperties);
-  //   isFormValid = result.success;
-  // }
 </script>
 
 {#if shape.status === "inProgress"}
   <form class="flex flex-col gap-4 p-4" on:submit|preventDefault={handleFormSubmit}>
     <p>Sauvegarde {shape.type}</p>
-    <FeatureFormInputs bind:isFormValid bind:formInputs />
-    <!-- {#each formInputs as feature, i}
-      {#if feature.type === "bool"}
-        <div class="flex gap-4 items-center">
-          <Checkbox handleClick={(checked) => handleInputChange(checked, feature.name)} />
-          <span
-            >{feature.label}
-            {#if feature.required}
-              <span>*</span>
-            {/if}
-          </span>
-        </div>
-      {/if}
-      {#if feature.type === "list"}
-        <Combobox
-          placeholder={`Select a ${feature.label}`}
-          listItems={feature.options}
-          saveValue={(value) => handleInputChange(value, feature.name)}
-        />
-      {/if}
-      {#if ["int", "float", "str"].includes(feature.type)}
-        <div>
-          <span
-            >{feature.label}
-            {#if feature.required}
-              <span>*</span>
-            {/if}
-          </span>
-          <Input
-            type={feature.type === "str" ? "text" : "number"}
-            step={feature.type === "int" ? "1" : "any"}
-            autofocus={i === 0 ? true : false}
-            on:keyup={(e) => e.stopPropagation()}
-            on:change={(e) =>
-              handleInputChange(
-                feature.type === "str" ? e.currentTarget.value : Number(e.currentTarget.value),
-                feature.name,
-              )}
-          />
-        </div>
-      {/if}
-    {/each} -->
+    <FeatureFormInputs bind:isFormValid bind:formInputs bind:objectProperties />
+
     <div class="flex gap-4">
       <Button
         class="text-white"

--- a/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -14,38 +14,42 @@
    * http://www.cecill.info
    */
 
-  import { Button, Input, Checkbox, Combobox } from "@pixano/core/src";
+  import { Button } from "@pixano/core/src";
+  // import { Button, Input, Checkbox, Combobox } from "@pixano/core/src";
   import type { FeatureValues, ItemObject, Shape } from "@pixano/core";
 
-  import { newShape, itemObjects, canSave, itemMetas } from "../../lib/stores/imageWorkspaceStores";
-  import {
-    createObjectInputsSchema,
-    createSchemaFromFeatures,
-  } from "../../lib/settings/objectValidationSchemas";
+  import { newShape, itemObjects, canSave } from "../../lib/stores/imageWorkspaceStores";
+  // import { newShape, itemObjects, canSave, itemMetas } from "../../lib/stores/imageWorkspaceStores";
+  // import {
+  //   createObjectInputsSchema,
+  //   createSchemaFromFeatures,
+  // } from "../../lib/settings/objectValidationSchemas";
   import { GROUND_TRUTH } from "../../lib/constants";
-  import type { CreateObjectInputs, CreateObjectSchema } from "../../lib/types/imageWorkspaceTypes";
+  import type { CreateObjectInputs } from "../../lib/types/imageWorkspaceTypes";
+  // import type { CreateObjectInputs, CreateObjectSchema } from "../../lib/types/imageWorkspaceTypes";
   import { mapShapeInputsToFeatures } from "../../lib/api/featuresApi";
-  import { defaultObjectFeatures } from "../../lib/settings/defaultFeatures";
+  // import { defaultObjectFeatures } from "../../lib/settings/defaultFeatures";
+  import FeatureFormInputs from "../Features/FeatureFormInputs.svelte";
 
   let shape: Shape;
   let isFormValid: boolean = false;
+  let formInputs: CreateObjectInputs = [];
 
   let objectProperties: { [key: string]: FeatureValues } = {};
-  let formInputs: CreateObjectInputs = [];
-  let objectValidationSchema: CreateObjectSchema;
+  // let objectValidationSchema: CreateObjectSchema;
 
-  itemMetas.subscribe((metas) => {
-    const itemFeaturesArray = Object.values(metas.itemFeatures || defaultObjectFeatures).map(
-      (feature) => ({
-        ...feature,
-        label: feature.name,
-        required: true,
-        type: feature.dtype,
-      }),
-    );
-    objectValidationSchema = createSchemaFromFeatures(itemFeaturesArray);
-    formInputs = createObjectInputsSchema.parse(itemFeaturesArray);
-  });
+  // itemMetas.subscribe((metas) => {
+  //   const itemFeaturesArray = Object.values(metas.itemFeatures || defaultObjectFeatures).map(
+  //     (feature) => ({
+  //       ...feature,
+  //       label: feature.name,
+  //       required: true,
+  //       type: feature.dtype,
+  //     }),
+  //   );
+  //   objectValidationSchema = createSchemaFromFeatures(itemFeaturesArray);
+  //   formInputs = createObjectInputsSchema.parse(itemFeaturesArray);
+  // });
 
   newShape.subscribe((value) => {
     if (value) shape = value;
@@ -96,19 +100,20 @@
     canSave.set(true);
   };
 
-  const handleInputChange = (value: string | number | boolean, propertyLabel: string) => {
-    objectProperties[propertyLabel] = value;
-  };
-  $: {
-    const result = objectValidationSchema.safeParse(objectProperties);
-    isFormValid = result.success;
-  }
+  // const handleInputChange = (value: string | number | boolean, propertyLabel: string) => {
+  //   objectProperties[propertyLabel] = value;
+  // };
+  // $: {
+  //   const result = objectValidationSchema.safeParse(objectProperties);
+  //   isFormValid = result.success;
+  // }
 </script>
 
 {#if shape.status === "inProgress"}
   <form class="flex flex-col gap-4 p-4" on:submit|preventDefault={handleFormSubmit}>
     <p>Sauvegarde {shape.type}</p>
-    {#each formInputs as feature, i}
+    <FeatureFormInputs bind:isFormValid bind:formInputs />
+    <!-- {#each formInputs as feature, i}
       {#if feature.type === "bool"}
         <div class="flex gap-4 items-center">
           <Checkbox handleClick={(checked) => handleInputChange(checked, feature.name)} />
@@ -148,7 +153,7 @@
           />
         </div>
       {/if}
-    {/each}
+    {/each} -->
     <div class="flex gap-4">
       <Button
         class="text-white"

--- a/ui/components/imageWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/imageWorkspace/src/components/Toolbar.svelte
@@ -112,7 +112,7 @@
       on:click={handleSmartToolClick}
       on:dblclick={() =>
         modelsStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }))}
-      class="relative hover:bg-primary-light inline-flex items-center justify-center rounded-md text-sm font-medium whitespace-nowrap ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-10 w-10 bg-transparent text-gray-800"
+      class="relative hover:bg-primary-light inline-flex items-center justify-center rounded-md text-sm font-medium whitespace-nowrap ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-10 w-10 bg-transparent text-slate-800"
     >
       <BrushIcon />
       <MagicIcon />

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -1,7 +1,13 @@
 import type { ItemObject, BBox, DisplayControl, Mask, DatasetItem, Shape } from "@pixano/core";
 import { mask_utils } from "@pixano/models/src";
 
-import { GROUND_TRUTH, MODEL_RUN, PRE_ANNOTATION } from "../constants";
+import {
+  ANNOTATION_ITEM_STROKE_FACTOR,
+  GROUND_TRUTH,
+  MODEL_RUN,
+  NOT_ANNOTATION_ITEM_OPACITY,
+  PRE_ANNOTATION,
+} from "../constants";
 import type { ObjectsSortedByModelType } from "../types/imageWorkspaceTypes";
 import { DEFAULT_FEATURE } from "../settings/defaultFeatures";
 
@@ -33,10 +39,11 @@ export const mapObjectToBBox = (obj: ItemObject, views: DatasetItem["views"]) =>
     catId: (obj.features.category_id?.value || 1) as number,
     bbox: [x, y, w, h],
     tooltip,
-    opacity: 1.0,
+    opacity: obj.highlighted === "none" ? NOT_ANNOTATION_ITEM_OPACITY : 1.0,
     visible: !obj.bbox.displayControl?.hidden,
     editing: obj.displayControl?.editing,
     locked: obj.displayControl?.locked,
+    strokeFactor: obj.highlighted === "self" ? ANNOTATION_ITEM_STROKE_FACTOR : 1,
   } as BBox;
 };
 

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -61,9 +61,7 @@ export const mapObjectToMasks = (obj: ItemObject) => {
     return;
   const rle = obj.mask.counts;
   const size = obj.mask.size;
-
   const maskPoly = mask_utils.generatePolygonSegments(rle, size[0]);
-
   const masksSVG = mask_utils.convertSegmentsToSVG(maskPoly);
 
   return {
@@ -74,7 +72,7 @@ export const mapObjectToMasks = (obj: ItemObject) => {
     catId: (obj.features.category_id?.value || 1) as number,
     visible: !obj.mask.displayControl?.hidden,
     editing: obj.displayControl?.editing,
-    opacity: 1.0,
+    opacity: obj.highlighted === "none" ? NOT_ANNOTATION_ITEM_OPACITY : 1.0,
     isManual: !!obj.isManual,
   } as Mask;
 };

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -103,8 +103,11 @@ export const toggleObjectDisplayControl = (
 export const sortObjectsByModel = (objects: ItemObject[]) =>
   objects.reduce(
     (acc, object) => {
+      if (object.source_id === PRE_ANNOTATION) {
+        acc[PRE_ANNOTATION] = [object, ...acc[PRE_ANNOTATION]];
+      }
       if (object.source_id === GROUND_TRUTH) {
-        acc[GROUND_TRUTH] = [object, ...acc[GROUND_TRUTH]];
+        acc[object.source_id] = [object, ...acc[GROUND_TRUTH]];
       } else {
         const modelAlreadyExists = acc[MODEL_RUN].some(
           (model) => model.modelName === object.source_id,

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -8,7 +8,7 @@ import {
   NOT_ANNOTATION_ITEM_OPACITY,
   PRE_ANNOTATION,
 } from "../constants";
-import type { ObjectsSortedByModelType } from "../types/imageWorkspaceTypes";
+import type { ObjectProperties, ObjectsSortedByModelType } from "../types/imageWorkspaceTypes";
 import { DEFAULT_FEATURE } from "../settings/defaultFeatures";
 
 const defineTooltip = (object: ItemObject) => {
@@ -183,6 +183,7 @@ export const mapObjectWithNewStatus = (
   allObjects: ItemObject[],
   objectsToAnnotate: ItemObject[],
   status: "accepted" | "rejected",
+  features: ObjectProperties = {},
 ) => {
   const nextObjectId = objectsToAnnotate[1]?.id;
   return allObjects.map((object) => {
@@ -193,6 +194,11 @@ export const mapObjectWithNewStatus = (
     }
     if (object.id === objectsToAnnotate[0]?.id) {
       object.preAnnotation = status;
+      Object.keys(features || {}).forEach((key) => {
+        if (object.features[key]) {
+          object.features[key].value = features[key];
+        }
+      });
     }
     return object;
   });

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -25,7 +25,12 @@ const defineTooltip = (object: ItemObject) => {
 };
 
 export const mapObjectToBBox = (obj: ItemObject, views: DatasetItem["views"]) => {
-  if (!obj.bbox) return;
+  if (
+    !obj.bbox ||
+    obj.preAnnotation === "rejected" ||
+    (obj.source_id === PRE_ANNOTATION && obj.preAnnotation === "accepted")
+  )
+    return;
   const imageHeight = (views?.[obj.view_id]?.features.height.value as number) || 1;
   const imageWidth = (views?.[obj.view_id]?.features.width.value as number) || 1;
   const x = obj.bbox.coords[0] * imageWidth;
@@ -48,7 +53,12 @@ export const mapObjectToBBox = (obj: ItemObject, views: DatasetItem["views"]) =>
 };
 
 export const mapObjectToMasks = (obj: ItemObject) => {
-  if (!obj.mask) return;
+  if (
+    !obj.mask ||
+    obj.preAnnotation ||
+    (obj.source_id === PRE_ANNOTATION && obj.preAnnotation === "accepted")
+  )
+    return;
   const rle = obj.mask.counts;
   const size = obj.mask.size;
 

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -27,8 +27,8 @@ const defineTooltip = (object: ItemObject) => {
 export const mapObjectToBBox = (obj: ItemObject, views: DatasetItem["views"]) => {
   if (
     !obj.bbox ||
-    obj.preAnnotation === "rejected" ||
-    (obj.source_id === PRE_ANNOTATION && obj.preAnnotation === "accepted")
+    obj.review_state === "rejected" ||
+    (obj.source_id === PRE_ANNOTATION && obj.review_state === "accepted")
   )
     return;
   const imageHeight = (views?.[obj.view_id]?.features.height.value as number) || 1;
@@ -55,8 +55,8 @@ export const mapObjectToBBox = (obj: ItemObject, views: DatasetItem["views"]) =>
 export const mapObjectToMasks = (obj: ItemObject) => {
   if (
     !obj.mask ||
-    obj.preAnnotation ||
-    (obj.source_id === PRE_ANNOTATION && obj.preAnnotation === "accepted")
+    obj.review_state ||
+    (obj.source_id === PRE_ANNOTATION && obj.review_state === "accepted")
   )
     return;
   const rle = obj.mask.counts;
@@ -114,7 +114,7 @@ export const sortObjectsByModel = (objects: ItemObject[]) =>
   objects.reduce(
     (acc, object) => {
       if (object.source_id === PRE_ANNOTATION) {
-        if (!object.preAnnotation) acc[PRE_ANNOTATION] = [object, ...acc[PRE_ANNOTATION]];
+        if (!object.review_state) acc[PRE_ANNOTATION] = [object, ...acc[PRE_ANNOTATION]];
         return acc;
       }
       if (object.source_id === GROUND_TRUTH) {
@@ -174,7 +174,7 @@ export const updateExistingObject = (old: ItemObject[], newShape: Shape) =>
   });
 
 export const getObjectsToPreAnnotate = (objects: ItemObject[]) =>
-  objects.filter((object) => object.source_id === PRE_ANNOTATION && !object.preAnnotation);
+  objects.filter((object) => object.source_id === PRE_ANNOTATION && !object.review_state);
 
 export const sortAndFilterObjectsToAnnotate = (
   objects: ItemObject[],
@@ -205,7 +205,7 @@ export const mapObjectWithNewStatus = (
       object.highlighted = "none";
     }
     if (object.id === objectsToAnnotate[0]?.id) {
-      object.preAnnotation = status;
+      object.review_state = status;
       Object.keys(features || {}).forEach((key) => {
         if (object.features[key]) {
           object.features[key].value = features[key];

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -1,7 +1,7 @@
 import type { ItemObject, BBox, DisplayControl, Mask, DatasetItem, Shape } from "@pixano/core";
 import { mask_utils } from "@pixano/models/src";
 
-import { GROUND_TRUTH, MODEL_RUN } from "../constants";
+import { GROUND_TRUTH, MODEL_RUN, PRE_ANNOTATION } from "../constants";
 import type { ObjectsSortedByModelType } from "../types/imageWorkspaceTypes";
 import { DEFAULT_FEATURE } from "../settings/defaultFeatures";
 
@@ -123,9 +123,10 @@ export const sortObjectsByModel = (objects: ItemObject[]) =>
           });
         }
       }
+      acc[PRE_ANNOTATION] = acc[MODEL_RUN][0]?.objects || [];
       return acc;
     },
-    { [GROUND_TRUTH]: [], [MODEL_RUN]: [] } as ObjectsSortedByModelType,
+    { [GROUND_TRUTH]: [], [MODEL_RUN]: [], [PRE_ANNOTATION]: [] } as ObjectsSortedByModelType,
   );
 
 export const updateExistingObject = (old: ItemObject[], newShape: Shape) =>

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -173,12 +173,14 @@ export const updateExistingObject = (old: ItemObject[], newShape: Shape) =>
     return object;
   });
 
+export const getObjectsToPreAnnotate = (objects: ItemObject[]) =>
+  objects.filter((object) => object.source_id === PRE_ANNOTATION && !object.preAnnotation);
+
 export const sortAndFilterObjectsToAnnotate = (
   objects: ItemObject[],
   confidenceFilterValue: number[],
 ) =>
   objects
-    .filter((object) => object.source_id === PRE_ANNOTATION && !object.preAnnotation)
     .filter((object) => {
       const confidence = object.bbox?.confidence || 0;
       return confidence >= confidenceFilterValue[0];

--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -103,7 +103,7 @@ export const toggleObjectDisplayControl = (
 export const sortObjectsByModel = (objects: ItemObject[]) =>
   objects.reduce(
     (acc, object) => {
-      if (object.source_id === PRE_ANNOTATION) {
+      if (object.source_id === PRE_ANNOTATION && !object.preAnnotation) {
         acc[PRE_ANNOTATION] = [object, ...acc[PRE_ANNOTATION]];
       }
       if (object.source_id === GROUND_TRUTH) {
@@ -133,7 +133,6 @@ export const sortObjectsByModel = (objects: ItemObject[]) =>
           });
         }
       }
-      acc[PRE_ANNOTATION] = acc[MODEL_RUN][0]?.objects || [];
       return acc;
     },
     { [GROUND_TRUTH]: [], [MODEL_RUN]: [], [PRE_ANNOTATION]: [] } as ObjectsSortedByModelType,
@@ -162,3 +161,18 @@ export const updateExistingObject = (old: ItemObject[], newShape: Shape) =>
     }
     return object;
   });
+
+export const sortAndFilterObjectsToAnnotate = (
+  objects: ItemObject[],
+  confidenceFilterValue: number[],
+) =>
+  objects
+    // .sort((a, b) => {
+    //   const confidenceA = a.bbox?.confidence || 0;
+    //   const confidenceB = b.bbox?.confidence || 0;
+    //   return confidenceB - confidenceA;
+    // })
+    .filter((object) => {
+      const confidence = object.bbox?.confidence || 0;
+      return confidence >= confidenceFilterValue[0];
+    });

--- a/ui/components/imageWorkspace/src/lib/constants.ts
+++ b/ui/components/imageWorkspace/src/lib/constants.ts
@@ -2,3 +2,7 @@
 export const GROUND_TRUTH = "Ground Truth";
 export const MODEL_RUN = "Model Run";
 export const PRE_ANNOTATION = "pre annotation";
+
+// PRE-ANNOTATION
+export const ANNOTATION_ITEM_STROKE_FACTOR = 3;
+export const NOT_ANNOTATION_ITEM_OPACITY = 0.3;

--- a/ui/components/imageWorkspace/src/lib/constants.ts
+++ b/ui/components/imageWorkspace/src/lib/constants.ts
@@ -4,5 +4,5 @@ export const MODEL_RUN = "Model Run";
 export const PRE_ANNOTATION = "pre annotation";
 
 // PRE-ANNOTATION
-export const ANNOTATION_ITEM_STROKE_FACTOR = 3;
+export const ANNOTATION_ITEM_STROKE_FACTOR = 4;
 export const NOT_ANNOTATION_ITEM_OPACITY = 0.3;

--- a/ui/components/imageWorkspace/src/lib/constants.ts
+++ b/ui/components/imageWorkspace/src/lib/constants.ts
@@ -1,3 +1,4 @@
 // source ids
 export const GROUND_TRUTH = "Ground Truth";
 export const MODEL_RUN = "Model Run";
+export const PRE_ANNOTATION = "pre annotation";

--- a/ui/components/imageWorkspace/src/lib/constants.ts
+++ b/ui/components/imageWorkspace/src/lib/constants.ts
@@ -3,6 +3,8 @@ export const GROUND_TRUTH = "Ground Truth";
 export const MODEL_RUN = "Model Run";
 export const PRE_ANNOTATION = "Pre-annotation";
 
+export const EXISTING_SOURCE_IDS = [GROUND_TRUTH, PRE_ANNOTATION];
+
 // PRE-ANNOTATION
 export const ANNOTATION_ITEM_STROKE_FACTOR = 4;
 export const NOT_ANNOTATION_ITEM_OPACITY = 0.3;

--- a/ui/components/imageWorkspace/src/lib/constants.ts
+++ b/ui/components/imageWorkspace/src/lib/constants.ts
@@ -1,7 +1,7 @@
 // source ids
 export const GROUND_TRUTH = "Ground Truth";
 export const MODEL_RUN = "Model Run";
-export const PRE_ANNOTATION = "pre annotation";
+export const PRE_ANNOTATION = "Pre-annotation";
 
 // PRE-ANNOTATION
 export const ANNOTATION_ITEM_STROKE_FACTOR = 4;

--- a/ui/components/imageWorkspace/src/lib/types/imageWorkspaceTypes.ts
+++ b/ui/components/imageWorkspace/src/lib/types/imageWorkspaceTypes.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import * as ort from "onnxruntime-web";
 
-import type { ItemObject } from "@pixano/core";
+import type { FeatureValues, ItemObject } from "@pixano/core";
 
 import { GROUND_TRUTH, MODEL_RUN, PRE_ANNOTATION } from "../constants";
 import type {
@@ -21,6 +21,8 @@ export type ListInput = z.infer<typeof listInputSchema>;
 export type OtherInput = z.infer<typeof otherInputSchema>;
 
 export type CreateObjectInputs = z.infer<typeof createObjectInputsSchema>;
+
+export type ObjectProperties = { [key: string]: FeatureValues };
 
 export type CreateObjectSchemaDefinition = Record<string, z.ZodTypeAny>;
 export type CreateObjectSchema = z.ZodObject<CreateObjectSchemaDefinition>;

--- a/ui/components/imageWorkspace/src/lib/types/imageWorkspaceTypes.ts
+++ b/ui/components/imageWorkspace/src/lib/types/imageWorkspaceTypes.ts
@@ -3,7 +3,7 @@ import * as ort from "onnxruntime-web";
 
 import type { ItemObject } from "@pixano/core";
 
-import { GROUND_TRUTH, MODEL_RUN } from "../constants";
+import { GROUND_TRUTH, MODEL_RUN, PRE_ANNOTATION } from "../constants";
 import type {
   createObjectInputsSchema,
   listInputSchema,
@@ -12,6 +12,7 @@ import type {
 
 export type ObjectsSortedByModelType = {
   [GROUND_TRUTH]: ItemObject[];
+  [PRE_ANNOTATION]: ItemObject[];
   [MODEL_RUN]: { modelName: string; objects: ItemObject[] }[];
 };
 


### PR DESCRIPTION
This PR integrates the Pre-annotation feature: 
- User can switch the Pre-annotation space feature on and off
- User can filter objects in the Pre-annotation table with a confidence slider
- User can reject or accept objects from the Pre-annotation table
- Current object selected in the Pre-annotation space is highlighted on ImageCanvas

How the data is processed:
- The Pre-annotation table is selected with source="Pre-annotation" in db.json (ItemObject.source_id)
- Accepted objects are flagged with review_state="accepted" in Pre-annotation table and copied to Ground Truth table
- Rejected objects are flagged with review_state="rejected" in Pre-annotation table
- Objects flagged as accepted or rejected are no longer suggested in the Pre-annotation space

<img width="429" alt="image" src="https://github.com/pixano/pixano/assets/105201321/66a73ce6-637a-40f0-b866-72f2416f6618">
