### PR TITLE
fix(front): Fix buttons in DatasetHeader

### DIFF
--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -105,10 +105,13 @@
         <button on:click={() => navigateTo("/")} class="h-10 w-10">
           <img src={pixanoLogo} alt="Logo Pixano" class="w-8 h-8 mx-2" />
         </button>
-        <IconButton on:click={() => navigateTo("/")}>
+        <IconButton
+          on:click={() => navigateTo(currentItemId ? `/${datasetName}/dataset` : "/")}
+          tooltipContent={currentItemId ? "Back to dataset" : "Back to home"}
+        >
           <ArrowLeftCircleIcon />
         </IconButton>
-        <button on:click={() => navigateTo(`/${datasetName}/dataset`)}> {datasetName} </button>
+        {datasetName}
       </div>
     </div>
     {#if currentItemId}

--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -116,11 +116,11 @@
         <Loader2Icon class="animate-spin" />
       {:else}
         <div class="flex items-center gap-4">
-          <IconButton on:click={() => goToNeighborItem("previous")}>
+          <IconButton on:click={() => goToNeighborItem("previous")} tooltipContent="Previous item">
             <ArrowLeft />
           </IconButton>
           {currentItemId}
-          <IconButton on:click={() => goToNeighborItem("next")}>
+          <IconButton on:click={() => goToNeighborItem("next")} tooltipContent="Next item">
             <ArrowRight />
           </IconButton>
         </div>


### PR DESCRIPTION
## Issue

Fixes #119

## Description

- Add missing tooltips for back button and dataset navigation buttons
- Make back button go to the parent page (home page if on dataset page, dataset page if on item page), instead of behaving like the Pixano logo button