### PR TITLE
fix(front): Use pan tool when editing object

### DIFF
--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -14,7 +14,7 @@
    * http://www.cecill.info
    */
 
-  import type { DatasetItem, SelectionTool, DatasetInfo, ItemObject } from "@pixano/core";
+  import type { DatasetItem, DatasetInfo, ItemObject } from "@pixano/core";
 
   import Toolbar from "./components/Toolbar.svelte";
   import Inspector from "./components/Inspector/InspectorInspector.svelte";
@@ -39,8 +39,6 @@
   export let shouldSaveCurrentItem: boolean;
 
   let isSaving: boolean = false;
-
-  let selectedTool: SelectionTool;
 
   let embeddings: Embeddings = {};
 
@@ -109,14 +107,13 @@
       <Loader2Icon class="animate-spin" />
     </div>
   {/if}
-  <Toolbar bind:selectedTool />
-  <DatasetItemViewer {selectedTool} {selectedItem} {embeddings} {isLoading} />
+  <Toolbar />
+  <DatasetItemViewer {selectedItem} {embeddings} {isLoading} />
   <Inspector on:click={onSave} {isLoading} />
   <LoadModelModal
     {models}
     currentDatasetId={currentDataset.id}
     selectedItemId={selectedItem.id}
     bind:embeddings
-    {selectedTool}
   />
 </div>

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -17,7 +17,7 @@
   import { Loader2Icon } from "lucide-svelte";
 
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
-  import type { DatasetItem, SelectionTool } from "@pixano/core";
+  import type { DatasetItem } from "@pixano/core";
 
   import ImageViewer from "./ImageViewer.svelte";
   import VideoViewer from "./VideoViewer.svelte";
@@ -25,8 +25,6 @@
 
   export let selectedItem: DatasetItem;
   export let embeddings: Record<string, ort.Tensor>;
-
-  export let selectedTool: SelectionTool;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
   export let isLoading: boolean;
 
@@ -39,7 +37,7 @@
       <Loader2Icon class="animate-spin text-white" />
     </div>
   {:else if itemType === "image"}
-    <ImageViewer {selectedItem} {embeddings} bind:selectedTool bind:currentAnn />
+    <ImageViewer {selectedItem} {embeddings} bind:currentAnn />
   {:else if itemType === "video"}
     <VideoViewer />
   {:else if itemType === "3d"}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -16,7 +16,7 @@
   import * as ort from "onnxruntime-web";
   import { Canvas2D } from "@pixano/canvas2d";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
-  import type { DatasetItem, SelectionTool, Shape } from "@pixano/core";
+  import type { DatasetItem, Shape } from "@pixano/core";
 
   import {
     newShape as newShapeStore,
@@ -25,16 +25,16 @@
     itemBboxes,
     itemMasks,
     preAnnotationIsActive,
+    selectedTool,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { updateExistingObject } from "../../lib/api/objectsApi";
 
   export let selectedItem: DatasetItem;
   export let embeddings: Record<string, ort.Tensor>;
-
-  export let selectedTool: SelectionTool;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
 
   let newShape: Shape;
+  let allIds: string[] = [];
 
   $: {
     newShapeStore.set(newShape);
@@ -54,7 +54,7 @@
     newShape = value;
   });
 
-  let allIds: string[] = [];
+  $: selectedTool.set($selectedTool);
 
   itemObjects.subscribe((value) => {
     allIds = value.map((item) => item.id);
@@ -68,7 +68,7 @@
     bboxes={$itemBboxes}
     masks={$itemMasks}
     {embeddings}
-    bind:selectedTool
+    bind:selectedTool={$selectedTool}
     bind:currentAnn
     bind:newShape
   />

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -18,11 +18,12 @@
   import { cn, IconButton, Checkbox } from "@pixano/core/src";
   import type { DisplayControl, ItemObject } from "@pixano/core";
 
-  import { canSave, itemObjects } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { canSave, itemObjects, selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
   import { createObjectCardId, toggleObjectDisplayControl } from "../../lib/api/objectsApi";
   import { createFeature } from "../../lib/api/featuresApi";
 
   import UpdateFeatureInputs from "../Features/UpdateFeatureInputs.svelte";
+  import { panTool } from "../../lib/settings/selectionTools";
 
   export let itemObject: ItemObject;
   export let colorScale: (id: string) => string;
@@ -104,6 +105,11 @@
       }),
     );
   };
+
+  const onEditIconClick = () => {
+    handleIconClick("editing", !isEditing), (open = true);
+    !isEditing && selectedTool.set(panTool);
+  };
 </script>
 
 <article
