### PR TITLE
fix(front): Do not add random transform shape after deleting an object

### DIFF
--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -63,7 +63,6 @@
 
   $: {
     if (currentItemId !== selectedItem?.id) {
-      console.log("Loading new item");
       isLoadingNewItemStore.set(true);
       handleSelectItem(selectedDataset, currentItemId);
     }

--- a/ui/components/canvas2d/src/api/rectangleApi.ts
+++ b/ui/components/canvas2d/src/api/rectangleApi.ts
@@ -8,18 +8,14 @@ export const toggleIsEditingBBox = (
   bboxId: BBox["id"],
 ) => {
   const rect: Konva.Rect = stage.findOne(`#rect${bboxId}`);
+  const transformer: Konva.Transformer = stage.findOne("#transformer");
   if (rect) {
-    const transformer: Konva.Transformer = stage.findOne("#transformer");
     const nodes = transformer?.nodes();
     transformer?.nodes(
       value === "on" ? [rect] : [...nodes.filter((node) => node.id() !== rect.id())],
     );
-    //   return bboxes.map((bbox) => {
-    //     if (bbox.id === currentBox.id) {
-    //       bbox.editing = value === "on";
-    //     }
-    //     return bbox;
-    //   });
+  } else {
+    transformer?.nodes([]);
   }
 };
 

--- a/ui/components/canvas2d/src/components/Rectangle.svelte
+++ b/ui/components/canvas2d/src/components/Rectangle.svelte
@@ -15,6 +15,7 @@
    */
 
   // Imports
+  import { onDestroy } from "svelte";
   import Konva from "konva";
   import { Rect, Label, Tag, Text, Group } from "svelte-konva";
   import type { BBox, SelectionTool, Shape } from "@pixano/core";
@@ -103,6 +104,13 @@
       };
     }
   };
+
+  onDestroy(() => {
+    const transformer: Konva.Transformer = stage.findOne("#transformer");
+    if (transformer) {
+      transformer.nodes([]);
+    }
+  });
 </script>
 
 <Group


### PR DESCRIPTION
## Issue

Fixes #147 

## Description

The `transformer` is the Konva object that allow modifying shape.
When a rectangle is destroyed (removed from the DOM), it is always removed from the `Transformer`
