### PR TITLE
fix(front): Do not mutate object if id does not match

### DIFF
--- a/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/imageWorkspace/src/lib/api/objectsApi.ts
@@ -127,6 +127,7 @@ export const updateExistingObject = (old: ItemObject[], newShape: Shape) => {
     if (newShape.highlighted === "self") {
       object.highlighted = newShape.shapeId === object.id ? "self" : "none";
     }
+    if (newShape.shapeId !== object.id) return object;
     if (newShape.type === "mask" && object.mask) {
       return {
         ...object,


### PR DESCRIPTION
## Issue
fixes #128

## description
small changes, big impact here. 
editing a polygon was mutating the wrong object because I was not checking for the ID to mutate. 