@@ -136,12 +142,8 @@
     </div>
     <div class="flex items-center">
       {#if showIcons || isEditing}
-        <IconButton
-          tooltipContent="Edit object"
-          selected={isEditing}
-          on:click={() => {
-            handleIconClick("editing", !isEditing), (open = true);
-          }}><Pencil class="h-4" /></IconButton
+        <IconButton tooltipContent="Edit object" selected={isEditing} on:click={onEditIconClick}
+          ><Pencil class="h-4" /></IconButton
         >
         <IconButton tooltipContent="Delete object" on:click={deleteObject}
           ><Trash2 class="h-4" /></IconButton

--- a/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
@@ -18,9 +18,13 @@
 
   import { SelectModal, WarningModal } from "@pixano/core";
   import { SAM } from "@pixano/models";
-  import type { DatasetInfo, DatasetItem, SelectionTool } from "@pixano/core";
+  import type { DatasetInfo, DatasetItem } from "@pixano/core";
   import { loadEmbeddings as loadEmbeddingsApi } from "../lib/api/modelsApi";
-  import { interactiveSegmenterModel, modelsStore } from "../lib/stores/datasetItemWorkspaceStores";
+  import {
+    interactiveSegmenterModel,
+    modelsStore,
+    selectedTool,
+  } from "../lib/stores/datasetItemWorkspaceStores";
   import type { Embeddings, ModelSelection } from "../lib/types/datasetItemWorkspaceTypes";
   import ConfirmModal from "@pixano/core/src/components/modals/ConfirmModal.svelte";
 
@@ -28,7 +32,6 @@
   export let currentDatasetId: DatasetInfo["id"];
   export let selectedItemId: DatasetItem["id"];
   export let embeddings: Embeddings;
-  export let selectedTool: SelectionTool;
 
   let currentModalOpen: ModelSelection["currentModalOpen"] = "none";
   let selectedModelName: ModelSelection["selectedModelName"];
@@ -83,10 +86,10 @@
   });
 
   $: {
-    if (selectedTool?.isSmart && models.length > 1 && !selectedModelName) {
+    if ($selectedTool?.isSmart && models.length > 1 && !selectedModelName) {
       modelsStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
     }
-    if (selectedTool?.isSmart && models.length == 0) {
+    if ($selectedTool?.isSmart && models.length == 0) {
       modelsStore.update((store) => ({ ...store, currentModalOpen: "noModel" }));
     }
   }

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -38,15 +38,15 @@
     interactiveSegmenterModel,
     newShape,
     modelsStore,
+    selectedTool,
   } from "../lib/stores/datasetItemWorkspaceStores";
   import { onMount } from "svelte";
 
-  export let selectedTool: SelectionTool;
   let previousSelectedTool: SelectionTool | null = null;
   let showSmartTools: boolean = false;
 
   const selectTool = (tool: SelectionTool) => {
-    if (tool !== selectedTool) selectedTool = tool;
+    if (tool !== $selectedTool) selectedTool.set(tool);
   };
 
   const handleSmartToolClick = () => {
@@ -70,10 +70,10 @@
   });
 
   $: {
-    if (!previousSelectedTool?.isSmart || !selectedTool?.isSmart) {
+    if (!previousSelectedTool?.isSmart || !$selectedTool?.isSmart) {
       newShape.set({ status: "none" });
     }
-    previousSelectedTool = selectedTool;
+    previousSelectedTool = $selectedTool;
   }
 </script>
 
@@ -82,21 +82,21 @@
     <IconButton
       tooltipContent={panTool.name}
       on:click={() => selectTool(panTool)}
-      selected={selectedTool?.type === "PAN"}
+      selected={$selectedTool?.type === "PAN"}
     >
       <MousePointer />
     </IconButton>
     <IconButton
       tooltipContent={rectangleTool.name}
       on:click={() => selectTool(rectangleTool)}
-      selected={selectedTool?.type === "RECTANGLE" && !selectedTool.isSmart}
+      selected={$selectedTool?.type === "RECTANGLE" && !$selectedTool.isSmart}
     >
       <Square />
     </IconButton>
     <IconButton
       tooltipContent={polygonTool.name}
       on:click={() => selectTool(polygonTool)}
-      selected={selectedTool?.type === "POLYGON"}
+      selected={$selectedTool?.type === "POLYGON"}
     >
       <Share2 />
     </IconButton>
@@ -118,7 +118,7 @@
       <IconButton
         tooltipContent={addSmartPointTool.name}
         on:click={() => selectTool(addSmartPointTool)}
-        selected={selectedTool?.type === "POINT_SELECTION" && !!selectedTool.label}
+        selected={$selectedTool?.type === "POINT_SELECTION" && !!$selectedTool.label}
       >
         <PlusCircleIcon />
         <MagicIcon />
@@ -126,7 +126,7 @@
       <IconButton
         tooltipContent={removeSmartPointTool.name}
         on:click={() => selectTool(removeSmartPointTool)}
-        selected={selectedTool?.type === "POINT_SELECTION" && !selectedTool.label}
+        selected={$selectedTool?.type === "POINT_SELECTION" && !$selectedTool.label}
       >
         <MinusCircleIcon />
         <MagicIcon />
@@ -134,7 +134,7 @@
       <IconButton
         tooltipContent={smartRectangleTool.name}
         on:click={() => selectTool(smartRectangleTool)}
-        selected={selectedTool?.type === "RECTANGLE" && selectedTool.isSmart}
+        selected={$selectedTool?.type === "RECTANGLE" && $selectedTool.isSmart}
       >
         <Square />
         <MagicIcon />

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -24,6 +24,7 @@ import type {
   BBox,
   ItemFeature,
   FeaturesValues,
+  SelectionTool,
 } from "@pixano/core";
 
 import { mapObjectToBBox, mapObjectToMasks } from "../api/objectsApi";
@@ -31,6 +32,7 @@ import type { ModelSelection } from "../types/datasetItemWorkspaceTypes";
 
 // Exports
 export const newShape = writable<Shape>();
+export const selectedTool = writable<SelectionTool>();
 export const itemObjects = writable<ItemObject[]>([]);
 export const interactiveSegmenterModel = writable<InteractiveImageSegmenter>();
 export const itemMetas = writable<{


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #189 

## Description

<!--- A clear and concise description of the content of this pull request. -->
- add `selectedTool` to `DatasetItemWorkspaceStore` 
- use PAN when switching to edit mode