### PR TITLE
feat(back): Choose Pre-annotation or Model run in InferenceModel

### DIFF
--- a/.github/workflows/.pylintrc
+++ b/.github/workflows/.pylintrc
@@ -12,7 +12,7 @@ max-branches=20
 
 [DESIGN]
 max-args = 10
-max-locals = 25
+max-locals = 20
 
 [SIMILARITIES]
 min-similarity-lines=10

--- a/.github/workflows/.pylintrc
+++ b/.github/workflows/.pylintrc
@@ -12,7 +12,7 @@ max-branches=20
 
 [DESIGN]
 max-args = 10
-max-locals = 20
+max-locals = 25
 
 [SIMILARITIES]
 min-similarity-lines=10

--- a/notebooks/models/pre_annotation.ipynb
+++ b/notebooks/models/pre_annotation.ipynb
@@ -146,8 +146,8 @@
         "### Generate inferences\n",
         "\n",
         "You have two options when generating inferences.\n",
-        "- With `ann_type=\"Pre-annotation\"`, the annotations will show up in the Pixano app as pre-annotations that you can individually accept as Ground Truth or reject.\n",
-        "- With `ann_type=\"Model run\"`, the annotations will instead be displayed in \"Model run\", a separate category that you can use to visualize the model's predictions and compare them to existing Ground Truth."
+        "- With `process_type=\"pre_ann\"`, the annotations will show up in the Pixano app as pre-annotations that you can individually accept as Ground Truth or reject.\n",
+        "- With `process_type=\"model_run\"`, the annotations will instead be displayed in \"Model run\", a separate category that you can use to visualize the model's predictions and compare them to existing Ground Truth."
       ]
     },
     {
@@ -167,8 +167,7 @@
       "source": [
         "dataset = model.process_dataset(\n",
         "    dataset_dir=dataset_dir,\n",
-        "    process_type=\"ann\",\n",
-        "    ann_type=\"Pre-annotation\",\n",
+        "    process_type=\"pre_ann\",\n",
         "    views=views,\n",
         "    splits=splits,\n",
         "    batch_size=1,\n",

--- a/notebooks/models/pre_annotation.ipynb
+++ b/notebooks/models/pre_annotation.ipynb
@@ -34,7 +34,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -58,7 +58,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -108,7 +108,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -127,7 +127,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -143,7 +143,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Generate inferences"
+        "### Generate inferences\n",
+        "\n",
+        "You have two options when generating inferences.\n",
+        "- With `ann_type=\"Pre-annotation\"`, the annotations will show up in the Pixano app as pre-annotations that you can individually accept as Ground Truth or reject.\n",
+        "- With `ann_type=\"Model run\"`, the annotations will instead be displayed in \"Model run\", a separate category that you can use to visualize the model's predictions and compare them to existing Ground Truth."
       ]
     },
     {
@@ -157,13 +161,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
         "dataset = model.process_dataset(\n",
         "    dataset_dir=dataset_dir,\n",
-        "    process_type=\"obj\",\n",
+        "    process_type=\"ann\",\n",
+        "    ann_type=\"Pre-annotation\",\n",
         "    views=views,\n",
         "    splits=splits,\n",
         "    batch_size=1,\n",
@@ -218,7 +223,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.13"
+      "version": "3.10.11"
     },
     "orig_nbformat": 4,
     "vscode": {

--- a/pixano/models/inference_model.py
+++ b/pixano/models/inference_model.py
@@ -179,9 +179,9 @@ class InferenceModel(ABC):
     def process_dataset(
         self,
         dataset_dir: Path,
-        process_type: str,
-        ann_type: str,
         views: list[str],
+        process_type: str,
+        ann_type: str = None,
         splits: list[str] = None,
         batch_size: int = 1,
         threshold: float = 0.0,
@@ -190,6 +190,7 @@ class InferenceModel(ABC):
 
         Args:
             dataset_dir (Path): Dataset directory
+            views (list[str]): Dataset views
             process_type (str): Process type
                                 - 'ann' for annotations
                                 - 'segment_emb' for segmentation embeddings
@@ -197,7 +198,6 @@ class InferenceModel(ABC):
             ann_type (str): Annotation type
                                 - 'Pre-annotation' for pre-annotations to accept or reject as Ground Truth
                                 - 'Model run' for annotations to compare to Ground Truth
-            views (list[str]): Dataset views
             splits (list[str], optional): Dataset splits, all if None. Defaults to None.
             batch_size (int, optional): Rows per process batch. Defaults to 1.
             threshold (float, optional): Confidence threshold for predictions. Defaults to 0.0.
@@ -213,14 +213,12 @@ class InferenceModel(ABC):
                 "'segment_emb' or 'search_emb' for segmentation or semantic search embeddings)"
             )
 
-        if ann_type not in ["Pre-annotation", "Model run"]:
-            if process_type == "ann":
-                raise ValueError(
-                    "Please choose a valid annotation type"
-                    "('Pre-annotation' for pre-annotations to accept or reject as Ground Truth,"
-                    "'Model run' for annotations to compare to Ground Truth)"
-                )
-            ann_type = None
+        if process_type == "ann" and ann_type not in ["Pre-annotation", "Model run"]:
+            raise ValueError(
+                "Please choose a valid annotation type"
+                "('Pre-annotation' for pre-annotations to accept or reject as Ground Truth,"
+                "'Model run' for annotations to compare to Ground Truth)"
+            )
 
         if not views:
             raise ValueError("Please select which views you want to process on.")

--- a/ui/.prettierrc.cjs
+++ b/ui/.prettierrc.cjs
@@ -4,4 +4,12 @@ module.exports = {
   trailingComma: "all",
   printWidth: 100,
   plugins: ["prettier-plugin-svelte"],
+  overrides: [
+    {
+      files: ["tsconfig.json", "jsconfig.json"],
+      options: {
+        parser: "jsonc",
+      },
+    },
+  ],
 };

--- a/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/imageWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -133,7 +133,7 @@
           <PrimaryButton on:click={handleAcceptItem} isSelected disabled={!isFormValid}
             ><Check />Accept</PrimaryButton
           >
-          <PrimaryButton on:click={handleRejectItem}>Ignore</PrimaryButton>
+          <PrimaryButton on:click={handleRejectItem}>Reject</PrimaryButton>
         </div>
       </div>
     {/if}


### PR DESCRIPTION
## Description

Fixes #90 

## Changes

### Added

- Add option in pre-annotation notebook to save annotations as "Pre-annotation" or "Model run"
  - The `process_type` argument in `InferenceModel.process_dataset()` is now split from `"obj"` to either `"pre_ann"` or `"model_run"` to let the user choose if they want the generated annotations to appear as "Pre-annotation" or "Model run" in the app.
  - The pre-annotation notebook is also updated to reflect this new choice.

### Fixed

- Update "Ignore" pre-annotation button to "Reject" in the app
  - As discussed during the latest sprint demo (Fri 02/02/2024), "Reject" makes more sense for the end users, and better reflects the fact that the annotation will not be shown again.
  - This update also improves consistency with new documentation in inference_model.py and pre_annotation.ipynb describing the choice between "Pre-annotation" and "Model run".
- Update Prettier config for 3.2.5
  - Prettier 3.2.5 makes a change to the parser used for tsconfig.json files ([more info in their changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#use-json-parser-for-tsconfigjson-by-default-16012-by-sosukesuzuki)). Update the Prettier config to keep formatting those files with the jsonc parser.