### PR TITLE
feat(front): Create concave polygons

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1117,13 +1117,11 @@
             selectedItemId={selectedItem.id}
             bind:newShape
           />
-
           {#each manualMasks as manualMask}
             {#key manualMask.id}
               {#if manualMask.viewId === view.id}
                 <PolygonGroup
                   viewId={view.id}
-                  selectedItemId={selectedItem.id}
                   bind:newShape
                   {stage}
                   {images}

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -55,6 +55,7 @@
     getNewRectangleDimensions,
   } from "./api/boundingBoxesApi";
   import PolygonGroup from "./components/PolygonGroup.svelte";
+  import CreatePolygon from "./components/CreatePolygon.svelte";
 
   // Exports
   export let selectedItem: DatasetItem;
@@ -511,11 +512,12 @@
     const x = Math.round(cursorPositionOnImage.x);
     const y = Math.round(cursorPositionOnImage.y);
 
-    manualMasks = manualMasks.map((mask) =>
-      mask.status === "created"
-        ? mask
-        : { ...mask, points: [...mask.points, { x, y, id: mask.points.length }], viewId },
-    );
+    const oldPoints = newShape.status === "creating" ? newShape.points : [];
+    newShape = {
+      status: "creating",
+      type: "mask",
+      points: [...oldPoints, { x, y, id: oldPoints.length || 0 }],
+    };
   }
 
   // ********** PAN TOOL ********** //
@@ -1107,6 +1109,15 @@
           <Group config={{ id: "masks" }} />
           <Group config={{ id: "bboxes" }} />
           <Group config={{ id: "input" }} />
+          <CreatePolygon
+            viewId={view.id}
+            {stage}
+            {images}
+            {zoomFactor}
+            selectedItemId={selectedItem.id}
+            bind:newShape
+          />
+
           {#each manualMasks as manualMask}
             {#key manualMask.id}
               {#if manualMask.viewId === view.id}
@@ -1116,9 +1127,9 @@
                   bind:newShape
                   {stage}
                   {images}
+                  {zoomFactor}
                   polygonDetails={manualMask}
                   color={colorScale(manualMask.id)}
-                  {zoomFactor}
                 />
               {/if}
             {/key}

--- a/ui/components/canvas2d/src/api/boundingBoxesApi.ts
+++ b/ui/components/canvas2d/src/api/boundingBoxesApi.ts
@@ -322,15 +322,6 @@ export function mapMaskPointsToLineCoordinates(masks: Mask[]): PolygonGroupDetai
       mask.points = simplifiedPoints as PolygonGroupPoint[];
       return mask as PolygonGroupDetails;
     });
-  const emptyMask: PolygonGroupDetails = {
-    visible: true,
-    status: "creating",
-    points: [],
-    svg: [],
-    editing: false,
-    id: "creating",
-    viewId: undefined,
-  };
-  mappedMasks.push(emptyMask);
+
   return mappedMasks;
 }

--- a/ui/components/canvas2d/src/components/CreatePolygon.svelte
+++ b/ui/components/canvas2d/src/components/CreatePolygon.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  /**
+   * @copyright CEA
+   * @author CEA
+   * @license CECILL
+   *
+   * This software is a collaborative computer program whose purpose is to
+   * generate and explore labeled data for computer vision applications.
+   * This software is governed by the CeCILL-C license under French law and
+   * abiding by the rules of distribution of free software. You can use,
+   * modify and/ or redistribute the software under the terms of the CeCILL-C
+   * license as circulated by CEA, CNRS and INRIA at the following URL
+   *
+   * http://www.cecill.info
+   */
+
+  // Imports
+  import Konva from "konva";
+  import { Group, Line } from "svelte-konva";
+
+  import type { DatasetItem, Shape } from "@pixano/core";
+  import type { PolygonGroupPoint } from "../lib/types/canvas2dTypes";
+  import { runLengthEncode, convertPointToSvg } from "../api/maskApi";
+  import { INPUTRECT_STROKEWIDTH } from "../lib/constants";
+  import PolygonPoints from "./PolygonPoints.svelte";
+
+  // Exports
+  export let viewId: string;
+  export let selectedItemId: DatasetItem["id"];
+  export let newShape: Shape;
+  export let stage: Konva.Stage;
+  export let images: Record<string, HTMLImageElement> = {};
+  export let zoomFactor: Record<string, number>;
+  const POLYGON_ID = "creating";
+
+  let polygonPoints: PolygonGroupPoint[][] = [];
+
+  let isClosed = false;
+
+  $: {
+    if (newShape.status === "creating") {
+      const lastPolygonDetailsPoint = newShape.points.at(-1);
+      const lastSimplifiedPoint = polygonPoints?.[0]?.at(-1);
+      if (lastPolygonDetailsPoint && lastPolygonDetailsPoint?.id !== lastSimplifiedPoint?.id) {
+        polygonPoints = [[...(polygonPoints[0] || []), lastPolygonDetailsPoint]];
+      }
+      if (newShape.points.length === 0) {
+        polygonPoints = [];
+      }
+    }
+    if (newShape.status === "none") {
+      polygonPoints = [];
+      isClosed = false;
+    }
+  }
+
+  function handlePolygonPointsClick(i: number, viewId: string) {
+    if (i === 0) {
+      const svg = polygonPoints.map((point) => convertPointToSvg(point));
+      const counts = runLengthEncode(svg, images[viewId].width, images[viewId].height);
+      newShape = {
+        status: "inProgress",
+        masksImageSVG: [],
+        rle: {
+          counts,
+          size: [images[viewId].height, images[viewId].width],
+        },
+        type: "mask",
+        viewId: viewId,
+        itemId: selectedItemId,
+        imageWidth: images[viewId].width,
+        imageHeight: images[viewId].height,
+        isManual: true,
+      };
+      isClosed = true;
+    }
+  }
+
+  function handlePolygonPointsDragMove(id: number, i: number) {
+    const pos = stage.findOne(`#dot-${POLYGON_ID}-${i}-${id}`).position();
+    const newPolygonPoints = polygonPoints.map((points, pi) =>
+      pi === i
+        ? points.map((point) => (point.id === id ? { ...point, x: pos.x, y: pos.y } : point))
+        : points,
+    );
+    polygonPoints = newPolygonPoints;
+  }
+
+  $: flatPoints = polygonPoints[0]?.reduce((acc, val) => [...acc, val.x, val.y], [] as number[]);
+</script>
+
+<Group config={{ id: "polygon", draggable: true }}>
+  <Line
+    config={{
+      points: flatPoints,
+      stroke: "hsl(316deg 60% 29.41%)",
+      strokeWidth: INPUTRECT_STROKEWIDTH / zoomFactor[viewId],
+      fill: "#f9f4f773",
+      closed: isClosed,
+    }}
+  />
+  <PolygonPoints
+    {viewId}
+    {stage}
+    {zoomFactor}
+    polygonId={POLYGON_ID}
+    points={polygonPoints}
+    {handlePolygonPointsClick}
+    {handlePolygonPointsDragMove}
+    handlePolygonPointsDragEnd={null}
+  />
+</Group>

--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -17,9 +17,9 @@
   // Imports
 
   import Konva from "konva";
-  import { Group, Circle, Shape as KonvaShape, Path } from "svelte-konva";
+  import { Group, Shape as KonvaShape } from "svelte-konva";
 
-  import type { DatasetItem, Shape } from "@pixano/core";
+  import type { Shape } from "@pixano/core";
   import type { PolygonGroupDetails, PolygonGroupPoint } from "../lib/types/canvas2dTypes";
   import {
     sceneFunc,
@@ -28,11 +28,10 @@
     parseSvgPath,
     runLengthEncode,
   } from "../api/maskApi";
-  import { INPUTRECT_STROKEWIDTH } from "../lib/constants";
+  import PolygonPoints from "./PolygonPoints.svelte";
 
   // Exports
   export let viewId: string;
-  export let selectedItemId: DatasetItem["id"];
   export let newShape: Shape;
   export let stage: Konva.Stage;
   export let images: Record<string, HTMLImageElement> = {};
@@ -53,30 +52,17 @@
     ),
   };
 
