### PR TITLE
fix(front): Update object in preannotation only if its active

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -52,7 +52,7 @@
   });
 
   $: {
-    if (objectsToAnnotate.length === 0) {
+    if (preAnnotationIsActive && objectsToAnnotate.length === 0) {
       preAnnotationIsActive = false;
       itemObjects.update((objects) =>
         objects.map((object) => {


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #178 

## Description

<!--- A clear and concise description of the content of this pull request. -->
Reactivity in `<PreAnnotation />`component was causing an unwanted update of all objects. It was intended to be only if pre-annotation was active. 
