### PR TITLE
fix(api): Create bounding box from mask automatically

### DIFF
--- a/pixano/data/item/item_object.py
+++ b/pixano/data/item/item_object.py
@@ -96,12 +96,8 @@ class ItemBBox(BaseModel):
             else None
         )
 
-    def to_pyarrow(self, mask: ItemURLE = None) -> BBox:
+    def to_pyarrow(self) -> BBox:
         """Return ItemBbox as BBox
-
-        Args:
-            mask (ItemURLE, optional): Mask to create BBox from in ItemBBox is empty. Defaults to None.
-
 
         Returns:
             BBox: Bounding box
@@ -110,7 +106,7 @@ class ItemBBox(BaseModel):
         return (
             BBox.from_dict(self.model_dump())
             if self.coords != [0.0, 0.0, 0.0, 0.0]
-            else BBox.from_rle(mask.to_pyarrow()) if mask else None
+            else None
         )
 
 
@@ -202,7 +198,11 @@ class ItemObject(BaseModel):
         pyarrow_object["review_state"] = self.review_state
 
         pyarrow_mask = self.mask.to_pyarrow() if self.mask else None
-        pyarrow_bbox = self.bbox.to_pyarrow(self.mask) if self.bbox else None
+        pyarrow_bbox = (
+            self.bbox.to_pyarrow()
+            if self.bbox
+            else BBox.from_rle(pyarrow_mask) if pyarrow_mask else None
+        )
 
         pyarrow_object["mask"] = pyarrow_mask.to_dict() if pyarrow_mask else None
         pyarrow_object["bbox"] = pyarrow_bbox.to_dict() if pyarrow_bbox else None

--- a/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
+++ b/ui/components/imageWorkspace/src/components/ActionsTabs/ObjectTabFlatItem.svelte
@@ -119,7 +119,7 @@
       style="border-color:{color}"
     >
       <div class="flex flex-col gap-2">
-        {#if itemObject.bbox && !itemObject.bbox.coords.every((coord) => coord === 0)}
+        {#if itemObject.bbox}
           <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
             <p class="font-medium first-letter:uppercase">Bounding box</p>
             <Checkbox

--- a/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/imageWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -67,12 +67,6 @@
       if (shape.type === "mask") {
         newObject = {
           ...baseObject,
-          bbox: {
-            coords: [0, 0, 0, 0],
-            format: "xywh",
-            is_normalized: true,
-            confidence: 1,
-          },
           mask: {
             counts: shape.rle.counts,
             size: shape.rle.size,


### PR DESCRIPTION
## Description

Part 1/2 of issue #89 

## Changes

### Fixed

- Fix creating bounding box from mask automatically
  - Create bounding box from mask when saving an object without needing to create an empty box in the frontend first. This fixes the issue where the empty box would be displayed on the image while it shouldn't.