### PR TITLE
feat: slide video inspector

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1006,12 +1006,11 @@
 </script>
 
 <div
-  class={cn("flex flex-col-reverse h-full bg-slate-800 transition-opacity duration-300 delay-100", {
+  class={cn("h-full bg-slate-800 transition-opacity duration-300 delay-100", {
     "opacity-0": !isReady,
   })}
   bind:this={stageContainer}
 >
-  <slot />
   <Stage
     bind:config={stageConfig}
     bind:handle={stage}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -33,9 +33,8 @@
     objectIdBeingEdited,
   } from "../../lib/stores/videoViewerStores";
 
-  import VideoInspector from "../VideoPlayer/VideoInspector.svelte";
-  import VideoControls from "../VideoPlayer/VideoControls.svelte";
   import { onMount } from "svelte";
+  import VideoInspector from "../VideoPlayer/VideoInspector.svelte";
   import { updateExistingObject } from "../../lib/api/objectsApi";
   import { editKeyBoxInTracklet, linearInterpolation } from "../../lib/api/videoApi";
 

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -45,6 +45,9 @@
   export let brightness: number;
   export let contrast: number;
 
+  let height = 250;
+  let expanding = false;
+
   let imagesPerView: Record<string, HTMLImageElement[]> = {};
 
   let imagesFilesUrls: Record<string, string[]> = Object.entries(selectedItem.views).reduce(
@@ -126,9 +129,29 @@
   }
 
   $: selectedTool.set($selectedTool);
+
+  const startExpand = () => {
+    expanding = true;
+  };
+
+  const stopExpand = () => {
+    expanding = false;
+  };
+
+  const expand = (e: MouseEvent) => {
+    if (expanding) {
+      height = document.body.scrollHeight - e.pageY;
+    }
+  };
 </script>
 
-<section class="pl-4 h-full w-full flex flex-col max-h-[calc(100vh-80px)]">
+<section
+  class="pl-4 h-full w-full flex flex-col max-h-[calc(100vh-80px)]"
+  on:mouseup={stopExpand}
+  on:mousemove={expand}
+  role="tab"
+  tabindex="0"
+>
   {#if isLoaded}
     <div class="overflow-hidden grow">
       <Canvas2D
@@ -143,11 +166,10 @@
         bind:selectedTool={$selectedTool}
         bind:currentAnn
         bind:newShape={$newShape}
-      >
-        <VideoControls {updateView} />
-      </Canvas2D>
+      />
     </div>
-    <div class="h-full grow max-h-[25%] overflow-hidden">
+    <button class="h-1 bg-primary-light cursor-row-resize w-full" on:mousedown={startExpand} />
+    <div class="h-full grow max-h-[25%] overflow-hidden" style={`max-height: ${height}px`}>
       <VideoInspector {updateView} />
     </div>
   {/if}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -57,7 +57,7 @@
     newFrameIndex: VideoItemBBox["frame_index"],
     draggedFrameIndex: VideoItemBBox["frame_index"],
   ) => {
-    const [prevFrameIndex, nextFrameIndex] = findNeighborKeyBoxes(tracklet, draggedFrameIndex);
+    const [prevFrameIndex, nextFrameIndex] = findNeighborKeyBoxes(tracklet, newFrameIndex);
     if (newFrameIndex <= prevFrameIndex || newFrameIndex >= nextFrameIndex) return;
     tracklet.keyBoxes = tracklet.keyBoxes.map((keyBox) => {
       if (keyBox.frame_index === draggedFrameIndex) {

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
@@ -13,7 +13,7 @@
    *
    * http://www.cecill.info
    */
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import { PlayIcon, PauseIcon } from "lucide-svelte";
   import { getCurrentImageTime } from "../../lib/api/videoApi";
   import {
@@ -27,11 +27,6 @@
   export let updateView: (frameIndex: number) => void;
 
   let currentTime: string;
-
-  onMount(() => {
-    updateView($currentFrameIndex);
-    videoControls.update((old) => ({ ...old, isLoaded: true }));
-  });
 
   onDestroy(() => {
     clearInterval($videoControls.intervalId);

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -19,14 +19,22 @@
   import ObjectTrack from "./ObjectTrack.svelte";
   import TimeTrack from "./TimeTrack.svelte";
   import VideoPlayerRow from "./VideoPlayerRow.svelte";
+  import VideoControls from "./VideoControls.svelte";
+
   import {
     currentFrameIndex,
     lastFrameIndex,
     videoControls,
   } from "../../lib/stores/videoViewerStores";
   import { SliderRoot } from "@pixano/core";
+  import { onMount } from "svelte";
 
   export let updateView: (frameIndex: number) => void;
+
+  onMount(() => {
+    updateView($currentFrameIndex);
+    videoControls.update((old) => ({ ...old, isLoaded: true }));
+  });
 
   const onTimeTrackClick = (index: number) => {
     currentFrameIndex.set(index);
@@ -51,18 +59,22 @@
       </VideoPlayerRow>
     </div>
     <div class="flex flex-col grow z-10">
-      <div class="grow">
-        {#each Object.values($itemObjects) as object}
-          {#if object.datasetItemType === "video"}
-            <VideoPlayerRow>
-              <ObjectTrack slot="timeTrack" {object} {onTimeTrackClick} {updateView} />
-            </VideoPlayerRow>
-          {/if}
-        {/each}
-      </div>
-      <div class="max-w-[200px] p-4 sticky bottom-0 left-0 z-20 bg-white shadow">
-        <SliderRoot bind:value={$videoControls.zoomLevel} min={100} max={$lastFrameIndex * 3} />
-      </div>
+      {#each Object.values($itemObjects) as object}
+        {#if object.datasetItemType === "video"}
+          <VideoPlayerRow>
+            <ObjectTrack slot="timeTrack" {object} {onTimeTrackClick} {updateView} />
+          </VideoPlayerRow>
+        {/if}
+      {/each}
+    </div>
+    <div class="px-2 sticky bottom-0 left-0 z-20 bg-white shadow flex justify-between">
+      <VideoControls {updateView} />
+      <SliderRoot
+        class="max-w-[200px]"
+        bind:value={$videoControls.zoomLevel}
+        min={100}
+        max={$lastFrameIndex * 3}
+      />
     </div>
   </div>
 {/if}


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #244 

## Description

<!--- A clear and concise description of the content of this pull request. -->

- moved video controls to the bottom
- video inspector size is draggable by hover over the gray separator, clicking and moving the mouse
 
<img width="885" alt="image" src="https://github.com/pixano/pixano/assets/105201321/3c22116a-86a9-49e3-a360-8df8e74be5c1">

