### PR TITLE
fix(front): Allow zero to be shown in model run number of object

### DIFF
--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectsInspector.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectsInspector.svelte
@@ -64,7 +64,7 @@
         <ObjectsModelSection
           sectionTitle="Model run"
           modelName={selectedModel}
-          numberOfItem={allItemsSortedByModel[selectedModel].length}
+          numberOfItem={allItemsSortedByModel[selectedModel]?.length || 0}
         >
           <Combobox
             slot="modelSelection"


### PR DESCRIPTION
## issue fixed
#101 
## bug description
I could not display the number of object included in a model since it was deleted