### PR TITLE
fix(api): Allow refreshing the deployed app

### DIFF
--- a/pixano/app/serve.py
+++ b/pixano/app/serve.py
@@ -108,7 +108,19 @@ class App:
         self.app.dependency_overrides[get_settings] = get_settings_override
 
         @self.app.get("/", response_class=HTMLResponse)
-        def app_main(request: fastapi.Request):
+        def main_page(request: fastapi.Request):
+            return templates.TemplateResponse("index.html", {"request": request})
+
+        @self.app.get("/{ds_id}/dataset", response_class=HTMLResponse)
+        async def dataset_page(request: fastapi.Request):
+            return templates.TemplateResponse("index.html", {"request": request})
+
+        @self.app.get("/{ds_id}/dashboard", response_class=HTMLResponse)
+        async def dashboard_page(request: fastapi.Request):
+            return templates.TemplateResponse("index.html", {"request": request})
+
+        @self.app.get("/{ds_id}/dataset/{item_id}", response_class=HTMLResponse)
+        async def item_page(request: fastapi.Request):
             return templates.TemplateResponse("index.html", {"request": request})
 
         self.app.mount("/_app", StaticFiles(directory=ASSETS_PATH), name="assets")


### PR DESCRIPTION
## Issue

Fixes #158

## Description

Solution found with the help of @timothee-LJN!

Adding individual endpoints for each frontend route allows refreshing the page without "Not found" errors, and keeps the current route.

Currently, only three routes exists outside of the already functional home page: the dataset page, the dashboard page, and the item page. If new routes are added in the frontend, they will need to be added in the backend server as well.