### PR TITLE
feat: show thumbnail on editor

### DIFF
--- a/docs/restAPI_reference/data_items.md
+++ b/docs/restAPI_reference/data_items.md
@@ -65,6 +65,17 @@ type videoDatasetItemPayload = {
           ],
         },
       ],
+      thumbnails: {
+        [viewId]: {
+          uri: string;
+          coords: [x, y, width, height];
+          imageDimensions: {
+            width: number;
+            height: number
+          }
+
+        }
+      }
     },
   },
 ```

--- a/docs/restAPI_reference/data_items.md
+++ b/docs/restAPI_reference/data_items.md
@@ -61,21 +61,11 @@ type videoDatasetItemPayload = {
               confidence: number;
               frame_index: number;
               is_key: boolean;
+              is_thumbnail: boolean
             },
           ],
         },
       ],
-      thumbnails: {
-        [viewId]: {
-          uri: string;
-          coords: [x, y, width, height];
-          imageDimensions: {
-            width: number;
-            height: number
-          }
-
-        }
-      }
     },
   },
 ```

--- a/ui/components/canvas2d/src/components/Thumbnail.svelte
+++ b/ui/components/canvas2d/src/components/Thumbnail.svelte
@@ -20,7 +20,8 @@
   export let imageDimension: { width: number; height: number };
   export let coords: number[];
   export let imageUrl: string;
-  export let maxSize: number = 48;
+  export let maxSize: number | undefined = undefined;
+  export let minSize: number | undefined = undefined;
 
   let [x, y, width, height] = coords;
 
@@ -33,8 +34,16 @@
   let stageHeight = height * imageDimension.height;
 
   $: {
-    if (Math.max(stageWidth, stageHeight) > maxSize) {
+    if (maxSize && Math.max(stageWidth, stageHeight) > maxSize) {
       const ratio = Math.max(stageWidth, stageHeight) / maxSize;
+      stageWidth /= ratio;
+      stageHeight /= ratio;
+    }
+  }
+
+  $: {
+    if (minSize && Math.max(stageWidth, stageHeight) < minSize) {
+      const ratio = Math.max(stageWidth, stageHeight) / minSize;
       stageWidth /= ratio;
       stageHeight /= ratio;
     }
@@ -61,10 +70,10 @@
           image: img,
           id: "thumbnail-image",
           crop: {
-            x: x * imageDimension.width,
-            y: y * imageDimension.height,
-            width: width * imageDimension.width,
-            height: height * imageDimension.height,
+            x: x * imageDimension.width - (width * imageDimension.width) / 2,
+            y: y * imageDimension.height - (height * imageDimension.height) / 2,
+            width: width * imageDimension.width * 2,
+            height: height * imageDimension.height * 2,
           },
         }}
       />

--- a/ui/components/core/src/api.ts
+++ b/ui/components/core/src/api.ts
@@ -20,6 +20,7 @@ import type {
   DatasetItem,
   ExplorerData,
   VideoObject,
+  ObjectThumbnail,
 } from "./lib/types/datasetTypes";
 
 // Exports
@@ -158,6 +159,26 @@ export async function getDatasetItem(datasetId: string, itemId: string): Promise
             return tracklet;
           });
           obj.displayedBox = undefined;
+          obj.thumbnails =
+            item?.type === "video"
+              ? Object.entries(item.views).reduce(
+                  (acc, [viewId, views]) => {
+                    if (obj.datasetItemType === "video") {
+                      acc[viewId] = {
+                        uri: views[0].uri,
+                        baseImageDimensions: {
+                          width: views[0].features.width.value as number,
+                          height: views[0].features.height.value as number,
+                        },
+                        frameIndex: 0,
+                        coords: obj.track[0].keyBoxes[0].coords,
+                      };
+                    }
+                    return acc;
+                  },
+                  {} as Record<string, ObjectThumbnail>,
+                )
+              : undefined;
           return obj;
         });
         item.objects = objects;

