### PR TITLE
fix(front): Fix Objects disappear on click in pre-annotation mode

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -24,6 +24,7 @@
     canSave,
     itemBboxes,
     itemMasks,
+    preAnnotationIsActive,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { updateExistingObject } from "../../lib/api/objectsApi";
 
@@ -37,7 +38,7 @@
 
   $: {
     newShapeStore.set(newShape);
-    if (newShape?.status === "editing") {
+    if (newShape?.status === "editing" && !$preAnnotationIsActive) {
       itemObjects.update((oldObjects) => updateExistingObject(oldObjects, newShape));
       canSave.update((old) => {
         if (old) return old;

--- a/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
@@ -36,7 +36,7 @@
   export let formInputs: CreateObjectInputs = [];
   export let objectProperties: { [key: string]: FeatureValues } = {};
   export let initialValues: Record<string, ItemFeature> = {};
-  export let enableAutofocus: boolean = true;
+  export let isAutofocusEnabled: boolean = true;
 
   let objectValidationSchema: CreateObjectSchema;
 
@@ -114,7 +114,7 @@
           value={findStringValue(feature.name)}
           onTextInputChange={(value) => handleInputChange(value, feature.name)}
           featureList={mapFeatureList($itemMetas.featuresList?.objects[feature.name])}
-          autofocus={i === 0 && enableAutofocus}
+          autofocus={i === 0 && isAutofocusEnabled}
         />
       {:else}
         <Input

--- a/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
@@ -36,6 +36,7 @@
   export let formInputs: CreateObjectInputs = [];
   export let objectProperties: { [key: string]: FeatureValues } = {};
   export let initialValues: Record<string, ItemFeature> = {};
+  export let enableAutofocus: boolean = true;
 
   let objectValidationSchema: CreateObjectSchema;
 
@@ -113,7 +114,7 @@
           value={findStringValue(feature.name)}
           onTextInputChange={(value) => handleInputChange(value, feature.name)}
           featureList={mapFeatureList($itemMetas.featuresList?.objects[feature.name])}
-          autofocus={i === 0}
+          autofocus={i === 0 && enableAutofocus}
         />
       {:else}
         <Input

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -18,7 +18,7 @@
 
   import ObjectCard from "./ObjectCard.svelte";
   import ObjectsModelSection from "./ObjectsModelSection.svelte";
-  import { itemObjects } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { itemObjects, preAnnotationIsActive } from "../../lib/stores/datasetItemWorkspaceStores";
   import { GROUND_TRUTH, PRE_ANNOTATION } from "../../lib/constants";
   import { createObjectCardId, sortObjectsByModel } from "../../lib/api/objectsApi";
   import PreAnnotation from "../PreAnnotation/PreAnnotation.svelte";
@@ -29,7 +29,6 @@
     [PRE_ANNOTATION]: [],
   };
   let allIds: string[] = [];
-  let preAnnotationIsActive: boolean = false;
 
   itemObjects.subscribe((value) => {
     allIds = value.map((item) => item.id);
@@ -54,8 +53,8 @@
 </script>
 
 <div class="p-2 flex flex-col h-[calc(100vh-200px)]">
-  <PreAnnotation {colorScale} bind:preAnnotationIsActive />
-  {#if !preAnnotationIsActive}
+  <PreAnnotation {colorScale} />
+  {#if !$preAnnotationIsActive}
     <div
       class={cn("gap-4 grow grid grid-cols-1 grid-rows-2 h-full", {
         block: !selectedModel,

--- a/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -20,7 +20,11 @@
   import { PrimaryButton, Slider, IconButton, Switch, cn } from "@pixano/core";
   import type { ItemObject } from "@pixano/core";
   import CreateFeatureInputs from "../Features/CreateFeatureInputs.svelte";
-  import { canSave, itemObjects } from "../../lib/stores/datasetItemWorkspaceStores";
+  import {
+    canSave,
+    itemObjects,
+    preAnnotationIsActive,
+  } from "../../lib/stores/datasetItemWorkspaceStores";
   import { GROUND_TRUTH } from "../../lib/constants";
   import {
     getObjectsToPreAnnotate,
@@ -31,7 +35,6 @@
   import type { ObjectProperties } from "../../lib/types/datasetItemWorkspaceTypes";
 
   export let colorScale: (id: string) => string;
-  export let preAnnotationIsActive: boolean = false;
 
   let objectsToAnnotate: ItemObject[] = [];
   let filteredObjectsToAnnotate: ItemObject[] = [];
@@ -52,8 +55,8 @@
   });
 
   $: {
-    if (preAnnotationIsActive && objectsToAnnotate.length === 0) {
-      preAnnotationIsActive = false;
+    if ($preAnnotationIsActive && objectsToAnnotate.length === 0) {
+      preAnnotationIsActive.set(false);
       itemObjects.update((objects) =>
         objects.map((object) => {
           object.highlighted = "all";
@@ -85,7 +88,7 @@
   };
 
   const onSwitchChange = (checked: boolean | undefined) => {
-    preAnnotationIsActive = checked || false;
+    $preAnnotationIsActive = checked || false;
     itemObjects.update((objects) => {
       const objectsToPreAnnotate = getObjectsToPreAnnotate(objects);
       const tempObjects = sortAndFilterObjectsToAnnotate(
@@ -93,8 +96,8 @@
         confidenceFilterValue,
       );
       return objects.map((object) => {
-        object.highlighted = preAnnotationIsActive ? "none" : "all";
-        if (object.id === tempObjects[0]?.id && preAnnotationIsActive) {
+        object.highlighted = $preAnnotationIsActive ? "none" : "all";
+        if (object.id === tempObjects[0]?.id && $preAnnotationIsActive) {
           object.highlighted = "self";
         }
         return object;
@@ -109,7 +112,7 @@
       confidenceFilterValue,
     );
     if (objectsToAnnotate.length === 0) {
-      preAnnotationIsActive = false;
+      preAnnotationIsActive.set(false);
     }
   };
 </script>
@@ -132,11 +135,11 @@
       </Tooltip.Root>
       <h3 class="uppercase font-medium">PRE ANNOTATION</h3>
     </div>
-    {#if preAnnotationIsActive}
+    {#if $preAnnotationIsActive}
       <span>{filteredObjectsToAnnotate.length}</span>
     {/if}
   </div>
-  {#if preAnnotationIsActive}
+  {#if $preAnnotationIsActive}
     <div class="my-2 flex items-center">
       <IconButton tooltipContent="confidence slider">
         <Filter />
@@ -157,6 +160,7 @@
               bind:isFormValid
               initialValues={objectToAnnotate.features}
               bind:objectProperties
+              enableAutofocus={false}
             />
           {/key}
         </div>

--- a/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -160,7 +160,7 @@
               bind:isFormValid
               initialValues={objectToAnnotate.features}
               bind:objectProperties
-              enableAutofocus={false}
+              isAutofocusEnabled={false}
             />
           {/key}
         </div>

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -41,6 +41,7 @@ export const itemMetas = writable<{
   id: DatasetItem["id"];
 }>();
 export const canSave = writable<boolean>(false);
+export const preAnnotationIsActive = writable<boolean>(false);
 export const modelsStore = writable<ModelSelection>({
   currentModalOpen: "none",
   selectedModelName: "",


### PR DESCRIPTION
## Issue

Fixes #156 

## Description

- Put preAnnotationIsActive in store
- prevent unwanted update of itemObjects when in pre-annotation mode

Also, remove annoying autofocus on feature input(s) in pre-annotation mode