### PR TITLE
None predefined types

### DIFF
--- a/pixano/datasets/features/types/bbox.py
+++ b/pixano/datasets/features/types/bbox.py
@@ -33,6 +33,12 @@ class BBox(pydantic.BaseModel):
     is_normalized: bool
     confidence: float
 
+    @staticmethod
+    def none():
+        return BBox(
+            coords=[0, 0, 0, 0], format="xywh", is_normalized=True, confidence=0
+        )
+
     @property
     def xyxy_coords(self) -> list[float]:
         """Return bounding box xyxy coordinates.

--- a/pixano/datasets/features/types/bbox3d.py
+++ b/pixano/datasets/features/types/bbox3d.py
@@ -29,3 +29,7 @@ class BBox3D(pydantic.BaseModel):
     position: list[float]
     size: list[float]
     heading: float  # TODO : use list[float] instead (need to adapt VDP dataset)
+
+    @staticmethod
+    def none():
+        return BBox3D(position=[0, 0, 0, 0, 0, 0], size=[0, 0, 0], heading=[0, 0, 0])

--- a/pixano/datasets/features/types/camcalibration.py
+++ b/pixano/datasets/features/types/camcalibration.py
@@ -49,7 +49,35 @@ class CamCalibration(pydantic.BaseModel):
         extrinsics (Extrinsics): extrinsics
         intrinsics (Intrinsics): intrinsics
     """
+
     type: str
     base_intrinsics: BaseIntrinsics
     extrinsics: Extrinsics
     intrinsics: Intrinsics
+
+    @staticmethod
+    def none():
+        return CamCalibration(
+            type="N/A",
+            base_intrinsics=BaseIntrinsics(
+                cx_offset_px=0.0,
+                cy_offset_px=0.0,
+                img_height_px=0,
+                img_width_px=0,
+            ),
+            extrinsics=Extrinsics(
+                pos_x_m=0.0,
+                pos_y_m=0.0,
+                pos_z_m=0.0,
+                rot_x_deg=0.0,
+                rot_z1_deg=0.0,
+                rot_z2_deg=0.0,
+            ),
+            intrinsics=Intrinsics(
+                c1=0.0,
+                c2=0.0,
+                c3=0.0,
+                c4=0.0,
+                pixel_aspect_ratio=0.0,
+            ),
+        )

--- a/pixano/datasets/features/types/compressed_rle.py
+++ b/pixano/datasets/features/types/compressed_rle.py
@@ -24,12 +24,16 @@ class CompressedRLE(pydantic.BaseModel):
     """Compressed RLE mask type.
 
     Attributes:
-        _size (list[int]): Mask size
-        _counts (bytes): Mask RLE encoding
+        size (list[int]): Mask size
+        counts (bytes): Mask RLE encoding
     """
 
     size: list[int]
     counts: bytes
+
+    @staticmethod
+    def none():
+        return CompressedRLE(size=[0, 0], counts=b'')
 
     def to_mask(self) -> np.ndarray:
         """Convert compressed RLE mask to NumPy array.

--- a/pixano/datasets/features/types/keypoints.py
+++ b/pixano/datasets/features/types/keypoints.py
@@ -21,17 +21,17 @@ class KeyPoints(pydantic.BaseModel):
     """A set of keypoints.
 
     Attributes:
+        template_id (str): id of keypoint template
         coords (list[float]): List of 2D coordinates of the keypoints.
-        edges (list[list[int]]): List of edges between keypoints.
+        # edges (list[list[int]]): List of edges between keypoints.
         visibles (list[bool]): List of visibility status for each keypoint.
     """
 
+    template_id: str
     coords: list[float]
-    edges: list[list[int]]
+    # edges: list[list[int]]
     visibles: list[bool]
 
-# class KeyPoints(pydantic.BaseModel):
-#     vertices: list[float]
-#     vertices_visibily: list[bool]
-#     # edges: list[list[int]]  # inclus dans type/template (?)
-#     type: str  # <-- refere à un pattern
+    @staticmethod
+    def none():
+        return KeyPoints(template_id="None", coords=[0, 0], visibles=[False])

--- a/pixano/datasets/features/types/nd_array_float.py
+++ b/pixano/datasets/features/types/nd_array_float.py
@@ -16,6 +16,10 @@ class NDArrayFloat(pydantic.BaseModel):
     values: list[float]
     shape: list[int]
 
+    @staticmethod
+    def none():
+        return NDArrayFloat(values=[0, 0], shape=[1, 1])
+
     @classmethod
     def from_numpy(cls, arr: np.ndarray) -> "NDArrayFloat":
         """Create an instance of the class from a NumPy array.


### PR DESCRIPTION
## Issue

LanceDB doesn't allows null values. (It should with Lance V2 format planned for september)

So in the meanwhile, we use empty types that we must detect/interpret as null values

## Description

Each Pixano base type has a "none()" static function to create this empty type, for convenience