### PR TITLE
fix(front): Fix home page background color

### DIFF
--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -112,7 +112,7 @@
   {:else}
     <DatasetHeader datasetName={currentDatasetName} {pageId} {currentDatasetName} />
   {/if}
-  <main class="h-1 min-h-screen">
+  <main class="h-1 min-h-screen bg-slate-50">
     <slot />
   </main>
 </div>


### PR DESCRIPTION
## Issue

Fixes #174

## Description

Fix inconsistent background color at the bottom of the home page

![image](https://github.com/pixano/pixano/assets/56968251/2271a982-7455-47ab-8dd7-826fa9cf2c2d)