### PR TITLE
feat(back): track_objet native class

### DIFF
--- a/pixano/datasets/features/__init__.py
+++ b/pixano/datasets/features/__init__.py
@@ -25,6 +25,12 @@ from .schemas.object import (
 from .schemas.point_cloud import PointCloud
 from .schemas.registry import register_schema
 from .schemas.sequence_frame import SequenceFrame, is_sequence_frame
+from .schemas.track_object import (
+    TrackObject,
+    TrackObjectWithBBox,
+    TrackObjectWithBBoxAndMask,
+    TrackObjectWithMask,
+)
 from .schemas.tracklet import (
     Tracklet,
     TrackletWithTimestamp,
@@ -35,11 +41,10 @@ from .schemas.video import Video
 from .schemas.view import View
 from .types.bbox import BBox, is_bbox
 from .types.bbox3d import BBox3D
+from .types.camcalibration import CamCalibration
 from .types.compressed_rle import CompressedRLE
 from .types.keypoints import KeyPoints
 from .types.nd_array_float import NDArrayFloat
-from .types.camcalibration import CamCalibration
-
 
 __all__ = [
     "BaseSchema",
@@ -54,6 +59,10 @@ __all__ = [
     "ObjectWithBBox",
     "ObjectWithBBoxAndMask",
     "ObjectWithMask",
+    "TrackObject",
+    "TrackObjectWithBBox",
+    "TrackObjectWithBBoxAndMask",
+    "TrackObjectWithMask",
     "NDArrayFloat",
     "CamCalibration",
     "PointCloud",

--- a/pixano/datasets/features/schemas/track_object.py
+++ b/pixano/datasets/features/schemas/track_object.py
@@ -1,0 +1,44 @@
+# @Copyright: CEA-LIST/DIASI/SIALV/LVA (2024)
+# @Author: CEA-LIST/DIASI/SIALV/LVA <pixano@cea.fr>
+# @License: CECILL-C
+#
+# This software is a collaborative computer program whose purpose is to
+# generate and explore labeled data for computer vision applications.
+# This software is governed by the CeCILL-C license under French law and
+# abiding by the rules of distribution of free software. You can use,
+# modify and/ or redistribute the software under the terms of the CeCILL-C
+# license as circulated by CEA, CNRS and INRIA at the following URL
+#
+# http://www.cecill.info
+
+from pixano.datasets.features.schemas.registry import _register_schema_internal
+
+from .object import Object, ObjectWithBBox, ObjectWithBBoxAndMask, ObjectWithMask
+
+
+@_register_schema_internal
+class TrackObject(Object):
+    tracklet_id: str
+    is_key: bool
+    frame_idx: int
+
+
+@_register_schema_internal
+class TrackObjectWithBBox(ObjectWithBBox):
+    tracklet_id: str
+    is_key: bool
+    frame_idx: int
+
+
+@_register_schema_internal
+class TrackObjectWithMask(ObjectWithMask):
+    tracklet_id: str
+    is_key: bool
+    frame_idx: int
+
+
+@_register_schema_internal
+class TrackObjectWithBBoxAndMask(ObjectWithBBoxAndMask):
+    tracklet_id: str
+    is_key: bool
+    frame_idx: int

--- a/pixano/datasets/features/schemas/track_object.py
+++ b/pixano/datasets/features/schemas/track_object.py
@@ -24,21 +24,15 @@ class TrackObject(Object):
 
 
 @_register_schema_internal
-class TrackObjectWithBBox(ObjectWithBBox):
-    tracklet_id: str
-    is_key: bool
-    frame_idx: int
+class TrackObjectWithBBox(TrackObject, ObjectWithBBox):
+    pass
 
 
 @_register_schema_internal
-class TrackObjectWithMask(ObjectWithMask):
-    tracklet_id: str
-    is_key: bool
-    frame_idx: int
+class TrackObjectWithMask(TrackObject, ObjectWithMask):
+    pass
 
 
 @_register_schema_internal
-class TrackObjectWithBBoxAndMask(ObjectWithBBoxAndMask):
-    tracklet_id: str
-    is_key: bool
-    frame_idx: int
+class TrackObjectWithBBoxAndMask(TrackObject, ObjectWithBBoxAndMask):
+    pass


### PR DESCRIPTION
## Issue

TrackObject (TrackObjectWithBBox, TrackObjectWithMask, TrackObjectWithBBoxAndMask) must be native Pixano types as their fields are required

## Description

TrackObject classes in pixano.datasets.features.schemas
