### PR TITLE
fix(front): Improve autocomplete UX and placement

### DIFF
--- a/ui/components/core/src/components/ui/input/input.svelte
+++ b/ui/components/core/src/components/ui/input/input.svelte
@@ -19,7 +19,6 @@
   )}
 >
   <slot />
-  <!-- svelte-ignore a11y-autofocus -->
   <input
     class={cn(
       "w-full p-2 placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
@@ -39,6 +38,6 @@
     on:paste
     on:input
     {...$$restProps}
-    {autofocus}
+    {...autofocus ? { autofocus: true } : {}}
   />
 </div>

--- a/ui/components/core/src/index.ts
+++ b/ui/components/core/src/index.ts
@@ -39,6 +39,7 @@ export { Input } from "./components/ui/input";
 export { Slider } from "./components/ui/slider";
 export { Switch } from "./components/ui/switch";
 export * as Command from "./components/ui/command";
+export * as Popover from "./components/ui/popover";
 
 // lib
 // utils

--- a/ui/components/datasetItemWorkspace/src/components/Features/AutoCompleteFeatureInput.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/AutoCompleteFeatureInput.svelte
@@ -63,12 +63,15 @@
       type="button"
       use:builder.action
       {...builder}
-      class={cn("flex h-11 rounded-md bg-transparent py-3 text-sm", className)}
+      class={cn(
+        "py-0 rounded-md bg-transparent flex h-10 items-center border border-input bg-white px-3 text-sm ring-offset-background w-full",
+        className,
+      )}
     >
       {selectedValue}
     </button>
   </Popover.Trigger>
-  <Popover.Content class="w-[200px] p-0 " tabindex={-1}>
+  <Popover.Content class="p-0 " tabindex={-1}>
     <Command.Root>
       <Command.Input
         {placeholder}

--- a/ui/components/datasetItemWorkspace/src/components/Features/AutoCompleteFeatureInput.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/AutoCompleteFeatureInput.svelte
@@ -20,9 +20,10 @@
 
   export let onTextInputChange: (value: string) => void;
   export let featureList: { value: string; label: string; isTemp?: boolean }[] = [];
-  export let placeholder: string = "Select an item";
+  export let placeholder: string = "Select a feature";
   export let value: string = "";
   export let autofocus: boolean = false;
+  export let className = "";
 
   let open = autofocus;
   let selectedValue = value || placeholder;
@@ -58,14 +59,19 @@
 
 <Popover.Root bind:open let:ids>
   <Popover.Trigger asChild let:builder>
-    <button placeholder="Search feature" use:builder.action {...builder}>
+    <button
+      type="button"
+      use:builder.action
+      {...builder}
+      class={cn("flex h-11 rounded-md bg-transparent py-3 text-sm", className)}
+    >
       {selectedValue}
     </button>
   </Popover.Trigger>
-  <Popover.Content class="w-[200px] p-0" tabindex={-1}>
+  <Popover.Content class="w-[200px] p-0 " tabindex={-1}>
     <Command.Root>
       <Command.Input
-        placeholder="Search framework..."
+        {placeholder}
         on:change={() => console.log("changed")}
         bind:value={inputValue}
         on:input={onSearchInput}

--- a/ui/components/datasetItemWorkspace/src/components/Features/AutoCompleteFeatureInput.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/AutoCompleteFeatureInput.svelte
@@ -1,61 +1,86 @@
 <script lang="ts">
-  import { Check } from "lucide-svelte";
-  import { Command, cn } from "@pixano/core/src";
+  // import { Check } from "lucide-svelte";
+  // import { Command, cn, Popover } from "@pixano/core/src";
 
-  export let featureList: { value: string; label: string }[] = [];
+  // export let featureList: { value: string; label: string }[] = [];
+
+  // export let isFixed: boolean = false;
+
+  // let open = false;
+
+  // const onSelect = (currentValue: string) => {
+  //   value = currentValue;
+  //   onTextInputChange(value);
+  //   open = false;
+  // };
+
+  import { Check } from "lucide-svelte";
+  import { tick } from "svelte";
+  import { Command, cn, Popover } from "@pixano/core/src";
+
+  export let onTextInputChange: (value: string) => void;
+  export let featureList: { value: string; label: string; isTemp?: boolean }[] = [];
   export let placeholder: string = "Select an item";
   export let value: string = "";
-  export let onTextInputChange: (value: string) => void;
   export let autofocus: boolean = false;
-  export let isFixed: boolean = false;
 
-  let open = false;
-  let isHovering = false;
+  let open = autofocus;
+  let selectedValue = value || placeholder;
+  let inputValue: string = value;
 
-  const onSelect = (currentValue: string) => {
+  $: selectedValue = featureList.find((f) => f.value === value)?.label ?? placeholder;
+
+  // We want to refocus the trigger button when the user selects
+  // an item from the list so users can continue navigating the
+  // rest of the form with the keyboard.
+  function closeAndFocusTrigger(triggerId: string) {
+    open = false;
+    tick()
+      .then(() => {
+        document.getElementById(triggerId)?.focus();
+      })
+      .catch((err) => console.error(err));
+  }
+
+  const onSelect = (currentValue: string, trigger: string) => {
     value = currentValue;
     onTextInputChange(value);
-    open = false;
+    closeAndFocusTrigger(trigger);
   };
 
-  const onInputBlur = () => {
-    onTextInputChange(value);
-    if (!isHovering) {
-      open = false;
+  const onSearchInput = () => {
+    const existingValue = featureList.find((f) => f.value === inputValue)?.label;
+    if (!existingValue && inputValue) {
+      featureList = [...featureList, { value: inputValue, label: inputValue }];
     }
   };
 </script>
 
-<Command.Root class="overflow-visible">
-  <Command.Input
-    {placeholder}
-    {autofocus}
-    bind:value
-    on:blur={onInputBlur}
-    on:focus={() => (open = true)}
-    class="h-9"
-  />
-  {#if open}
-    <div
-      class={cn({ "fixed mt-8 z-10": isFixed })}
-      on:mouseenter={() => (isHovering = true)}
-      on:mouseleave={() => (isHovering = false)}
-      role="listbox"
-      tabindex="0"
-    >
-      <Command.Group
-        on:click={() => console.log("click")}
-        class={cn("z-10 bg-white top-full w-full max-h-[50vh] overflow-auto overflow-x-hidden", {
-          absolute: !isFixed,
-        })}
-      >
-        {#each featureList as feat}
-          <Command.Item value={feat.value} {onSelect}>
-            <Check class={cn("mr-2 h-4 w-4", value !== feat.value && "text-transparent")} />
-            {feat.label}
+<Popover.Root bind:open let:ids>
+  <Popover.Trigger asChild let:builder>
+    <button placeholder="Search feature" use:builder.action {...builder}>
+      {selectedValue}
+    </button>
+  </Popover.Trigger>
+  <Popover.Content class="w-[200px] p-0" tabindex={-1}>
+    <Command.Root>
+      <Command.Input
+        placeholder="Search framework..."
+        on:change={() => console.log("changed")}
+        bind:value={inputValue}
+        on:input={onSearchInput}
+      />
+      <Command.List>
+        {#each featureList as feature}
+          <Command.Item
+            value={feature.value}
+            onSelect={(currentValue) => onSelect(currentValue, ids.trigger)}
+          >
+            <Check class={cn("mr-2 h-4 w-4", value !== feature.value && "text-transparent")} />
+            {feature.label}
           </Command.Item>
         {/each}
-      </Command.Group>
-    </div>
-  {/if}
-</Command.Root>
+      </Command.List>
+    </Command.Root>
+  </Popover.Content>
+</Popover.Root>

--- a/ui/components/datasetItemWorkspace/src/components/Features/TextFeatureInput.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/TextFeatureInput.svelte
@@ -53,7 +53,6 @@
         value={feature.value}
         onTextInputChange={(value) => onTextInputChange(value, feature.name)}
         featureList={mapFeatureList($itemMetas.featuresList?.[featureClass][feature.name])}
-        isFixed={isEditing && featureClass === "objects"}
       />
     {:else}
       <Input

--- a/ui/components/datasetItemWorkspace/src/components/Features/TextFeatureInput.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/TextFeatureInput.svelte
@@ -53,7 +53,6 @@
         value={feature.value}
         onTextInputChange={(value) => onTextInputChange(value, feature.name)}
         featureList={mapFeatureList($itemMetas.featuresList?.[featureClass][feature.name])}
-        className="py-0 flex h-10 items-center rounded-md border border-input bg-white px-3 text-sm ring-offset-background w-full"
       />
     {:else}
       <Input

--- a/ui/components/datasetItemWorkspace/src/components/Features/TextFeatureInput.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/TextFeatureInput.svelte
@@ -53,6 +53,7 @@
         value={feature.value}
         onTextInputChange={(value) => onTextInputChange(value, feature.name)}
         featureList={mapFeatureList($itemMetas.featuresList?.[featureClass][feature.name])}
+        className="py-0 flex h-10 items-center rounded-md border border-input bg-white px-3 text-sm ring-offset-background w-full"
       />
     {:else}
       <Input

--- a/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
@@ -28,9 +28,11 @@
 </script>
 
 {#each features as feature}
-  <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+  <div class="grid gap-4 grid-cols-[150px_auto] mt-2 pr-4">
     {#if isEditing || feature.value !== undefined}
-      <p class="font-medium first-letter:uppercase">{feature.label.replace("_", " ")}</p>
+      <p class="font-medium first-letter:uppercase flex items-center">
+        {feature.label.replace("_", " ")}
+      </p>
     {/if}
 
     {#if feature.type === "bool" && (feature.value !== undefined || isEditing)}

--- a/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -106,7 +106,9 @@
 {#if shape.status === "inProgress"}
   <form class="flex flex-col gap-4 p-4" on:submit|preventDefault={handleFormSubmit}>
     <p>Save {shape.type}</p>
-    <CreateFeatureInputs bind:isFormValid bind:formInputs bind:objectProperties />
+    <div class="max-h-[calc(100vh-250px)] overflow-y-auto flex flex-col gap-4">
+      <CreateFeatureInputs bind:isFormValid bind:formInputs bind:objectProperties />
+    </div>
     <div class="flex gap-4">
       <Button
         class="text-white"


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #159 and #157

## Description

<!--- A clear and concise description of the content of this pull request. -->
- Reverted to a popover to display the feature list of the autocomplete feature as it allows placing the list on top of the app. 
- The combobox opens either on click or on keypress "enter" for keyboard users. I believe the UX is still performant.
- Fixes tiny layout alignments 
- For now, when the user input a new value, it can be selected. All "intermediate" values are temporary saved. Eg. If I input "Balloon", "B", "Ba", "Ball"... "Balloon" will be temporary saved. It is only visible if the user erases its input. Once its closed, only the final input is saved. I decided it was ok and not to lose more time on this. I can improve that behavior if you think I should. 


<img width="361" alt="image" src="https://github.com/pixano/pixano/assets/105201321/d0aa0a9a-57eb-40b9-9b16-c15dea33ae3e">

