### PR TITLE
fix(ci): Prevent CUDA installation in lint and test actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,12 +70,15 @@ jobs:
         with:
           python-version: "3.10"
 
+      # Install PyTorch and TensorFlow CPU versions manually to prevent installing CUDA
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install pylint
-          python -m pip install pixano-inference@git+https://github.com/pixano/pixano-inference
           python -m pip install .
+          python -m pip install torch~=2.2.0 torchaudio~=2.2.0 torchvision~=0.17.0 --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install tensorflow-cpu~=2.15.0
+          python -m pip install pixano-inference@git+https://github.com/pixano/pixano-inference
 
       - name: Lint backend code with Pylint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,13 @@ jobs:
         with:
           python-version: "3.10"
 
+      # Install PyTorch and TensorFlow CPU versions manually to prevent installing CUDA
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
+          python -m pip install torch~=2.2.0 torchaudio~=2.2.0 torchvision~=0.17.0 --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install tensorflow-cpu~=2.15.0
           python -m pip install pixano-inference@git+https://github.com/pixano/pixano-inference@v0.3.0b1
 
       - name: Test with unittest


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #196

## Description

<!--- A clear and concise description of the content of this pull request. -->
GPU support with CUDA is not necessary for linting and testing Pixano, so skipping CUDA installation by installing the CPU versions of PyTorch and TensorFlow reduces the actions run time by a minute or so.