### PR TITLE
fix(front): Only allow object selection when PAN tool is activated

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1051,6 +1051,7 @@
                   {stage}
                   viewId={view.id}
                   bind:newShape
+                  {selectedTool}
                 />
               {/key}
             {/if}
@@ -1074,6 +1075,7 @@
                   {zoomFactor}
                   {mask}
                   color={colorScale(mask.id)}
+                  {selectedTool}
                 />
               {/if}
             {/key}

--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -19,7 +19,7 @@
   import Konva from "konva";
   import { Group, Shape as KonvaShape } from "svelte-konva";
 
-  import type { Mask, Shape } from "@pixano/core";
+  import type { Mask, SelectionTool, Shape } from "@pixano/core";
   import type { PolygonGroupPoint, PolygonShape } from "../lib/types/canvas2dTypes";
   import {
     sceneFunc,
@@ -38,6 +38,7 @@
   export let mask: Mask;
   export let color: string;
   export let zoomFactor: Record<string, number>;
+  export let selectedTool: SelectionTool;
 
   let canEdit = false;
   let polygonShape: PolygonShape = {
@@ -130,6 +131,7 @@
     draggable: canEdit,
     visible: mask.visible,
     opacity: mask.opacity,
+    listening: selectedTool.type === "PAN",
   }}
 >
   {#if canEdit}

--- a/ui/components/canvas2d/src/components/PolygonPoints.svelte
+++ b/ui/components/canvas2d/src/components/PolygonPoints.svelte
@@ -45,7 +45,7 @@
     <Circle
       on:click={() => handlePolygonPointsClick?.(pi, viewId)}
       on:dragmove={() => handlePolygonPointsDragMove?.(point.id, i)}
-      on:dragend={() => handlePolygonPointsDragEnd()}
+      on:dragend={() => handlePolygonPointsDragEnd?.()}
       on:mouseover={(e) => {
         e.detail.target?.attrs?.id === `dot-${polygonId}-${i}-${point.id}` &&
           scaleCircleRadius(point.id, i, 2);

--- a/ui/components/canvas2d/src/components/Rectangle.svelte
+++ b/ui/components/canvas2d/src/components/Rectangle.svelte
@@ -17,7 +17,7 @@
   // Imports
   import Konva from "konva";
   import { Rect, Label, Tag, Text, Group } from "svelte-konva";
-  import type { BBox, Shape } from "@pixano/core";
+  import type { BBox, SelectionTool, Shape } from "@pixano/core";
 
   import { BBOX_STROKEWIDTH } from "../lib/constants";
   import {
@@ -33,6 +33,7 @@
   export let zoomFactor: number;
   export let viewId: string;
   export let newShape: Shape;
+  export let selectedTool: SelectionTool;
 
   let currentRect: Konva.Rect = stage.findOne(`#rect${bbox.id}`);
 
@@ -94,7 +95,11 @@
   };
 </script>
 
-<Group on:dblclick={onDoubleClick} on:click={onClick}>
+<Group
+  on:dblclick={onDoubleClick}
+  on:click={onClick}
+  config={{ listening: selectedTool.type === "PAN" }}
+>
   <Rect
     config={{
       id: `rect${bbox.id}`,


### PR DESCRIPTION
## issue
fixes #112 

## description
Users can now only select object by double clicking them when the PAN tool is activated to avoid conflict with shape creation. 