### PR TITLE
feat(ci): Use PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
   deploy_pypi:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -64,10 +66,7 @@ jobs:
         run: hatch build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   deploy_docs:
     name: Publish documentation website


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #193

## Description

<!--- A clear and concise description of the content of this pull request. -->

Use PyPI trusted publishing instead of API tokens
