### PR TITLE
fix(back): Check if categories field to export is not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Pixano will be documented in this file.
 ### Fixed
 
 - Fix InferenceModel to stop relying on table order (pixano#169)
+- Check if categories is null before iterating in COCOExporter (pixano#202)
 - Allow page refresh in the deployed app (pixano#173)
 - Switch to pan tool when editing an object (pixano#195)
 - Fix highlighted objects disappearing in pre-annotation mode (pixano#180)

--- a/pixano/data/exporters/coco_exporter.py
+++ b/pixano/data/exporters/coco_exporter.py
@@ -97,9 +97,13 @@ class COCOExporter(Exporter):
                     ],
                     "images": [],
                     "annotations": [],
-                    "categories": sorted(
-                        [cat.model_dump() for cat in self.dataset.info.categories],
-                        key=lambda c: c["id"],
+                    "categories": (
+                        sorted(
+                            [cat.model_dump() for cat in self.dataset.info.categories],
+                            key=lambda c: c["id"],
+                        )
+                        if self.dataset.info.categories is not None
+                        else []
                     ),
                 }
 
@@ -237,7 +241,7 @@ class COCOExporter(Exporter):
                 obj.features["category"].value if "category" in obj.features else None
             ),
         }
-        if category["name"] is not None:
+        if category["name"] is not None and self.dataset.info.categories is not None:
             for cat in self.dataset.info.categories:
                 if cat.name == category["name"]:
                     category["id"] = cat.id


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #201

## Description

<!--- A clear and concise description of the content of this pull request. -->
Since the `categories` field of `DatasetInfo` is optional, it can be null when using `ImageImporter`.
`COCOExporter` should thus check if the field is null before trying to iterate on it.