### PR TITLE
fix(back): missing protection on no supercategory to export

### DIFF
--- a/pixano/data/exporters/coco_exporter.py
+++ b/pixano/data/exporters/coco_exporter.py
@@ -304,6 +304,7 @@ class COCOExporter(Exporter):
             "category_id": category["id"],
             "category_name": category["name"],
         }
-        if category["supercategory"] != "":
+        if "supercategory" in category and category["supercategory"] != "":
             ann_object["supercategory"] = category["supercategory"]
+
         self.coco_json["annotations"].append(ann_object)


### PR DESCRIPTION
## Issue

Fixes #221 

## Description

Add a missing protection when "supercategory" field has not been filled (because no "supercategory" info in dataset)