-  $: canEdit = polygonDetails.status === "creating" || polygonDetails.editing;
+  $: canEdit = polygonDetails.editing;
 
   $: {
-    if (polygonDetails.id !== "creating") {
-      polygonShape.simplifiedPoints = polygonDetails.svg.reduce(
-        (acc, val) => [...acc, parseSvgPath(val)],
-        [] as PolygonGroupPoint[][],
-      );
-    } else {
-      const lastPolygonDetailsPoint = polygonDetails.points.at(-1);
-      const lastSimplifiedPoint = polygonShape.simplifiedPoints?.[0]?.at(-1);
-      if (lastPolygonDetailsPoint && lastPolygonDetailsPoint?.id !== lastSimplifiedPoint?.id) {
-        polygonShape.simplifiedPoints = [
-          [...(polygonShape.simplifiedPoints?.[0] || []), lastPolygonDetailsPoint],
-        ];
-      }
-      if (polygonDetails.points.length === 0) {
-        polygonShape.simplifiedPoints = [];
-      }
-    }
+    polygonShape.simplifiedPoints = polygonDetails.svg.reduce(
+      (acc, val) => [...acc, parseSvgPath(val)],
+      [] as PolygonGroupPoint[][],
+    );
   }
 
   $: polygonShape.simplifiedSvg = polygonShape.simplifiedPoints.map((point) =>
-    convertPointToSvg(point.filter(Boolean)),
+    convertPointToSvg(point),
   );
 
   function handlePolygonPointsDragMove(id: number, i: number) {
@@ -105,54 +91,10 @@
       };
     }
   }
