### PR TITLE
fix(front): Fix favicon 404 error

### DIFF
--- a/ui/apps/pixano/src/app.html
+++ b/ui/apps/pixano/src/app.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:," />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #149

## Description

Add empty favicon in HTML file to disable 404 error in deployed app. Favicon from Svelte file still loads correctly. 
