### PR TITLE
fix(front): Fix issues with loading segmentation models

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1087,6 +1087,7 @@
 {#if viewEmbeddingModal}
   <WarningModal
     message="No embeddings found for view '{viewWithoutEmbeddings}'."
+    details="The embeddings may not have finished loading yet. Please try again."
     on:confirm={() => (viewEmbeddingModal = false)}
   />
 {/if}

--- a/ui/components/imageWorkspace/src/components/LoadModelModal.svelte
+++ b/ui/components/imageWorkspace/src/components/LoadModelModal.svelte
@@ -108,13 +108,14 @@
   <WarningModal
     message="It looks like there is no model for interactive segmentation in your dataset library."
     details="Please refer to our interactive annotation notebook for information on how to export your model to ONNX."
-    on:confirm={() => (currentModalOpen = "none")}
+    on:confirm={() => modelsStore.update((store) => ({ ...store, currentModalOpen: "none" }))}
   />
 {/if}
 {#if currentModalOpen === "noEmbeddings"}
   <WarningModal
     message="No embeddings found for model {selectedModelName}."
     details="Please refer to our interactive annotation notebook for information on how to compute embeddings on your dataset."
-    on:confirm={() => (currentModalOpen = "selectModel")}
+    on:confirm={() =>
+      modelsStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }))}
   />
 {/if}

--- a/ui/components/imageWorkspace/src/lib/api/modelsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/modelsApi.ts
@@ -27,5 +27,8 @@ export async function loadEmbeddings(
       }
     }
   }
+  if (Object.keys(embeddings).length === 0) {
+    throw new Error("No embeddings found");
+  }
   return embeddings;
 }


### PR DESCRIPTION
## Issue

Fixes #123 

## Description

- Throw error in `modelsApi` if empty embeddings received to trigger the "No embeddings found for model" modal
- Fix updating the `currentModalOpen` variable that would trigger the "No embeddings found for model" modal even after switching model
- Add details to the "No embeddings found for view" modal that can trigger if clicking too quickly after selecting a model, because the embeddings have not yet finished loading