### PR TITLE
feat(back): protection against empty table and default review_state

### DIFF
--- a/pixano/data/dataset/dataset.py
+++ b/pixano/data/dataset/dataset.py
@@ -329,7 +329,8 @@ class Dataset(BaseModel):
                         info_table.fields[col.name] = col.dtype
 
             # Merge with main table
-            table.to_lance().merge(new_columns_table, "id")
+            if len(new_columns_table) > 0:
+                table.to_lance().merge(new_columns_table, "id")
             self.save_info()
 
     def load_items(
@@ -726,6 +727,7 @@ class Dataset(BaseModel):
                         "view_id": "str",
                         "bbox": "bbox",
                         "mask": "compressedrle",
+                        "review_state": "str",
                     },
                 )
                 for feat in obj.features.values():


### PR DESCRIPTION
## Issue

Fixes #227 

## Description

Add protection to not merge when empty table
Add review_state internal field when creating table --> this should probably be reworked with python API and custom schemas