--- a/ui/components/core/src/api.ts
+++ b/ui/components/core/src/api.ts
@@ -147,38 +147,39 @@ export async function getDatasetItem(datasetId: string, itemId: string): Promise
           obj.track = obj.track.map((tracklet) => {
             tracklet.start = tracklet.keyBoxes[0].frame_index;
             tracklet.end = tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index;
-            tracklet.keyBoxes = tracklet.keyBoxes.map((keyBox) => {
+            tracklet.keyBoxes = tracklet.keyBoxes.map((keyBox, i) => {
               if (
                 keyBox.frame_index === tracklet.keyBoxes[0].frame_index ||
                 keyBox.frame_index === tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index
               ) {
                 keyBox.is_key = true;
+                keyBox.is_thumbnail = i === 0;
               }
               return keyBox;
             });
             return tracklet;
           });
           obj.displayedBox = undefined;
-          obj.thumbnails =
-            item?.type === "video"
-              ? Object.entries(item.views).reduce(
-                  (acc, [viewId, views]) => {
-                    if (obj.datasetItemType === "video") {
-                      acc[viewId] = {
-                        uri: views[0].uri,
-                        baseImageDimensions: {
-                          width: views[0].features.width.value as number,
-                          height: views[0].features.height.value as number,
-                        },
-                        frameIndex: 0,
-                        coords: obj.track[0].keyBoxes[0].coords,
-                      };
-                    }
-                    return acc;
-                  },
-                  {} as Record<string, ObjectThumbnail>,
-                )
-              : undefined;
+          // obj.thumbnails =
+          //   item?.type === "video"
+          //     ? Object.entries(item.views).reduce(
+          //         (acc, [viewId, views]) => {
+          //           if (obj.datasetItemType === "video") {
+          //             acc[viewId] = {
+          //               uri: views[0].uri,
+          //               baseImageDimensions: {
+          //                 width: views[0].features.width.value as number,
+          //                 height: views[0].features.height.value as number,
+          //               },
+          //               frameIndex: 0,
+          //               coords: obj.track[0].keyBoxes[0].coords,
+          //             };
+          //           }
+          //           return acc;
+          //         },
+          //         {} as Record<string, ObjectThumbnail>,
+          //       )
+          //     : undefined;
           return obj;
         });
         item.objects = objects;

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -150,7 +150,6 @@ export interface ObjectThumbnail {
     width: number;
     height: number;
   };
-  frameIndex: number;
   coords: Array<number>;
 }
 
