### PR TITLE
fix(back): add is_key & rename keyBoxes to boxes

### DIFF
--- a/pixano/app/api/items.py
+++ b/pixano/app/api/items.py
@@ -402,11 +402,11 @@ async def get_dataset_item(  # noqa: D417
                                 "tracklet_id": tracklet_id,
                                 "tracklet_objs": [
                                     {
-                                        "keyBoxes": {
+                                        "boxes": {
                                             **vars(obj.bbox),
                                             "frame_index": obj.frame_idx,
-                                            "is_keypoint": i % (len(tracklet_objs) - 1)
-                                            == 0,
+                                            "is_key": obj.is_key,
+                                            "is_thumbnail": i == 0,
                                         },
                                         "obj_features": obj,  # we put the whole obj to get features from it below
                                     }
@@ -458,14 +458,14 @@ async def get_dataset_item(  # noqa: D417
                                 "track": [
                                     {
                                         "id": tracklet["tracklet_id"],
-                                        "start": tracklet["tracklet_objs"][0][
-                                            "keyBoxes"
-                                        ]["frame_index"],
-                                        "end": tracklet["tracklet_objs"][-1][
-                                            "keyBoxes"
-                                        ]["frame_index"],
-                                        "keyBoxes": [
-                                            obj["keyBoxes"]
+                                        "start": tracklet["tracklet_objs"][0]["boxes"][
+                                            "frame_index"
+                                        ],
+                                        "end": tracklet["tracklet_objs"][-1]["boxes"][
+                                            "frame_index"
+                                        ],
+                                        "boxes": [
+                                            obj["boxes"]
                                             for obj in tracklet["tracklet_objs"]
                                         ],
                                     }

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -40,7 +40,9 @@
         selectedItem = item;
         if (selectedItem.type === "video") {
           selectedItem.objects.map((obj) => {
-            obj.displayedBox = obj.track[0].keyBoxes[0];
+            if (obj.datasetItemType === "video") {
+              obj.displayedBox = obj.track[0].boxes[0];
+            }
             return obj;
           });
         }

--- a/ui/components/core/src/api.ts
+++ b/ui/components/core/src/api.ts
@@ -19,8 +19,6 @@ import type {
   DatasetItems,
   DatasetItem,
   ExplorerData,
-  VideoObject,
-  ObjectThumbnail,
 } from "./lib/types/datasetTypes";
 
 // Exports
@@ -140,50 +138,51 @@ export async function getDatasetItem(datasetId: string, itemId: string): Promise
     const response = await fetch(`/datasets/${datasetId}/items/${itemId}`);
     if (response.ok) {
       item = (await response.json()) as DatasetItem;
+
       // TODO : remove this when the backend is fixed
       // TODO : API changes | keyBoxes should be renamed `boxes` since is_key is now a params
-      if (item.type === "video") {
-        const objects: Array<VideoObject> = item.objects.map((obj) => {
-          obj.track = obj.track.map((tracklet) => {
-            tracklet.start = tracklet.keyBoxes[0].frame_index;
-            tracklet.end = tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index;
-            tracklet.keyBoxes = tracklet.keyBoxes.map((keyBox, i) => {
-              if (
-                keyBox.frame_index === tracklet.keyBoxes[0].frame_index ||
-                keyBox.frame_index === tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index
-              ) {
-                keyBox.is_key = true;
-                keyBox.is_thumbnail = i === 0;
-              }
-              return keyBox;
-            });
-            return tracklet;
-          });
-          obj.displayedBox = undefined;
-          // obj.thumbnails =
-          //   item?.type === "video"
-          //     ? Object.entries(item.views).reduce(
-          //         (acc, [viewId, views]) => {
-          //           if (obj.datasetItemType === "video") {
-          //             acc[viewId] = {
-          //               uri: views[0].uri,
-          //               baseImageDimensions: {
-          //                 width: views[0].features.width.value as number,
-          //                 height: views[0].features.height.value as number,
-          //               },
-          //               frameIndex: 0,
-          //               coords: obj.track[0].keyBoxes[0].coords,
-          //             };
-          //           }
-          //           return acc;
-          //         },
-          //         {} as Record<string, ObjectThumbnail>,
-          //       )
-          //     : undefined;
-          return obj;
-        });
-        item.objects = objects;
-      }
+      // if (item.type === "video") {
+      //   const objects: Array<VideoObject> = item.objects.map((obj) => {
+      //     obj.track = obj.track.map((tracklet) => {
+      //       tracklet.start = tracklet.keyBoxes[0].frame_index;
+      //       tracklet.end = tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index;
+      //       tracklet.keyBoxes = tracklet.keyBoxes.map((keyBox, i) => {
+      //         if (
+      //           keyBox.frame_index === tracklet.keyBoxes[0].frame_index ||
+      //           keyBox.frame_index === tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index
+      //         ) {
+      //           keyBox.is_key = true;
+      //           keyBox.is_thumbnail = i === 0;
+      //         }
+      //         return keyBox;
+      //       });
+      //       return tracklet;
+      //     });
+      //     obj.displayedBox = undefined;
+      //     // obj.thumbnails =
+      //     //   item?.type === "video"
+      //     //     ? Object.entries(item.views).reduce(
+      //     //         (acc, [viewId, views]) => {
+      //     //           if (obj.datasetItemType === "video") {
+      //     //             acc[viewId] = {
+      //     //               uri: views[0].uri,
+      //     //               baseImageDimensions: {
+      //     //                 width: views[0].features.width.value as number,
+      //     //                 height: views[0].features.height.value as number,
+      //     //               },
+      //     //               frameIndex: 0,
+      //     //               coords: obj.track[0].keyBoxes[0].coords,
+      //     //             };
+      //     //           }
+      //     //           return acc;
+      //     //         },
+      //     //         {} as Record<string, ObjectThumbnail>,
+      //     //       )
+      //     //     : undefined;
+      //     return obj;
+      //   });
+      //   item.objects = objects;
+      // }
     } else {
       item = {} as DatasetItem;
       console.log(

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -171,7 +171,7 @@ export type VideoItemBBox = ItemBBox & {
   hidden?: boolean;
 };
 export interface Tracklet {
-  keyBoxes: VideoItemBBox[];
+  boxes: VideoItemBBox[];
   start: number;
   end: number;
 }

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -45,7 +45,7 @@
   let embeddings: Embeddings = {};
 
   $: itemObjects.update((oldObjects) =>
-    selectedItem.objects.map((object) => {
+    selectedItem?.objects.map((object) => {
       const oldObject = oldObjects.find((o) => o.id === object.id);
       if (oldObject) {
         return { ...oldObject, ...object };

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -96,7 +96,7 @@
     );
   };
 
-  const findNeighborKeyBoxes = (
+  const findNeighborBoxes = (
     tracklet: Tracklet,
     frameIndex: VideoItemBBox["frame_index"],
   ): [number, number] => findNeighbors(object.track, tracklet, frameIndex, $lastFrameIndex);
@@ -130,7 +130,7 @@
       {onEditKeyBoxClick}
       onSplitTrackletClick={() => onSplitTrackletClick(i)}
       onDeleteTrackletClick={() => onDeleteTrackletClick(i)}
-      {findNeighborKeyBoxes}
+      {findNeighborBoxes}
       {updateView}
       {moveCursorToPosition}
     />

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -33,7 +33,7 @@
   export let onAddKeyBoxClick: () => void;
   export let onSplitTrackletClick: () => void;
   export let onDeleteTrackletClick: () => void;
-  export let findNeighborKeyBoxes: (tracklet: Tracklet, frameIndex: number) => [number, number];
+  export let findNeighborBoxes: (tracklet: Tracklet, frameIndex: number) => [number, number];
   export let updateView: (frameIndex: number) => void;
   export let moveCursorToPosition: (clientX: number) => void;
 
@@ -57,16 +57,16 @@
     newFrameIndex: VideoItemBBox["frame_index"],
     draggedFrameIndex: VideoItemBBox["frame_index"],
   ) => {
-    const [prevFrameIndex, nextFrameIndex] = findNeighborKeyBoxes(tracklet, newFrameIndex);
+    const [prevFrameIndex, nextFrameIndex] = findNeighborBoxes(tracklet, newFrameIndex);
     if (newFrameIndex <= prevFrameIndex || newFrameIndex >= nextFrameIndex) return;
-    tracklet.keyBoxes = tracklet.keyBoxes.map((keyBox) => {
-      if (keyBox.frame_index === draggedFrameIndex) {
-        keyBox.frame_index = newFrameIndex;
+    tracklet.boxes = tracklet.boxes.map((box) => {
+      if (box.frame_index === draggedFrameIndex) {
+        box.frame_index = newFrameIndex;
       }
-      return keyBox;
+      return box;
     });
-    tracklet.start = tracklet.keyBoxes[0].frame_index;
-    tracklet.end = tracklet.keyBoxes[tracklet.keyBoxes.length - 1].frame_index;
+    tracklet.start = tracklet.boxes[0].frame_index;
+    tracklet.end = tracklet.boxes[tracklet.boxes.length - 1].frame_index;
     updateView(newFrameIndex);
     currentFrameIndex.set(newFrameIndex);
   };
@@ -114,10 +114,10 @@
     <ContextMenu.Item inset on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
   </ContextMenu.Content>
 </ContextMenu.Root>
-{#each tracklet.keyBoxes as keyBox}
-  {#if keyBox.is_key}
+{#each tracklet.boxes as box}
+  {#if box.is_key}
     <TrackletKeyBox
-      {keyBox}
+      {box}
       {color}
       {oneFrameInPixel}
       {onEditKeyBoxClick}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyBox.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyBox.svelte
@@ -23,7 +23,7 @@
 
   export let objectId: ItemObject["id"];
 
-  export let keyBox: VideoItemBBox;
+  export let box: VideoItemBBox;
   export let color: string;
   export let oneFrameInPixel: number;
   export let onEditKeyBoxClick: (keyBox: VideoItemBBox) => void;
@@ -37,7 +37,7 @@
   $: {
     const currentObjectBeingEdited = $itemObjects.find((object) => object.displayControl?.editing);
     isBoxBeingEdited =
-      keyBox.frame_index === $currentFrameIndex && currentObjectBeingEdited?.id === objectId;
+      box.frame_index === $currentFrameIndex && currentObjectBeingEdited?.id === objectId;
   }
 
   const onDeleteKeyBoxClick = (box: VideoItemBBox) => {
@@ -58,7 +58,7 @@
     node.addEventListener("mousedown", (event) => {
       moving = true;
       startPosition = event.clientX;
-      startFrameIndex = keyBox.frame_index;
+      startFrameIndex = box.frame_index;
       startOneFrameInPixel = oneFrameInPixel;
       selectedTool.set(panTool);
     });
@@ -68,7 +68,7 @@
         const distance = event.clientX - startPosition;
         const raise = distance / startOneFrameInPixel;
         const newFrameIndex = startFrameIndex + raise;
-        updateTrackletWidth(Math.round(newFrameIndex), keyBox.frame_index);
+        updateTrackletWidth(Math.round(newFrameIndex), box.frame_index);
       }
     });
 
@@ -85,16 +85,16 @@
       "hover:scale-150",
       { "bg-primary !border-primary": isBoxBeingEdited },
     )}
-    style={`left: ${getKeyBoxLeftPosition(keyBox)}%; border-color: ${color}`}
+    style={`left: ${getKeyBoxLeftPosition(box)}%; border-color: ${color}`}
   >
     <button class="h-full w-full" use:dragMe />
   </ContextMenu.Trigger>
   <ContextMenu.Content>
-    <ContextMenu.Item inset on:click={() => onDeleteKeyBoxClick(keyBox)}
+    <ContextMenu.Item inset on:click={() => onDeleteKeyBoxClick(box)}
       >Remove key box</ContextMenu.Item
     >
     {#if !isBoxBeingEdited}
-      <ContextMenu.Item inset on:click={() => onEditKeyBoxClick(keyBox)}>Edit box</ContextMenu.Item>
+      <ContextMenu.Item inset on:click={() => onEditKeyBoxClick(box)}>Edit box</ContextMenu.Item>
     {/if}
   </ContextMenu.Content>
 </ContextMenu.Root>

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
@@ -322,7 +322,7 @@ export const defineCreatedObject = (
           {
             start: currentFrameIndex,
             end: currentFrameIndex + 5,
-            keyBoxes: [
+            boxes: [
               { ...bbox, frame_index: currentFrameIndex, is_key: true, is_thumbnail: true },
               { ...bbox, frame_index: currentFrameIndex + 5, is_key: true },
             ],
@@ -376,9 +376,9 @@ export const highlightCurrentObject = (
 
 const findThumbnailBox = (track: Tracklet[]) => {
   const trackletWithThumbnail = track.find((tracklet) =>
-    tracklet.keyBoxes.some((box) => box.is_thumbnail),
+    tracklet.boxes.some((box) => box.is_thumbnail),
   );
-  const box = trackletWithThumbnail?.keyBoxes.find((box) => box.is_thumbnail);
+  const box = trackletWithThumbnail?.boxes.find((b) => b.is_thumbnail);
   return box;
 };
 

--- a/ui/tools/storybook/stories/components/workspaces/datasetItemWorkspaceMocks.ts
+++ b/ui/tools/storybook/stories/components/workspaces/datasetItemWorkspaceMocks.ts
@@ -5,6 +5,7 @@ import type {
   ItemView,
   Tracklet,
   VideoDatasetItem,
+  VideoItemBBox,
 } from "@pixano/core/src";
 import { datasetPreview, imgThumbnail } from "../../assets/base64image";
 import fleurs from "../../../assets/fleurs.jpg";
@@ -44,6 +45,7 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
   type: "image",
   id: "fleurs.jpg",
   split: "demo",
+  datasetId: "foo",
   features: {
     label: {
       name: "label",
@@ -59,8 +61,8 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
   views: {
     image: mockImage,
   },
-  objects: {
-    EZ4s6R0E_y: {
+  objects: [
+    {
       datasetItemType: "image",
       id: "EZ4s6R0E_y",
       item_id: "fleurs.jpg",
@@ -101,7 +103,7 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
         hidden: false,
       },
     },
-    QfNTSmYHmg: {
+    {
       datasetItemType: "image",
       id: "QfNTSmYHmg",
       item_id: "fleurs.jpg",
@@ -171,7 +173,7 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
         hidden: false,
       },
     },
-    tJA83zBeSh: {
+    {
       datasetItemType: "image",
       id: "tJA83zBeSh",
       item_id: "fleurs.jpg",
@@ -238,233 +240,234 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
         hidden: false,
       },
     },
-  },
+  ],
   embeddings: {},
 };
 
 export const mockedCurrentDataset: DatasetInfo = {
+  size: "25",
   id: "QSctnfM7Ek68M7w6tyNhHf",
   name: "demo_agriculture",
   description: "LIST Days - agriculture",
-  estimated_size: "681.31 KB",
+
   num_elements: 25,
-  splits: ["demo"],
-  tables: {
-    main: [
-      {
-        name: "db",
-        fields: {
-          id: "str",
-          views: "[str]",
-          split: "str",
-          label: "str",
-          category_name: "str",
-        },
-        source: "Pre-annotation",
-        type: undefined,
-      },
-    ],
-    media: [
-      {
-        name: "image",
-        fields: {
-          id: "str",
-          image: "image",
-        },
-        source: undefined,
-        type: undefined,
-      },
-    ],
-    embeddings: [
-      {
-        name: "emb_230602_141614_SAM_ViT_H",
-        fields: {
-          id: "str",
-          image: "bytes",
-        },
-        source: "SAM_ViT_H",
-        type: "segment",
-      },
-      {
-        name: "emb_231110_110736_CLIP",
-        fields: {
-          id: "str",
-          image: "vector(512)",
-        },
-        source: "CLIP",
-        type: "search",
-      },
-      {
-        name: "emb_231208_153758_SAM_ViT_B",
-        fields: {
-          id: "str",
-          image: "bytes",
-        },
-        source: "SAM_ViT_B",
-        type: "segment",
-      },
-    ],
-    objects: [
-      {
-        name: "obj_231208_163253_YOLOv5s",
-        fields: {
-          id: "str",
-          item_id: "str",
-          view_id: "str",
-          bbox: "bbox",
-          mask: "compressedrle",
-          category_id: "int",
-          category_name: "str",
-          review_state: "str",
-        },
-        source: "Pre-annotation",
-        type: undefined,
-      },
-      {
-        name: "obj_231208_163619_FasterRCNN_R50",
-        fields: {
-          id: "str",
-          item_id: "str",
-          view_id: "str",
-          bbox: "bbox",
-          mask: "compressedrle",
-          category_id: "int",
-          category_name: "str",
-          review_state: "str",
-        },
-        source: "Pre-annotation",
-        type: undefined,
-      },
-      {
-        name: "obj_231208_163854_FasterRCNN_R50",
-        fields: {
-          id: "str",
-          item_id: "str",
-          view_id: "str",
-          bbox: "bbox",
-          mask: "compressedrle",
-          category_id: "int",
-          category_name: "str",
-        },
-        source: "FasterRCNN_R50",
-        type: undefined,
-      },
-      {
-        name: "obj_annotator",
-        fields: {
-          id: "str",
-          item_id: "str",
-          view_id: "str",
-          bbox: "bbox",
-          mask: "compressedrle",
-          category_id: "int",
-          category_name: "str",
-        },
-        source: "Pixano Annotator",
-        type: undefined,
-      },
-      {
-        name: "objects",
-        fields: {
-          id: "str",
-          item_id: "str",
-          view_id: "str",
-          bbox: "bbox",
-          mask: "compressedrle",
-          category_name: "str",
-          category: "str",
-          review_state: "str",
-          category_id: "int",
-        },
-        source: "Ground Truth",
-        type: undefined,
-      },
-    ],
-  },
-  features_values: {
-    main: {
-      label: {
-        restricted: false,
-        values: ["arbre", "oranges", "poire", "None", "abeille", "printemps"],
-      },
-      category_name: { restricted: false, values: ["foo", "None"] },
-    },
-    objects: {
-      category_id: { restricted: false, values: [] },
-      category_name: {
-        restricted: false,
-        values: [
-          "toilet",
-          "chair",
-          "oranges",
-          "donut",
-          "bar",
-          "apple",
-          "dining table",
-          "pizza",
-          "refrigerator",
-          "None",
-          "potted plant",
-          "orange",
-          "bird",
-          "cake",
-          "sheep",
-          "salade",
-          "broccoli",
-          "olive",
-          "sandwich",
-          "oooo",
-          "banano",
-          "carrot",
-          "bowl",
-          "banana",
-          "carrotes",
-          "foo",
-          "choubidou",
-          "bottle",
-        ],
-      },
-      category: { restricted: false, values: ["vzfe", "front", "None", "seed", "foo", "bar"] },
-    },
-  },
+  // splits: ["demo"],
+  // tables: {
+  //   main: [
+  //     {
+  //       name: "db",
+  //       fields: {
+  //         id: "str",
+  //         views: "[str]",
+  //         split: "str",
+  //         label: "str",
+  //         category_name: "str",
+  //       },
+  //       source: "Pre-annotation",
+  //       type: undefined,
+  //     },
+  //   ],
+  //   media: [
+  //     {
+  //       name: "image",
+  //       fields: {
+  //         id: "str",
+  //         image: "image",
+  //       },
+  //       source: undefined,
+  //       type: undefined,
+  //     },
+  //   ],
+  //   embeddings: [
+  //     {
+  //       name: "emb_230602_141614_SAM_ViT_H",
+  //       fields: {
+  //         id: "str",
+  //         image: "bytes",
+  //       },
+  //       source: "SAM_ViT_H",
+  //       type: "segment",
+  //     },
+  //     {
+  //       name: "emb_231110_110736_CLIP",
+  //       fields: {
+  //         id: "str",
+  //         image: "vector(512)",
+  //       },
+  //       source: "CLIP",
+  //       type: "search",
+  //     },
+  //     {
+  //       name: "emb_231208_153758_SAM_ViT_B",
+  //       fields: {
+  //         id: "str",
+  //         image: "bytes",
+  //       },
+  //       source: "SAM_ViT_B",
+  //       type: "segment",
+  //     },
+  //   ],
+  //   objects: [
+  //     {
+  //       name: "obj_231208_163253_YOLOv5s",
+  //       fields: {
+  //         id: "str",
+  //         item_id: "str",
+  //         view_id: "str",
+  //         bbox: "bbox",
+  //         mask: "compressedrle",
+  //         category_id: "int",
+  //         category_name: "str",
+  //         review_state: "str",
+  //       },
+  //       source: "Pre-annotation",
+  //       type: undefined,
+  //     },
+  //     {
+  //       name: "obj_231208_163619_FasterRCNN_R50",
+  //       fields: {
+  //         id: "str",
+  //         item_id: "str",
+  //         view_id: "str",
+  //         bbox: "bbox",
+  //         mask: "compressedrle",
+  //         category_id: "int",
+  //         category_name: "str",
+  //         review_state: "str",
+  //       },
+  //       source: "Pre-annotation",
+  //       type: undefined,
+  //     },
+  //     {
+  //       name: "obj_231208_163854_FasterRCNN_R50",
+  //       fields: {
+  //         id: "str",
+  //         item_id: "str",
+  //         view_id: "str",
+  //         bbox: "bbox",
+  //         mask: "compressedrle",
+  //         category_id: "int",
+  //         category_name: "str",
+  //       },
+  //       source: "FasterRCNN_R50",
+  //       type: undefined,
+  //     },
+  //     {
+  //       name: "obj_annotator",
+  //       fields: {
+  //         id: "str",
+  //         item_id: "str",
+  //         view_id: "str",
+  //         bbox: "bbox",
+  //         mask: "compressedrle",
+  //         category_id: "int",
+  //         category_name: "str",
+  //       },
+  //       source: "Pixano Annotator",
+  //       type: undefined,
+  //     },
+  //     {
+  //       name: "objects",
+  //       fields: {
+  //         id: "str",
+  //         item_id: "str",
+  //         view_id: "str",
+  //         bbox: "bbox",
+  //         mask: "compressedrle",
+  //         category_name: "str",
+  //         category: "str",
+  //         review_state: "str",
+  //         category_id: "int",
+  //       },
+  //       source: "Ground Truth",
+  //       type: undefined,
+  //     },
+  //   ],
+  // },
+  // features_values: {
+  //   main: {
+  //     label: {
+  //       restricted: false,
+  //       values: ["arbre", "oranges", "poire", "None", "abeille", "printemps"],
+  //     },
+  //     category_name: { restricted: false, values: ["foo", "None"] },
+  //   },
+  //   objects: {
+  //     category_id: { restricted: false, values: [] },
+  //     category_name: {
+  //       restricted: false,
+  //       values: [
+  //         "toilet",
+  //         "chair",
+  //         "oranges",
+  //         "donut",
+  //         "bar",
+  //         "apple",
+  //         "dining table",
+  //         "pizza",
+  //         "refrigerator",
+  //         "None",
+  //         "potted plant",
+  //         "orange",
+  //         "bird",
+  //         "cake",
+  //         "sheep",
+  //         "salade",
+  //         "broccoli",
+  //         "olive",
+  //         "sandwich",
+  //         "oooo",
+  //         "banano",
+  //         "carrot",
+  //         "bowl",
+  //         "banana",
+  //         "carrotes",
+  //         "foo",
+  //         "choubidou",
+  //         "bottle",
+  //       ],
+  //     },
+  //     category: { restricted: false, values: ["vzfe", "front", "None", "seed", "foo", "bar"] },
+  //   },
+  // },
   preview: datasetPreview,
-  stats: [],
-  page: {
-    items: [
-      {
-        id: "fleurs.jpg",
-        type: "image",
-        split: "demo",
-        features: {
-          label: {
-            name: "label",
-            dtype: "str",
-            value: "printemps",
-          },
-          category_name: {
-            name: "category_name",
-            dtype: "str",
-            value: "foo",
-          },
-        },
-        views: {
-          image: {
-            id: "image",
-            type: "image",
-            uri: "data/demo_agriculture_broken/media/image/demo/fleurs.jpg",
-            thumbnail: imgThumbnail,
-            frame_number: undefined,
-            total_frames: undefined,
-            features: {},
-          },
-        },
-        objects: {},
-        embeddings: {},
-      },
-    ],
-    total: 25,
-  },
-  isErrored: false,
+  // stats: [],
+  // page: {
+  //   items: [
+  //     {
+  //       id: "fleurs.jpg",
+  //       type: "image",
+  //       split: "demo",
+  //       features: {
+  //         label: {
+  //           name: "label",
+  //           dtype: "str",
+  //           value: "printemps",
+  //         },
+  //         category_name: {
+  //           name: "category_name",
+  //           dtype: "str",
+  //           value: "foo",
+  //         },
+  //       },
+  //       views: {
+  //         image: {
+  //           id: "image",
+  //           type: "image",
+  //           uri: "data/demo_agriculture_broken/media/image/demo/fleurs.jpg",
+  //           thumbnail: imgThumbnail,
+  //           frame_number: undefined,
+  //           total_frames: undefined,
+  //           features: {},
+  //         },
+  //       },
+  //       objects: {},
+  //       embeddings: {},
+  //     },
+  //   ],
+  //   total: 25,
+  // },
+  // isErrored: false,
 };
 
 export const mockHandleSaveItem = (item: DatasetItem) => {
@@ -472,32 +475,32 @@ export const mockHandleSaveItem = (item: DatasetItem) => {
   return Promise.resolve();
 };
 
-const displayedBox = {
+const displayedBox: VideoItemBBox = {
   coords: [0.5362540535588254, 0.1909159114200253, 0.09993766916635072, 0.18671048750633337],
   format: "xywh",
   is_normalized: true,
   confidence: 1,
-  frameIndex: 1,
+  frame_index: 1,
 };
 
 const track: Tracklet[] = [
   {
     start: 0,
     end: 73,
-    keyBoxes: [
+    boxes: [
       {
         coords: [0.5362540535588254, 0.1909159114200253, 0.09993766916635072, 0.18671048750633337],
         format: "xywh",
         is_normalized: true,
         confidence: 1,
-        frameIndex: 0,
+        frame_index: 0,
       },
       {
         coords: [0.5914342337390056, 0.2693339921343171, 0.09993766916635072, 0.18671048750633337],
         format: "xywh",
         is_normalized: true,
         confidence: 1,
-        frameIndex: 73,
+        frame_index: 73,
       },
     ],
   },
@@ -507,6 +510,7 @@ export const mockedVideoDatasetItem: VideoDatasetItem = {
   id: "fleurs.jpg",
   type: "video",
   split: "demo",
+  datasetId: "",
   features: {
     label: {
       name: "label",
@@ -537,8 +541,8 @@ export const mockedVideoDatasetItem: VideoDatasetItem = {
       uri: image,
     })),
   },
-  objects: {
-    EZ4s6R0E_y: {
+  objects: [
+    {
       id: "EZ4s6R0E_y",
       datasetItemType: "video",
       track,
@@ -569,6 +573,6 @@ export const mockedVideoDatasetItem: VideoDatasetItem = {
         hidden: false,
       },
     },
-  },
+  ],
   embeddings: {},
 };

--- a/ui/tools/storybook/stories/components/workspaces/videoDatasetPayload.ts
+++ b/ui/tools/storybook/stories/components/workspaces/videoDatasetPayload.ts
@@ -48,7 +48,7 @@ export const videoDatasetItemPayload = {
         {
           start: 0, // number
           end: 10, // number
-          keyBoxes: [
+          boxes: [
             {
               coords: [0, 0, 100, 100], // [number, number, number, number]
               format: "xywh",


### PR DESCRIPTION
## Issue

For SequenceFrame, tracks:
keypoints was arbitrarily set to be first and last object of each tracklet.

## Description

Now keypoints info is stored in object (TrackObject) as a flag "is_key"
Also, renamed "keyBoxes" to "boxes"

TODO (other PR/commit): put TrackObject in Pixano types