### PR TITLE
fix(front): Fix buttons in ImageInspector

### DIFF
--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -129,6 +129,7 @@
       <button
         class="rounded-full border w-3 h-3 mr-2 flex-[0_0_0.75rem]"
         style="background:{color}"
+        title="Highlight object"
         on:click={onColoredDotClick}
       />
       <span class="truncate w-max flex-auto">{itemObject.id}</span>

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -118,7 +118,7 @@
     <div class="flex items-center flex-auto max-w-[50%]">
       <IconButton
         on:click={() => handleIconClick("hidden", isVisible)}
-        tooltipContent={isVisible ? "Hide" : "Show"}
+        tooltipContent={isVisible ? "Hide object" : "Show object"}
       >
         {#if isVisible}
           <Eye class="h-4" />

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -146,12 +146,12 @@
           ><Trash2 class="h-4" /></IconButton
         >
       {/if}
-      <IconButton on:click={() => (open = !open)}
-        ><ChevronRight
-          class={cn("transition", { "rotate-90": open })}
-          strokeWidth={1}
-        /></IconButton
+      <IconButton
+        on:click={() => (open = !open)}
+        tooltipContent={open ? "Hide features" : "Show features"}
       >
+        <ChevronRight class={cn("transition", { "rotate-90": open })} strokeWidth={1} />
+      </IconButton>
     </div>
   </div>
   {#if open}

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -138,7 +138,9 @@
         <IconButton
           tooltipContent="Edit object"
           selected={isEditing}
-          on:click={() => handleIconClick("editing", !isEditing)}><Pencil class="h-4" /></IconButton
+          on:click={() => {
+            handleIconClick("editing", !isEditing), (open = true);
+          }}><Pencil class="h-4" /></IconButton
         >
         <IconButton tooltipContent="Delete object" on:click={deleteObject}
           ><Trash2 class="h-4" /></IconButton

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -116,7 +116,10 @@
     style="border-color:{itemObject.highlighted === 'self' ? color : 'transparent'}"
   >
     <div class="flex items-center flex-auto max-w-[50%]">
-      <IconButton on:click={() => handleIconClick("hidden", isVisible)}>
+      <IconButton
+        on:click={() => handleIconClick("hidden", isVisible)}
+        tooltipContent={isVisible ? "Hide" : "Show"}
+      >
         {#if isVisible}
           <Eye class="h-4" />
         {:else}

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -133,11 +133,11 @@
     <div class="flex items-center">
       {#if showIcons || isEditing}
         <IconButton
-          tooltipContent="edit object"
+          tooltipContent="Edit object"
           selected={isEditing}
           on:click={() => handleIconClick("editing", !isEditing)}><Pencil class="h-4" /></IconButton
         >
-        <IconButton tooltipContent="delete object" on:click={deleteObject}
+        <IconButton tooltipContent="Delete object" on:click={deleteObject}
           ><Trash2 class="h-4" /></IconButton
         >
       {/if}

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectCard.svelte
@@ -170,6 +170,7 @@
                   <Checkbox
                     handleClick={() => handleIconClick("hidden", boxIsVisible, ["bbox"])}
                     bind:checked={boxIsVisible}
+                    title={boxIsVisible ? "Hide" : "Show"}
                     class="mx-1"
                   />
                 </div>
@@ -180,6 +181,7 @@
                   <Checkbox
                     handleClick={() => handleIconClick("hidden", maskIsVisible, ["mask"])}
                     bind:checked={maskIsVisible}
+                    title={maskIsVisible ? "Hide" : "Show"}
                     class="mx-1"
                   />
                 </div>

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectsModelSection.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectsModelSection.svelte
@@ -26,7 +26,8 @@
   export let numberOfItem: number;
 
   let visibilityStatus: "hidden" | "shown" | "mixed" = "shown";
-  $: tooltipContent = visibilityStatus === "hidden" ? "Show all" : "Hide all";
+  $: tooltipContent =
+    visibilityStatus === "hidden" ? `Show ${modelName} objects` : `Hide ${modelName} objects`;
 
   itemObjects.subscribe((items) => {
     if (!items.length) return;

--- a/ui/components/imageWorkspace/src/components/ImageInspector/ObjectsModelSection.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/ObjectsModelSection.svelte
@@ -26,7 +26,7 @@
   export let numberOfItem: number;
 
   let visibilityStatus: "hidden" | "shown" | "mixed" = "shown";
-  $: tooltipContent = visibilityStatus === "hidden" ? "show all" : "hide all";
+  $: tooltipContent = visibilityStatus === "hidden" ? "Show all" : "Hide all";
 
   itemObjects.subscribe((items) => {
     if (!items.length) return;

--- a/ui/components/imageWorkspace/src/components/ImageInspector/SceneInspector.svelte
+++ b/ui/components/imageWorkspace/src/components/ImageInspector/SceneInspector.svelte
@@ -74,8 +74,12 @@
 <div class="border-b-2 border-b-slate-500 p-4 pb-8 text-slate-800">
   <h3 class="uppercase font-medium h-10">
     <span>Features</span>
-    <IconButton selected={isEditing} on:click={handleEditIconClick}
-      ><Pencil class="h-4" />
+    <IconButton
+      selected={isEditing}
+      on:click={handleEditIconClick}
+      tooltipContent="Edit scene features"
+    >
+      <Pencil class="h-4" />
     </IconButton>
   </h3>
   <div class="mx-4">


### PR DESCRIPTION
## Issue

Fixes #116 

## Description

- Open object card when clicking on editing button (since as of #87, object cards are closed by default)
- Add missing button tooltips (scene features, object visibility, object highlighting, object card toggle, bounding box and mask toggles)
- Fix existing button tooltips consistency (first letter should be uppercase)