### PR TITLE
feat(back): simplify Object and TrackObject

### DIFF
--- a/pixano/datasets/features/__init__.py
+++ b/pixano/datasets/features/__init__.py
@@ -15,22 +15,11 @@ from .schemas.base_schema import BaseSchema
 from .schemas.embedding import Embedding
 from .schemas.image import Image, is_image
 from .schemas.item import Item
-from .schemas.object import (
-    Object,
-    ObjectWithBBox,
-    ObjectWithBBoxAndMask,
-    ObjectWithMask,
-    is_object,
-)
+from .schemas.object import Object, is_object
 from .schemas.point_cloud import PointCloud
 from .schemas.registry import register_schema
 from .schemas.sequence_frame import SequenceFrame, is_sequence_frame
-from .schemas.track_object import (
-    TrackObject,
-    TrackObjectWithBBox,
-    TrackObjectWithBBoxAndMask,
-    TrackObjectWithMask,
-)
+from .schemas.track_object import TrackObject
 from .schemas.tracklet import (
     Tracklet,
     TrackletWithTimestamp,
@@ -56,13 +45,7 @@ __all__ = [
     "Image",
     "Item",
     "Object",
-    "ObjectWithBBox",
-    "ObjectWithBBoxAndMask",
-    "ObjectWithMask",
     "TrackObject",
-    "TrackObjectWithBBox",
-    "TrackObjectWithBBoxAndMask",
-    "TrackObjectWithMask",
     "NDArrayFloat",
     "CamCalibration",
     "PointCloud",

--- a/pixano/datasets/features/schemas/object.py
+++ b/pixano/datasets/features/schemas/object.py
@@ -24,28 +24,8 @@ class Object(BaseSchema):
 
     item_id: str
     view_id: str
-
-
-@_register_schema_internal
-class ObjectWithBBox(Object):
-    """Object with Bounding Box Lance Model."""
-
-    bbox: BBox
-
-
-@_register_schema_internal
-class ObjectWithMask(Object):
-    """Object with Mask Lance Model."""
-
-    mask: CompressedRLE
-
-
-@_register_schema_internal
-class ObjectWithBBoxAndMask(Object):
-    """Object with Bounding Box and Mask Lance Model."""
-
-    bbox: BBox
-    mask: CompressedRLE
+    bbox: BBox = BBox.none()
+    mask: CompressedRLE = CompressedRLE.none()
 
 
 def is_object(cls: type) -> bool:

--- a/pixano/datasets/features/schemas/track_object.py
+++ b/pixano/datasets/features/schemas/track_object.py
@@ -13,7 +13,7 @@
 
 from pixano.datasets.features.schemas.registry import _register_schema_internal
 
-from .object import Object, ObjectWithBBox, ObjectWithBBoxAndMask, ObjectWithMask
+from .object import Object
 
 
 @_register_schema_internal
@@ -21,18 +21,3 @@ class TrackObject(Object):
     tracklet_id: str
     is_key: bool
     frame_idx: int
-
-
-@_register_schema_internal
-class TrackObjectWithBBox(TrackObject, ObjectWithBBox):
-    pass
-
-
-@_register_schema_internal
-class TrackObjectWithMask(TrackObject, ObjectWithMask):
-    pass
-
-
-@_register_schema_internal
-class TrackObjectWithBBoxAndMask(TrackObject, ObjectWithBBoxAndMask):
-    pass

--- a/pixano/datasets/features/types/bbox.py
+++ b/pixano/datasets/features/types/bbox.py
@@ -36,7 +36,7 @@ class BBox(pydantic.BaseModel):
     @staticmethod
     def none():
         return BBox(
-            coords=[0, 0, 0, 0], format="xywh", is_normalized=True, confidence=0
+            coords=[0.0, 0.0, 0.0, 0.0], format="xywh", is_normalized=True, confidence=0
         )
 
     @property

--- a/pixano/datasets/features/types/compressed_rle.py
+++ b/pixano/datasets/features/types/compressed_rle.py
@@ -33,7 +33,7 @@ class CompressedRLE(pydantic.BaseModel):
 
     @staticmethod
     def none():
-        return CompressedRLE(size=[0, 0], counts=b'')
+        return CompressedRLE(size=[0.0, 0.0], counts=b'')
 
     def to_mask(self) -> np.ndarray:
         """Convert compressed RLE mask to NumPy array.


### PR DESCRIPTION
## Issue

Now that we can use "empty objects" to fake null values, we can avoid using ObjectWithBBox, ObjectWithMask, ...
We use Object, that has bbox and mask (and everything we could put), with empty values by default when not needed

Idem for TrackObject