@@ -163,12 +162,12 @@ export type ItemObjectBase = {
   displayControl?: DisplayControl;
   highlighted?: "none" | "self" | "all";
   review_state?: "accepted" | "rejected";
-  thumbnails?: Record<string, ObjectThumbnail>;
 };
 
 export type VideoItemBBox = ItemBBox & {
   frame_index: number;
   is_key?: boolean;
+  is_thumbnail?: boolean;
   hidden?: boolean;
 };
 export interface Tracklet {

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -96,14 +96,14 @@ interface BaseDatasetItem {
   id: string;
   datasetId: string;
   split: string;
-  objects: Record<string, ItemObject>; //remplacer par? Array<ItemObject>
+  objects: Array<ItemObject>;
   features: Record<string, ItemFeature>; //remplacer par? Array<ItemFeature>
   embeddings: Record<string, ItemEmbedding>; //remplacer par? Array<ItemEmbedding>
 }
 
 export type ImageDatasetItem = BaseDatasetItem & {
   type: "image";
-  objects: Record<string, ImageObject>;
+  objects: Array<ImageObject>;
   views: Record<string, ItemView>;
 };
 
@@ -144,17 +144,26 @@ export interface DisplayControl {
   editing?: boolean;
 }
 
+export interface ObjectThumbnail {
+  uri: string;
+  baseImageDimensions: {
+    width: number;
+    height: number;
+  };
+  frameIndex: number;
+  coords: Array<number>;
+}
+
 export type ItemObjectBase = {
   id: string;
   item_id: string;
   source_id: string;
   view_id: string;
-  //bbox?: ItemBBox;
-  //mask?: ItemRLE;
   features: Record<string, ItemFeature>;
   displayControl?: DisplayControl;
   highlighted?: "none" | "self" | "all";
   review_state?: "accepted" | "rejected";
+  thumbnails?: Record<string, ObjectThumbnail>;
 };
 
 export type VideoItemBBox = ItemBBox & {

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -14,7 +14,7 @@
    * http://www.cecill.info
    */
 
-  import type { DatasetItem, ItemObject, FeaturesValues } from "@pixano/core";
+  import type { DatasetItem, FeaturesValues } from "@pixano/core";
 
   import Toolbar from "./components/Toolbar.svelte";
   import Inspector from "./components/Inspector/InspectorInspector.svelte";
@@ -44,17 +44,15 @@
 
   let embeddings: Embeddings = {};
 
-  $: itemObjects.update((old) => {
-    return Object.values(selectedItem.objects || {})
-      .flat()
-      .map((object) => {
-        const oldObject = old.find((o) => o.id === object.id);
-        if (oldObject) {
-          return { ...oldObject, ...object };
-        }
-        return object;
-      });
-  });
+  $: itemObjects.update((oldObjects) =>
+    selectedItem.objects.map((object) => {
+      const oldObject = oldObjects.find((o) => o.id === object.id);
+      if (oldObject) {
+        return { ...oldObject, ...object };
+      }
+      return object;
+    }),
+  );
 
   $: itemMetas.set({
     mainFeatures: selectedItem.features,
@@ -78,15 +76,6 @@
     isSaving = true;
     let savedItem = { ...selectedItem };
 
-    itemObjects.subscribe((value) => {
-      savedItem.objects = value.reduce(
-        (acc, obj) => {
-          acc[obj.id] = obj;
-          return acc;
-        },
-        {} as Record<string, ItemObject>,
-      );
-    });
     itemMetas.subscribe((value) => {
       savedItem.features = value.mainFeatures;
     });

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -30,8 +30,7 @@
   import DatasetItemViewer from "./components/DatasetItemViewer/DatasetItemViewer.svelte";
   import { Loader2Icon } from "lucide-svelte";
 
-  //export let currentDataset: DatasetInfo;
-  export let featureValues: FeaturesValues; // <-- new (?) remplace currentDatset.features_values
+  export let featureValues: FeaturesValues;
   export let selectedItem: DatasetItem;
   export let models: string[] = [];
   export let handleSaveItem: (item: DatasetItem) => Promise<void>;

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -45,17 +45,6 @@
   export let brightness: number;
   export let contrast: number;
 
-  const imagesDimensions = Object.entries(selectedItem.views).reduce(
-    (acc, [key, value]) => {
-      acc[key] = {
-        width: value[0].features.width.value as number,
-        height: value[0].features.height.value as number,
-      };
-      return acc;
-    },
-    {} as Record<string, { width: number; height: number }>,
-  );
-
   let imagesPerView: Record<string, HTMLImageElement[]> = {};
 
   let imagesFilesUrls: Record<string, string[]> = Object.entries(selectedItem.views).reduce(
@@ -79,11 +68,11 @@
     });
 
     isLoaded = true;
-    const longerView = Object.values(imagesFilesUrls).reduce(
+    const longestView = Object.values(imagesFilesUrls).reduce(
       (acc, urls) => (urls.length > acc ? urls.length : acc),
       0,
     );
-    lastFrameIndex.set(longerView - 1);
+    lastFrameIndex.set(longestView - 1);
   });
 
   const updateView = (imageIndex: number) => {
@@ -159,7 +148,7 @@
       </Canvas2D>
     </div>
     <div class="h-full grow max-h-[25%] overflow-hidden">
-      <VideoInspector {updateView} {imagesFilesUrls} {imagesDimensions} />
+      <VideoInspector {updateView} />
     </div>
   {/if}
 </section>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -17,18 +17,20 @@
 
   import { cn, IconButton, Checkbox } from "@pixano/core/src";
   import { Thumbnail } from "@pixano/canvas2d";
-  import type { DisplayControl, ItemObject } from "@pixano/core";
+  import type { DisplayControl, ItemObject, ObjectThumbnail } from "@pixano/core";
 
   import {
     canSave,
     itemObjects,
     selectedTool,
     colorScale,
+    itemMetas,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     createObjectCardId,
     toggleObjectDisplayControl,
     highlightCurrentObject,
+    defineObjectThumbnail,
   } from "../../lib/api/objectsApi";
   import { createFeature } from "../../lib/api/featuresApi";
 
@@ -111,6 +113,8 @@
     handleIconClick("editing", !isEditing), (open = true);
     !isEditing && selectedTool.set(panTool);
   };
+
+  const thumbnail: ObjectThumbnail | null = defineObjectThumbnail($itemMetas, itemObject);
 </script>
 
 <article
@@ -195,15 +199,13 @@
             </div>
           {/if}
           <UpdateFeatureInputs featureClass="objects" {features} {isEditing} {saveInputChange} />
-          {#if itemObject.thumbnails}
-            {#each Object.values(itemObject.thumbnails) as thumbnail}
-              <Thumbnail
-                imageDimension={thumbnail.baseImageDimensions}
-                coords={thumbnail.coords}
-                imageUrl={`/${thumbnail.uri}`}
-                minSize={150}
-              />
-            {/each}
+          {#if thumbnail}
+            <Thumbnail
+              imageDimension={thumbnail.baseImageDimensions}
+              coords={thumbnail.coords}
+              imageUrl={`/${thumbnail.uri}`}
+              minSize={150}
+            />
           {/if}
         </div>
       </div>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -16,6 +16,7 @@
   import { Eye, EyeOff, Trash2, Pencil, ChevronRight } from "lucide-svelte";
 
   import { cn, IconButton, Checkbox } from "@pixano/core/src";
+  import { Thumbnail } from "@pixano/canvas2d";
   import type { DisplayControl, ItemObject } from "@pixano/core";
 
   import {
@@ -49,6 +50,12 @@
     itemObject.datasetItemType === "image" && !itemObject.mask?.displayControl?.hidden;
 
   $: color = $colorScale[1](itemObject.id);
+
+  $: {
+    if (itemObject.highlighted === "self") {
+      open = true;
+    }
+  }
 
   const handleIconClick = (
     displayControlProperty: keyof DisplayControl,
@@ -188,6 +195,16 @@
             </div>
           {/if}
           <UpdateFeatureInputs featureClass="objects" {features} {isEditing} {saveInputChange} />
+          {#if itemObject.thumbnails}
+            {#each Object.values(itemObject.thumbnails) as thumbnail}
+              <Thumbnail
+                imageDimension={thumbnail.baseImageDimensions}
+                coords={thumbnail.coords}
+                imageUrl={`/${thumbnail.uri}`}
+                minSize={150}
+              />
+            {/each}
+          {/if}
         </div>
       </div>
     </div>

--- a/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -50,7 +50,13 @@
     let newObject: ItemObject | null = null;
     itemObjects.update((oldObjects) => {
       if (shape.status !== "saving") return oldObjects;
-      newObject = defineCreatedObject(shape, $itemMetas.type, features, $currentFrameIndex);
+      newObject = defineCreatedObject(
+        shape,
+        $itemMetas.type,
+        features,
+        $currentFrameIndex,
+        $itemMetas.views,
+      );
       objectIdBeingEdited.set(newObject?.id || null);
       const objectsWithoutHighlighted: ItemObject[] = oldObjects.map((object) => ({
         ...object,

--- a/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -50,13 +50,7 @@
     let newObject: ItemObject | null = null;
     itemObjects.update((oldObjects) => {
       if (shape.status !== "saving") return oldObjects;
-      newObject = defineCreatedObject(
-        shape,
-        $itemMetas.type,
-        features,
-        $currentFrameIndex,
-        $itemMetas.views,
-      );
+      newObject = defineCreatedObject(shape, $itemMetas.type, features, $currentFrameIndex);
       objectIdBeingEdited.set(newObject?.id || null);
       const objectsWithoutHighlighted: ItemObject[] = oldObjects.map((object) => ({
         ...object,

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -100,14 +100,6 @@
     tracklet: Tracklet,
     frameIndex: VideoItemBBox["frame_index"],
   ): [number, number] => findNeighbors(object.track, tracklet, frameIndex, $lastFrameIndex);
-
-  let showThumbnail = false;
-  let thumbnailPosition = 0;
-
-  const changeThumbnailPosition = (mouseClientX: number) => {
-    const timeTrackPosition = objectTimeTrack.getBoundingClientRect();
-    thumbnailPosition = mouseClientX - timeTrackPosition.x + 20;
-  };
 </script>
 
 <div
@@ -115,16 +107,8 @@
   id={`video-object-${object.id}`}
   style={`width: ${$videoControls.zoomLevel[0]}%`}
   bind:this={objectTimeTrack}
-  on:mouseenter={() => (showThumbnail = true)}
-  on:mouseleave={() => (showThumbnail = false)}
-  on:mousemove={(e) => changeThumbnailPosition(e.clientX)}
   role="complementary"
 >
-  {#if showThumbnail}
-    <div class="absolute top-[30%] z-40" style={`left: ${thumbnailPosition}px`}>
-      <slot />
-    </div>
-  {/if}
   <span
     class="w-[1px] bg-primary h-full absolute top-0 z-30 pointer-events-none"
     style={`left: ${($currentFrameIndex / ($lastFrameIndex + 1)) * 100}%`}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -24,12 +24,9 @@
     lastFrameIndex,
     videoControls,
   } from "../../lib/stores/videoViewerStores";
-  import { Thumbnail } from "@pixano/canvas2d";
   import { SliderRoot } from "@pixano/core";
 
   export let updateView: (frameIndex: number) => void;
-  export let imagesDimensions: Record<string, { width: number; height: number }>;
-  export let imagesFilesUrls: Record<string, string[]>;
 
   const onTimeTrackClick = (index: number) => {
     currentFrameIndex.set(index);
@@ -58,13 +55,7 @@
         {#each Object.values($itemObjects) as object}
           {#if object.datasetItemType === "video"}
             <VideoPlayerRow>
-              <ObjectTrack slot="timeTrack" {object} {onTimeTrackClick} {updateView}>
-                <Thumbnail
-                  imageDimension={imagesDimensions[object.view_id]}
-                  coords={object.track[0].keyBoxes[0].coords}
-                  imageUrl={`/${imagesFilesUrls[object.view_id][object.track[0].start]}`}
-                />
-              </ObjectTrack>
+              <ObjectTrack slot="timeTrack" {object} {onTimeTrackClick} {updateView} />
             </VideoPlayerRow>
           {/if}
         {/each}

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
@@ -36,6 +36,7 @@ import {
   HIGHLIGHTED_MASK_STROKE_FACTOR,
 } from "../constants";
 import type {
+  ItemsMeta,
   ObjectProperties,
   ObjectsSortedByModelType,
 } from "../types/datasetItemWorkspaceTypes";
@@ -283,6 +284,7 @@ export const defineCreatedObject = (
   videoType: DatasetItem["type"],
   features: ItemObjectBase["features"],
   currentFrameIndex: number,
+  views: ItemsMeta["views"],
 ) => {
   let newObject: ItemObject | null = null;
   const baseObject = {
@@ -326,6 +328,17 @@ export const defineCreatedObject = (
           },
         ],
         displayedBox: { ...bbox, frame_index: 0 },
+        thumbnails: {
+          [shape.viewId]: {
+            uri: (views[shape.viewId] as ItemView[])[0].uri,
+            coords,
+            baseImageDimensions: {
+              width: shape.imageWidth,
+              height: shape.imageHeight,
+            },
+            frameIndex: currentFrameIndex,
+          },
+        },
       };
     } else {
       newObject = {

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -19,31 +19,21 @@ import {
   type Shape,
   type InteractiveImageSegmenter,
   type ItemObject,
-  type DatasetItem,
   type Mask,
   type BBox,
-  type ItemFeature,
-  type FeaturesValues,
   type SelectionTool,
   utils,
 } from "@pixano/core";
 
 import { mapObjectToBBox, mapObjectToMasks } from "../api/objectsApi";
-import type { ModelSelection } from "../types/datasetItemWorkspaceTypes";
+import type { ItemsMeta, ModelSelection } from "../types/datasetItemWorkspaceTypes";
 
 // Exports
 export const newShape = writable<Shape>();
 export const selectedTool = writable<SelectionTool>();
 export const itemObjects = writable<ItemObject[]>([]);
 export const interactiveSegmenterModel = writable<InteractiveImageSegmenter>();
-export const itemMetas = writable<{
-  mainFeatures: DatasetItem["features"]; // features
-  objectFeatures: Record<string, ItemFeature>; // itemFeatures
-  featuresList: FeaturesValues; // featuresValues
-  views: DatasetItem["views"];
-  id: DatasetItem["id"];
-  type: DatasetItem["type"];
-}>();
+export const itemMetas = writable<ItemsMeta>();
 export const canSave = writable<boolean>(false);
 export const preAnnotationIsActive = writable<boolean>(false);
 export const modelsStore = writable<ModelSelection>({

--- a/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 import * as ort from "onnxruntime-web";
 
-import type { FeatureValues, ItemObject } from "@pixano/core";
+import type {
+  DatasetItem,
+  FeaturesValues,
+  FeatureValues,
+  ItemFeature,
+  ItemObject,
+} from "@pixano/core";
 
 import { GROUND_TRUTH, PRE_ANNOTATION } from "../constants";
 import type {
@@ -60,4 +66,13 @@ export type Embeddings = Record<string, ort.Tensor>;
 export type ModelSelection = {
   currentModalOpen: "selectModel" | "noModel" | "noEmbeddings" | "none";
   selectedModelName: string;
+};
+
+export type ItemsMeta = {
+  mainFeatures: DatasetItem["features"]; // feature;
+  objectFeatures: Record<string, ItemFeature>; // itemFeatures
+  featuresList: FeaturesValues;
+  views: DatasetItem["views"];
+  id: DatasetItem["id"];
+  type: DatasetItem["type"];
 };


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #244 

## Description

<!--- A clear and concise description of the content of this pull request. -->
- thumbnails are not displayed on track hover
- thumbnails are displayed on scene inspector
- object being highlighted are open in inspector (but not closed, this could be change. Any mind?) 
- by default, the thumbnail is the first frame of the track is used for the thumbnail. User cannot change that for now but I changed the data structure to save it in the database. Documentation has been updated. Maybe this could be simplified. What do you think @BertrandRenault ?
- it only works for videos now, shall we do it for images as well @jrabary ? 

<img width="1200" alt="image" src="https://github.com/pixano/pixano/assets/105201321/06de229d-aaa0-4a1d-acd9-03a5639fff39">
 
