### PR TITLE
fix(front): Keep modified points when creating a polygon

### DIFF
--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -64,16 +64,19 @@
     } else {
       const lastPolygonDetailsPoint = polygonDetails.points.at(-1);
       const lastSimplifiedPoint = polygonShape.simplifiedPoints?.[0]?.at(-1);
-      if (lastPolygonDetailsPoint?.id !== lastSimplifiedPoint?.id) {
+      if (lastPolygonDetailsPoint && lastPolygonDetailsPoint?.id !== lastSimplifiedPoint?.id) {
         polygonShape.simplifiedPoints = [
           [...(polygonShape.simplifiedPoints?.[0] || []), lastPolygonDetailsPoint],
         ];
+      }
+      if (polygonDetails.points.length === 0) {
+        polygonShape.simplifiedPoints = [];
       }
     }
   }
 
   $: polygonShape.simplifiedSvg = polygonShape.simplifiedPoints.map((point) =>
-    convertPointToSvg(point),
+    convertPointToSvg(point.filter(Boolean)),
   );
 
   function handlePolygonPointsDragMove(id: number, i: number) {

--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -62,7 +62,8 @@
         [] as PolygonGroupPoint[][],
       );
     } else {
-      polygonShape.simplifiedPoints = [polygonDetails.points];
+      const lastPoint = polygonDetails.points.at(-1);
+      polygonShape.simplifiedPoints = [[...(polygonShape.simplifiedPoints?.[0] || []), lastPoint]];
     }
   }
 

--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -62,8 +62,13 @@
         [] as PolygonGroupPoint[][],
       );
     } else {
-      const lastPoint = polygonDetails.points.at(-1);
-      polygonShape.simplifiedPoints = [[...(polygonShape.simplifiedPoints?.[0] || []), lastPoint]];
+      const lastPolygonDetailsPoint = polygonDetails.points.at(-1);
+      const lastSimplifiedPoint = polygonShape.simplifiedPoints?.[0]?.at(-1);
+      if (lastPolygonDetailsPoint?.id !== lastSimplifiedPoint?.id) {
+        polygonShape.simplifiedPoints = [
+          [...(polygonShape.simplifiedPoints?.[0] || []), lastPolygonDetailsPoint],
+        ];
+      }
     }
   }
 


### PR DESCRIPTION
**bug description**:  when a polygon is being created and the user wants to drag a point to modify the new shape, the modification gets canceled once a new point is added. 

This fixes the issue 
