### PR TITLE
fix(front): Fix buttons in Toolbar

### DIFF
--- a/ui/components/imageWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/imageWorkspace/src/components/Toolbar.svelte
@@ -43,14 +43,10 @@
 
   export let selectedTool: SelectionTool | null;
   let previousSelectedTool: SelectionTool | null = null;
-  let smartTools = [addSmartPointTool, removeSmartPointTool, smartRectangleTool];
   let showSmartTools: boolean = false;
 
   const selectTool = (tool: SelectionTool | null) => {
     if (tool !== selectedTool) selectedTool = tool;
-    if (tool && !smartTools.includes(tool) && showSmartTools) {
-      showSmartTools = !showSmartTools;
-    }
   };
 
   const handleSmartToolClick = () => {

--- a/ui/components/imageWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/imageWorkspace/src/components/Toolbar.svelte
@@ -32,7 +32,7 @@
     rectangleTool,
     addSmartPointTool,
     removeSmartPointTool,
-    polygoneTool,
+    polygonTool,
   } from "../lib/settings/selectionTools";
   import {
     interactiveSegmenterModel,
@@ -79,21 +79,22 @@
 <div class="h-full shadow-md bg-popover py-4 px-2 w-16 border-l border-slate-200 z-10">
   <div class="flex items-center flex-col gap-4">
     <IconButton
-      tooltipContent="Move image around"
+      tooltipContent={panTool.name}
       on:click={() => selectTool(panTool)}
       selected={selectedTool?.type === "PAN"}
     >
       <MousePointer />
     </IconButton>
     <IconButton
+      tooltipContent={rectangleTool.name}
       on:click={() => selectTool(rectangleTool)}
       selected={selectedTool?.type === "RECTANGLE" && !selectedTool.isSmart}
     >
       <Square />
     </IconButton>
     <IconButton
-      tooltipContent="Create a polygon"
-      on:click={() => selectTool(polygoneTool)}
+      tooltipContent={polygonTool.name}
+      on:click={() => selectTool(polygonTool)}
       selected={selectedTool?.type === "POLYGON"}
     >
       <Share2 />
@@ -135,7 +136,7 @@
         <MagicIcon />
       </IconButton>
       <IconButton
-        tooltipContent="Smart rectangle"
+        tooltipContent={smartRectangleTool.name}
         on:click={() => selectTool(smartRectangleTool)}
         selected={selectedTool?.type === "RECTANGLE" && selectedTool.isSmart}
       >

--- a/ui/components/imageWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/imageWorkspace/src/components/Toolbar.svelte
@@ -43,15 +43,20 @@
 
   export let selectedTool: SelectionTool | null;
   let previousSelectedTool: SelectionTool | null = null;
+  let smartTools = [addSmartPointTool, removeSmartPointTool, smartRectangleTool];
   let showSmartTools: boolean = false;
 
   const selectTool = (tool: SelectionTool | null) => {
     if (tool !== selectedTool) selectedTool = tool;
+    if (tool && !smartTools.includes(tool) && showSmartTools) {
+      showSmartTools = !showSmartTools;
+    }
   };
 
   const handleSmartToolClick = () => {
     if (!showSmartTools) {
       selectTool(addSmartPointTool);
+      modelsStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
     } else selectTool(null);
     showSmartTools = !showSmartTools;
   };
@@ -109,15 +114,10 @@
       "bg-slate-200 rounded-sm": showSmartTools,
     })}
   >
-    <button
-      on:click={handleSmartToolClick}
-      on:dblclick={() =>
-        modelsStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }))}
-      class="relative hover:bg-primary-light inline-flex items-center justify-center rounded-md text-sm font-medium whitespace-nowrap ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-10 w-10 bg-transparent text-slate-800"
-    >
+    <IconButton tooltipContent="Use a smart segmentation model" on:click={handleSmartToolClick}>
       <BrushIcon />
       <MagicIcon />
-    </button>
+    </IconButton>
     {#if showSmartTools}
       <IconButton
         tooltipContent={addSmartPointTool.name}

--- a/ui/components/imageWorkspace/src/lib/settings/selectionTools.ts
+++ b/ui/components/imageWorkspace/src/lib/settings/selectionTools.ts
@@ -6,16 +6,16 @@ export const panTool: SelectionTool = {
   cursor: "move",
 };
 
-export const smartRectangleTool: SelectionTool = {
-  name: "Smart rectangle selection",
+export const rectangleTool: SelectionTool = {
+  name: "Create a bounding box",
   type: "RECTANGLE",
   cursor: "crosshair",
-  isSmart: true,
+  isSmart: false,
 };
 
-export const rectangleTool: SelectionTool = {
-  name: "Rectangle selection",
-  type: "RECTANGLE",
+export const polygonTool: SelectionTool = {
+  name: "Create a polygon",
+  type: "POLYGON",
   cursor: "crosshair",
   isSmart: false,
 };
@@ -36,9 +36,9 @@ export const addSmartPointTool: SelectionTool = {
   isSmart: true,
 };
 
-export const polygoneTool: SelectionTool = {
-  name: "Polygone selection",
-  type: "POLYGON",
+export const smartRectangleTool: SelectionTool = {
+  name: "Rectangle selection",
+  type: "RECTANGLE",
   cursor: "crosshair",
-  isSmart: false,
+  isSmart: true,
 };


### PR DESCRIPTION
## Issue

Fixes #114

## Description

- Add missing tooltip for the bounding box and smart tool list buttons
- Fix existing tooltips for the other tools
- Use the `SelectionTool.name` as `tooltipContent` for all buttons
- Fix a typo: `polygoneTool` > `polygonTool`
- Redefine the smart tool list button with IconButton
  - IconButton allows the smart tool list button to use `tooltipContent` like the other buttons
  - `on:dblclick` is not implemented in IconButton. Show the model selection modal every time the smart tool list is opened instead. Closing and re-opening the smart tool list works similarly to double clicking.