### PR TITLE
fix(front): look for input rect in drag-rect instead of input

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -679,21 +679,17 @@
     //get box as Box
     let box: Box = null;
     const viewLayer: Konva.Layer = stage.findOne(`#${viewId}`);
-    const inputGroup: Konva.Group = viewLayer.findOne("#input");
-    for (const rect of inputGroup.children) {
-      if (rect instanceof Konva.Rect) {
-        //need to convert rect pos / size to topleft/bottomright
-        const size = rect.size();
-        const pos = rect.position();
-        box = {
-          x: pos.x,
-          y: pos.y,
-          width: size.width,
-          height: size.height,
-        };
-        //we should have only one Box
-        break;
-      }
+    const rect: Konva.Rect = viewLayer.findOne("#drag-rect");
+    if (rect) {
+      //need to convert rect pos / size to topleft/bottomright
+      const size = rect.size();
+      const pos = rect.position();
+      box = {
+        x: pos.x,
+        y: pos.y,
+        width: size.width,
+        height: size.height,
+      };
     }
     return box;
   }


### PR DESCRIPTION
## Issue

Fixes #229 

## Description

input rectangle for segmentation is not created under "input" group anymore (since #205 )
So we find it by it's name "drag-rect" now
