### PR TITLE
feat(front): Allow dragging rectangle when edit mode is on

### DIFF
--- a/ui/components/canvas2d/src/api/boundingBoxesApi.ts
+++ b/ui/components/canvas2d/src/api/boundingBoxesApi.ts
@@ -19,18 +19,22 @@ export const toggleIsEditingBBox = (
   currentBox: BBox,
   bboxes: BBox[],
 ) => {
-  const rectGroup = stage.findOne(`#${currentBox.id}`);
-  const rect: Konva.Rect = stage.findOne(`#rect${currentBox.id}`);
-  rectGroup.listening(value === "on");
-  const transformer: Konva.Transformer = stage.findOne("#transformer");
-  const nodes = transformer.nodes();
-  transformer.nodes(value === "on" ? [rect] : [...nodes.filter((node) => node.id() !== rect.id())]);
-  return bboxes.map((bbox) => {
-    if (bbox.id === currentBox.id) {
-      bbox.editing = value === "on";
-    }
-    return bbox;
-  });
+  const rectGroup: Konva.Group = stage.findOne(`#${currentBox.id}`);
+  const rect: Konva.Rect = rectGroup.findOne(`#rect${currentBox.id}`);
+  if (rect) {
+    rectGroup.listening(value === "on");
+    const transformer: Konva.Transformer = stage.findOne("#transformer");
+    const nodes = transformer.nodes();
+    transformer.nodes(
+      value === "on" ? [rect] : [...nodes.filter((node) => node.id() !== rect.id())],
+    );
+    return bboxes.map((bbox) => {
+      if (bbox.id === currentBox.id) {
+        bbox.editing = value === "on";
+      }
+      return bbox;
+    });
+  }
 };
 
 export const getNewRectangleDimensions = (rect: Konva.Rect, image: HTMLImageElement) => {
@@ -52,7 +56,6 @@ export const toggleBBoxIsLocked = (stage: Konva.Stage, currentBox: BBox) => {
   const lockIcon = stage.findOne(`#lockTooltip${currentBox.id}`);
   lockIcon.opacity(currentBox.locked ? 1 : 0);
   const isLocked = currentBox.locked;
-  // rect.draggable(!isLocked); // TODO100
   rect.listening(!isLocked);
   return currentBox;
 };

--- a/ui/components/canvas2d/src/api/boundingBoxesApi.ts
+++ b/ui/components/canvas2d/src/api/boundingBoxesApi.ts
@@ -183,7 +183,20 @@ export function addBBox(
     stickLabelsToRectangle(tooltip, lockTooltip, bboxRect);
   });
 
-  bboxRect.on("dragmove", function () {
+  bboxRect.on("dragmove", function (e) {
+    const imageSize = image.getSize();
+    if (e.target.x() < 0) {
+      bboxRect.x(0);
+    }
+    if (e.target.x() > imageSize.width - bboxRect.width()) {
+      bboxRect.x(imageSize.width - bboxRect.width());
+    }
+    if (e.target.y() < 0) {
+      bboxRect.y(0);
+    }
+    if (e.target.y() > imageSize.height - bboxRect.height()) {
+      bboxRect.y(imageSize.height - bboxRect.height());
+    }
     stickLabelsToRectangle(tooltip, lockTooltip, bboxRect);
   });
 

--- a/ui/components/canvas2d/src/api/boundingBoxesApi.ts
+++ b/ui/components/canvas2d/src/api/boundingBoxesApi.ts
@@ -19,8 +19,9 @@ export const toggleIsEditingBBox = (
   currentBox: BBox,
   bboxes: BBox[],
 ) => {
-  const rect = stage.findOne(`#rect${currentBox.id}`);
-  rect.draggable(value === "on");
+  const rectGroup = stage.findOne(`#${currentBox.id}`);
+  const rect: Konva.Rect = stage.findOne(`#rect${currentBox.id}`);
+  rectGroup.listening(value === "on");
   const transformer: Konva.Transformer = stage.findOne("#transformer");
   const nodes = transformer.nodes();
   transformer.nodes(value === "on" ? [rect] : [...nodes.filter((node) => node.id() !== rect.id())]);
@@ -84,13 +85,8 @@ export function addBBox(
     width: rect_width,
     height: rect_height,
     stroke: color,
-    draggable: false,
+    draggable: true,
     strokeWidth: BBOX_STROKEWIDTH / zoomFactor[viewId],
-  });
-
-  bboxRect.on("transformend", () => {
-    const box: Konva.Rect = bboxKonva.findOne(`#rect${bbox.id}`);
-    updateDimensions(box);
   });
 
   bboxKonva.add(bboxRect);
@@ -186,6 +182,11 @@ export function addBBox(
 
   bboxRect.on("dragmove", function () {
     stickLabelsToRectangle(tooltip, lockTooltip, bboxRect);
+  });
+
+  bboxRect.on("transformend dragend", () => {
+    const box: Konva.Rect = bboxKonva.findOne(`#rect${bbox.id}`);
+    updateDimensions(box);
   });
 }
 


### PR DESCRIPTION
fixes #62 

Rectangle are now draggable when edit mode is on.
New position is saved when user saves.