### PR TITLE
fix(front): Autofocus only the first input in Feature Form

### DIFF
--- a/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
@@ -94,18 +94,31 @@
           <span>*</span>
         {/if}
       </span>
-      <Input
-        type={feature.type === "str" ? "text" : "number"}
-        step={feature.type === "int" ? "1" : "any"}
-        autofocus={i === 0 ? true : false}
-        value={initialValues[feature.name]?.value || ""}
-        on:keyup={(e) => e.stopPropagation()}
-        on:input={(e) =>
-          handleInputChange(
-            feature.type === "str" ? e.currentTarget.value : Number(e.currentTarget.value),
-            feature.name,
-          )}
-      />
+      {#if i === 0}
+        <Input
+          type={feature.type === "str" ? "text" : "number"}
+          step={feature.type === "int" ? "1" : "any"}
+          value={initialValues[feature.name]?.value || ""}
+          on:keyup={(e) => e.stopPropagation()}
+          on:input={(e) =>
+            handleInputChange(
+              feature.type === "str" ? e.currentTarget.value : Number(e.currentTarget.value),
+              feature.name,
+            )}
+        />
+      {:else}
+        <Input
+          type={feature.type === "str" ? "text" : "number"}
+          step={feature.type === "int" ? "1" : "any"}
+          value={initialValues[feature.name]?.value || ""}
+          on:keyup={(e) => e.stopPropagation()}
+          on:input={(e) =>
+            handleInputChange(
+              feature.type === "str" ? e.currentTarget.value : Number(e.currentTarget.value),
+              feature.name,
+            )}
+        />
+      {/if}
     </div>
   {/if}
 {/each}

--- a/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
+++ b/ui/components/imageWorkspace/src/components/Features/FeatureFormInputs.svelte
@@ -99,6 +99,7 @@
           type={feature.type === "str" ? "text" : "number"}
           step={feature.type === "int" ? "1" : "any"}
           value={initialValues[feature.name]?.value || ""}
+          autofocus
           on:keyup={(e) => e.stopPropagation()}
           on:input={(e) =>
             handleInputChange(


### PR DESCRIPTION
## Issues
Fixes #113 

## Description
For some reason that I can't explain, `autofocus={false}` was not working, leading to warning in browser console and the last input being indeed focused. 
The fix is not DRY but the only way I could find to make it work. 