### PR TITLE
fix(back): Fix formatting for new stable version of black

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           options: "--check --verbose --diff --color"
           src: "./pixano"
+          version: "~= 24.0"
 
       - name: Format backend tests with black
         uses: psf/black@stable
@@ -110,6 +111,7 @@ jobs:
           options: "--check --verbose --diff --color"
           src: "./tests"
           jupyter: true
+          version: "~= 24.0"
 
       - name: Format Jupyter notebooks with black
         uses: psf/black@stable
@@ -117,3 +119,4 @@ jobs:
           options: "--check --verbose --diff --color"
           src: "./notebooks"
           jupyter: true
+          version: "~= 24.0"

--- a/pixano/data/dataset/dataset.py
+++ b/pixano/data/dataset/dataset.py
@@ -67,9 +67,11 @@ class Dataset(BaseModel):
             path=path,
             info=DatasetInfo.from_json(info_file),
             stats=DatasetStat.from_json(stats_file) if stats_file.is_file() else None,
-            thumbnail=Image(uri=thumb_file.absolute().as_uri()).url
-            if thumb_file.is_file()
-            else None,
+            thumbnail=(
+                Image(uri=thumb_file.absolute().as_uri()).url
+                if thumb_file.is_file()
+                else None
+            ),
         )
 
     @property
@@ -288,9 +290,11 @@ class Dataset(BaseModel):
                 for feat in new_feats:
                     # None is not supported for booleans yet (should be fixed in pylance 0.9.1)
                     feat_array = pa.array(
-                        [False] * len(table)
-                        if feat.dtype == "bool"
-                        else [None] * len(table),
+                        (
+                            [False] * len(table)
+                            if feat.dtype == "bool"
+                            else [None] * len(table)
+                        ),
                         type=field_to_pyarrow(feat.dtype),
                     )
                     new_feats_table = new_feats_table.append_column(

--- a/pixano/data/exporters/coco_exporter.py
+++ b/pixano/data/exporters/coco_exporter.py
@@ -233,9 +233,9 @@ class COCOExporter(Exporter):
         # Category
         category = {
             "id": None,
-            "name": obj.features["category"].value
-            if "category" in obj.features
-            else None,
+            "name": (
+                obj.features["category"].value if "category" in obj.features else None
+            ),
         }
         if category["name"] is not None:
             for cat in self.dataset.info.categories:

--- a/pixano/data/importers/coco_importer.py
+++ b/pixano/data/importers/coco_importer.py
@@ -152,16 +152,20 @@ class COCOImporter(Importer):
                                 "original_id": str(ann["id"]),
                                 "item_id": item_id,
                                 "view_id": "image",
-                                "bbox": BBox.from_xywh(ann["bbox"])
-                                .normalize(im["height"], im["width"])
-                                .to_dict()
-                                if ann["bbox"]
-                                else None,
-                                "mask": CompressedRLE.encode(
-                                    ann["segmentation"], im["height"], im["width"]
-                                ).to_dict()
-                                if ann["segmentation"]
-                                else None,
+                                "bbox": (
+                                    BBox.from_xywh(ann["bbox"])
+                                    .normalize(im["height"], im["width"])
+                                    .to_dict()
+                                    if ann["bbox"]
+                                    else None
+                                ),
+                                "mask": (
+                                    CompressedRLE.encode(
+                                        ann["segmentation"], im["height"], im["width"]
+                                    ).to_dict()
+                                    if ann["segmentation"]
+                                    else None
+                                ),
                                 "category": str(categories[ann["category_id"]]),
                             }
                             for ann in im_anns

--- a/pixano/data/item/item_object.py
+++ b/pixano/data/item/item_object.py
@@ -110,9 +110,7 @@ class ItemBBox(BaseModel):
         return (
             BBox.from_dict(self.model_dump())
             if self.coords != [0.0, 0.0, 0.0, 0.0]
-            else BBox.from_rle(mask.to_pyarrow())
-            if mask
-            else None
+            else BBox.from_rle(mask.to_pyarrow()) if mask else None
         )
 
 

--- a/pixano/models/inference_model.py
+++ b/pixano/models/inference_model.py
@@ -243,11 +243,11 @@ class InferenceModel(ABC):
                     save_batch.extend(
                         self.preannotate(process_batch, views, uri_prefix, threshold)
                         if process_type == "obj"
-                        else self.precompute_embeddings(
-                            process_batch, views, uri_prefix
+                        else (
+                            self.precompute_embeddings(process_batch, views, uri_prefix)
+                            if process_type in ["segment_emb", "search_emb"]
+                            else []
                         )
-                        if process_type in ["segment_emb", "search_emb"]
-                        else []
                     )
                     progress.update(batch_size)
 


### PR DESCRIPTION
## Description

A new stable release of the black formatter has been released (24), which breaks the backend formatting GitHub action on the latest commit to develop (2d72d37ab7a2f08a7648410e18250eb20105a7b0) as our code is formatted with version 23.
- Fix backend code formatting to be in line with version 24 of black
- Specify version 24 of black in the GitHub action to prevent this from happening with future releases of black

### Warning

For those working on the backend (@BertrandRenault), update your black formatter to version 24 as well:
```bash
pip install --upgrade black~=24.1.0
```