-
-  function handlePolygonPointsClick(i: number, viewId: string) {
-    if (i === 0) {
-      polygonShape.simplifiedPoints = [
-        [...polygonShape.simplifiedPoints[0], polygonShape.simplifiedPoints[0][0]],
-      ];
-      const counts = runLengthEncode(
-        polygonShape.simplifiedSvg,
-        images[viewId].width,
-        images[viewId].height,
-      );
-      newShape = {
-        status: "inProgress",
-        masksImageSVG: [],
-        rle: {
-          counts,
-          size: [images[viewId].height, images[viewId].width],
-        },
-        type: "mask",
-        viewId: viewId,
-        itemId: selectedItemId,
-        imageWidth: images[viewId].width,
-        imageHeight: images[viewId].height,
-        isManual: true,
-      };
-    }
-  }
-
-  function scaleCircleRadius(id: number, i: number, scale: number) {
-    const point: Konva.Circle = stage.findOne(`#dot-${polygonDetails.id}-${i}-${id}`);
-
-    point.scaleX(scale);
-    point.scaleY(scale);
-  }
 </script>
 
 <Group config={{ id: "polygon", draggable: canEdit, visible: polygonDetails.visible }}>
   {#if canEdit}
-    {#if polygonDetails.id === "creating"}
-      <Path
-        config={{
-          data: polygonShape.simplifiedSvg[0],
-          stroke: "hsl(316deg 60% 29.41%)",
-          strokeWidth: INPUTRECT_STROKEWIDTH / zoomFactor[viewId],
-          fill: "#f9f4f773",
-        }}
-      />
-    {/if}
     <KonvaShape
       config={{
         sceneFunc: (ctx, stage) => sceneFunc(ctx, stage, polygonShape.simplifiedSvg),
@@ -162,30 +104,16 @@
         fill: polygonDetails.status === "created" ? hexToRGBA(color, 0.5) : "#f9f4f773",
       }}
     />
-    {#each polygonShape.simplifiedPoints as shape, i}
-      {#each shape as point, pi}
-        <Circle
-          on:click={() => handlePolygonPointsClick(pi, viewId)}
-          on:dragmove={() => handlePolygonPointsDragMove(point.id, i)}
-          on:dragend={handlePolygonPointsDragEnd}
-          on:mouseover={(e) => {
-            e.detail.target?.attrs?.id === `dot-${polygonDetails.id}-${i}-${point.id}` &&
-              scaleCircleRadius(point.id, i, 2);
-          }}
-          on:mouseleave={() => scaleCircleRadius(point.id, i, 1)}
-          config={{
-            x: point.x,
-            y: point.y,
-            radius: (pi === 0 ? 6 : 4) / zoomFactor[viewId],
-            fill: pi === 0 ? "#781e60" : "rgb(0,128,0)",
-            stroke: "white",
-            strokeWidth: 1 / zoomFactor[viewId],
-            id: `dot-${polygonDetails.id}-${i}-${point.id}`,
-            draggable: true,
-          }}
-        />
-      {/each}
-    {/each}
+    <PolygonPoints
+      {viewId}
+      {stage}
+      {zoomFactor}
+      polygonId={polygonDetails.id}
+      points={polygonShape.simplifiedPoints}
+      handlePolygonPointsClick={null}
+      {handlePolygonPointsDragMove}
+      {handlePolygonPointsDragEnd}
+    />
   {:else}
     <KonvaShape
       config={{

--- a/ui/components/canvas2d/src/components/PolygonPoints.svelte
+++ b/ui/components/canvas2d/src/components/PolygonPoints.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  /**
+   * @copyright CEA
+   * @author CEA
+   * @license CECILL
+   *
+   * This software is a collaborative computer program whose purpose is to
+   * generate and explore labeled data for computer vision applications.
+   * This software is governed by the CeCILL-C license under French law and
+   * abiding by the rules of distribution of free software. You can use,
+   * modify and/ or redistribute the software under the terms of the CeCILL-C
+   * license as circulated by CEA, CNRS and INRIA at the following URL
+   *
+   * http://www.cecill.info
+   */
+
+  // Imports
+
+  import Konva from "konva";
+  import { Circle } from "svelte-konva";
+
+  import type { PolygonGroupPoint } from "../lib/types/canvas2dTypes";
+
+  // Exports
+  export let viewId: string;
+  export let stage: Konva.Stage;
+  export let zoomFactor: Record<string, number>;
+  export let polygonId: string;
+  export let points: PolygonGroupPoint[][];
+
+  export let handlePolygonPointsClick: (i: number, viewId: string) => void | null;
+  export let handlePolygonPointsDragMove: (id: number, i: number) => void | null;
+  export let handlePolygonPointsDragEnd: () => void | null;
+
+  function scaleCircleRadius(id: number, i: number, scale: number) {
+    const point: Konva.Circle = stage.findOne(`#dot-${polygonId}-${i}-${id}`);
+
+    point.scaleX(scale);
+    point.scaleY(scale);
+  }
+</script>
+
+{#each points as shape, i}
+  {#each shape as point, pi}
+    <Circle
+      on:click={() => handlePolygonPointsClick?.(pi, viewId)}
+      on:dragmove={() => handlePolygonPointsDragMove?.(point.id, i)}
+      on:dragend={handlePolygonPointsDragEnd}
+      on:mouseover={(e) => {
+        e.detail.target?.attrs?.id === `dot-${polygonId}-${i}-${point.id}` &&
+          scaleCircleRadius(point.id, i, 2);
+      }}
+      on:mouseleave={() => scaleCircleRadius(point.id, i, 1)}
+      config={{
+        x: point.x,
+        y: point.y,
+        radius: (pi === 0 ? 6 : 4) / zoomFactor[viewId],
+        fill: pi === 0 ? "#781e60" : "rgb(0,128,0)",
+        stroke: "white",
+        strokeWidth: 1 / zoomFactor[viewId],
+        id: `dot-${polygonId}-${i}-${point.id}`,
+        draggable: true,
+      }}
+    />
+  {/each}
+{/each}

--- a/ui/components/core/src/lib/types/objectTypes.ts
+++ b/ui/components/core/src/lib/types/objectTypes.ts
@@ -37,6 +37,18 @@ export type noShape = {
   shouldReset?: boolean;
 };
 
+export type PolygonGroupPoint = {
+  x: number;
+  y: number;
+  id: number;
+};
+
+export type CreateMaskShape = {
+  status: "creating";
+  type: "mask";
+  points: PolygonGroupPoint[];
+};
+
 export type editMaskShape = {
   status: "editing";
   type: "mask";
@@ -51,7 +63,12 @@ export type editRectangleShape = {
   coords: number[];
 };
 
-export type Shape = inProgressShape | noShape | editMaskShape | editRectangleShape;
+export type Shape =
+  | inProgressShape
+  | noShape
+  | editMaskShape
+  | editRectangleShape
+  | CreateMaskShape;
 
 export type FeatureValues = string | number | boolean;
 


### PR DESCRIPTION
fixes : #59 and pixano/pixano-project-manager#15 (duplicates).

Also fixes a bug found during development : we could not edit a mask (polygon). 

Description : 
- refactor code to seperate polygon already created and the polygon being created. It helps keeping code simple. 
- Use `<Line />`component to create polygon and allow concave polygons

<img width="191" alt="image" src="https://github.com/pixano/pixano/assets/105201321/436b24ad-faba-4f71-9b70-8f9f31aedfa2">
