### PR TITLE
fix: Fix videos bugs 

### DIFF
--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -84,7 +84,6 @@
     handleSelectItem(selectedDataset, currentItemId);
     saveCurrentItemStore.update((old) => ({ ...old, shouldSave: false }));
   }
-  $: console.log({ selectedDataset, selectedItem });
 </script>
 
 {#if selectedItem && selectedDataset}

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -84,6 +84,7 @@
     handleSelectItem(selectedDataset, currentItemId);
     saveCurrentItemStore.update((old) => ({ ...old, shouldSave: false }));
   }
+  $: console.log({ selectedDataset, selectedItem });
 </script>
 
 {#if selectedItem && selectedDataset}
@@ -96,6 +97,7 @@
       isLoading={isLoadingNewItem}
       bind:canSaveCurrentItem
       {shouldSaveCurrentItem}
+      headerHeight={80}
     />
   </div>
 {/if}

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -80,7 +80,6 @@
 
   $: {
     if (canvasSize) {
-      console.log({ canvasSize });
       for (const viewId of Object.keys(imagesPerView)) {
         scaleView(viewId);
       }

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -61,6 +61,7 @@
   export let colorScale: (value: string) => string;
   export let brightness: number;
   export let contrast: number;
+  export let canvasSize: number = 0;
 
   let isReady = false;
 
@@ -75,6 +76,15 @@
       clearAnnotationAndInputs();
     }
     prevSelectedTool = selectedTool;
+  }
+
+  $: {
+    if (canvasSize) {
+      console.log({ canvasSize });
+      for (const viewId of Object.keys(imagesPerView)) {
+        scaleView(viewId);
+      }
+    }
   }
 
   $: {
@@ -208,7 +218,7 @@
   }
 
   function scaleView(viewId: ItemView["id"]) {
-    const viewLayer: Konva.Layer = stage.findOne(`#${viewId}`);
+    const viewLayer: Konva.Layer = stage?.findOne(`#${viewId}`);
     if (viewLayer) {
       // Calculate max dims for every image in the grid
       const maxWidth = stage.width() / gridSize.cols;

--- a/ui/components/canvas2d/src/components/Thumbnail.svelte
+++ b/ui/components/canvas2d/src/components/Thumbnail.svelte
@@ -20,8 +20,9 @@
   export let imageDimension: { width: number; height: number };
   export let coords: number[];
   export let imageUrl: string;
-  export let maxSize: number | undefined = undefined;
-  export let minSize: number | undefined = undefined;
+  export let maxHeight: number | undefined = undefined;
+  export let maxWidth: number | undefined = undefined;
+  export let minWidth: number | undefined = undefined;
 
   let [x, y, width, height] = coords;
 
@@ -34,23 +35,58 @@
   let stageHeight = height * imageDimension.height;
 
   $: {
-    if (maxSize && Math.max(stageWidth, stageHeight) > maxSize) {
-      const ratio = Math.max(stageWidth, stageHeight) / maxSize;
+    if (maxHeight && stageHeight > maxHeight) {
+      const ratio = stageHeight / maxHeight;
+      stageWidth /= ratio;
+      stageHeight /= ratio;
+    }
+    if (maxHeight && stageHeight < maxHeight) {
+      const ratio = maxHeight / stageHeight;
+      stageWidth *= ratio;
+      stageHeight *= ratio;
+    }
+    if (maxWidth && stageWidth > maxWidth) {
+      const ratio = stageWidth / maxWidth;
       stageWidth /= ratio;
       stageHeight /= ratio;
     }
   }
 
   $: {
-    if (minSize && Math.max(stageWidth, stageHeight) < minSize) {
-      const ratio = Math.max(stageWidth, stageHeight) / minSize;
+    if (minWidth && Math.max(stageWidth, stageHeight) < minWidth) {
+      const ratio = Math.max(stageWidth, stageHeight) / minWidth;
       stageWidth /= ratio;
       stageHeight /= ratio;
     }
   }
+
+  const defineCrop = () => {
+    let cropX = x * imageDimension.width - (width * imageDimension.width) / 2;
+    if (cropX < 0) {
+      cropX = 0;
+    }
+    let cropY = y * imageDimension.height;
+    if (cropY < 0) {
+      cropY = 0;
+    }
+    let cropWidth = width * imageDimension.width * 2;
+    if (cropWidth > imageDimension.width) {
+      cropWidth = imageDimension.width;
+    }
+    let cropHeight = height * imageDimension.height * 2;
+    if (cropHeight > imageDimension.height) {
+      cropHeight = imageDimension.height;
+    }
+    return {
+      x: cropX,
+      y: cropY,
+      width: cropWidth,
+      height: cropHeight,
+    };
+  };
 </script>
 
-<div class="w-fit z-40">
+<div class="w-full h-fit flex justify-center">
   <Stage
     bind:handle={stage}
     config={{
@@ -69,12 +105,7 @@
           height: stageHeight,
           image: img,
           id: "thumbnail-image",
-          crop: {
-            x: x * imageDimension.width - (width * imageDimension.width) / 2,
-            y: y * imageDimension.height - (height * imageDimension.height) / 2,
-            width: width * imageDimension.width * 2,
-            height: height * imageDimension.height * 2,
-          },
+          crop: { ...defineCrop() },
         }}
       />
     </Layer>

--- a/ui/components/canvas2d/src/components/Thumbnail.svelte
+++ b/ui/components/canvas2d/src/components/Thumbnail.svelte
@@ -65,7 +65,7 @@
     if (cropX < 0) {
       cropX = 0;
     }
-    let cropY = y * imageDimension.height;
+    let cropY = y * imageDimension.height - (height * imageDimension.height) / 2;
     if (cropY < 0) {
       cropY = 0;
     }

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -37,6 +37,7 @@
   export let isLoading: boolean;
   export let canSaveCurrentItem: boolean;
   export let shouldSaveCurrentItem: boolean;
+  export let headerHeight: number = 0;
 
   let isSaving: boolean = false;
   let brightness: number = 0;
@@ -101,7 +102,14 @@
     </div>
   {/if}
   <Toolbar />
-  <DatasetItemViewer {selectedItem} {embeddings} {isLoading} {brightness} {contrast} />
+  <DatasetItemViewer
+    {selectedItem}
+    {embeddings}
+    {isLoading}
+    {brightness}
+    {contrast}
+    {headerHeight}
+  />
   <Inspector on:click={onSave} {isLoading} bind:brightness bind:contrast />
   <LoadModelModal
     {models}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -34,6 +34,7 @@
   export let isLoading: boolean;
   export let brightness: number;
   export let contrast: number;
+  export let headerHeight: number;
 
   $: {
     if ($newShape?.status === "editing" && !$preAnnotationIsActive) {
@@ -48,7 +49,7 @@
   }
 </script>
 
-<div class="max-w-[100%] bg-slate-800">
+<div class="max-w-[100%] bg-slate-800" style={`max-height: calc(100vh - ${headerHeight}px)`}>
   {#if isLoading}
     <div class="h-full w-full flex justify-center items-center">
       <Loader2Icon class="animate-spin text-white" />

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -159,6 +159,7 @@
         colorScale={$colorScale[1]}
         bboxes={$itemBboxes}
         masks={$itemMasks}
+        canvasSize={inspectorMaxHeight}
         {embeddings}
         {brightness}
         {contrast}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -44,6 +44,12 @@
   export let brightness: number;
   export let contrast: number;
 
+  $: {
+    if (selectedItem) {
+      currentFrameIndex.set(0);
+    }
+  }
+
   let inspectorMaxHeight = 250;
   let expanding = false;
 

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -44,7 +44,7 @@
   export let brightness: number;
   export let contrast: number;
 
-  let height = 250;
+  let inspectorMaxHeight = 250;
   let expanding = false;
 
   let imagesPerView: Record<string, HTMLImageElement[]> = {};
@@ -139,13 +139,13 @@
 
   const expand = (e: MouseEvent) => {
     if (expanding) {
-      height = document.body.scrollHeight - e.pageY;
+      inspectorMaxHeight = document.body.scrollHeight - e.pageY;
     }
   };
 </script>
 
 <section
-  class="pl-4 h-full w-full flex flex-col max-h-[calc(100vh-80px)]"
+  class="pl-4 h-full w-full flex flex-col"
   on:mouseup={stopExpand}
   on:mousemove={expand}
   role="tab"
@@ -168,7 +168,10 @@
       />
     </div>
     <button class="h-1 bg-primary-light cursor-row-resize w-full" on:mousedown={startExpand} />
-    <div class="h-full grow max-h-[25%] overflow-hidden" style={`max-height: ${height}px`}>
+    <div
+      class="h-full grow max-h-[25%] overflow-hidden"
+      style={`max-height: ${inspectorMaxHeight}px`}
+    >
       <VideoInspector {updateView} />
     </div>
   {/if}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -198,7 +198,8 @@
               imageDimension={thumbnail.baseImageDimensions}
               coords={thumbnail.coords}
               imageUrl={`/${thumbnail.uri}`}
-              minSize={150}
+              minWidth={150}
+              maxWidth={300}
             />
           {/if}
         </div>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -83,7 +83,8 @@
             imageDimension={thumbnail.baseImageDimensions}
             coords={thumbnail.coords}
             imageUrl={`/${thumbnail.uri}`}
-            minSize={150}
+            maxHeight={150}
+            maxWidth={300}
           />
         {/key}
       {/if}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsModelSection.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsModelSection.svelte
@@ -46,24 +46,24 @@
     }
   });
 
-  $: itemObjects.update((items) => {
-    return items.map((item) => {
+  $: itemObjects.update((objects) => {
+    return objects.map((object) => {
       const isHidden = visibilityStatus === "hidden";
       if (modelName === GROUND_TRUTH) {
-        if (item.source_id === modelName) {
-          return toggleObjectDisplayControl(item, "hidden", ["bbox", "mask"], isHidden);
+        if (object.source_id === modelName) {
+          return toggleObjectDisplayControl(object, "hidden", ["bbox", "mask"], isHidden);
         } else {
-          return item;
+          return object;
         }
       }
-      if (!EXISTING_SOURCE_IDS.includes(item.source_id)) {
-        if (item.source_id === modelName) {
-          return toggleObjectDisplayControl(item, "hidden", ["bbox", "mask"], isHidden);
+      if (!EXISTING_SOURCE_IDS.includes(object.source_id)) {
+        if (object.source_id === modelName) {
+          return toggleObjectDisplayControl(object, "hidden", ["bbox", "mask"], isHidden);
         } else {
-          return toggleObjectDisplayControl(item, "hidden", ["bbox", "mask"], true);
+          return toggleObjectDisplayControl(object, "hidden", ["bbox", "mask"], true);
         }
       }
-      return item;
+      return object;
     });
   });
 

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -58,7 +58,7 @@
     draggedFrameIndex: VideoItemBBox["frame_index"],
   ) => {
     const [prevFrameIndex, nextFrameIndex] = findNeighborBoxes(tracklet, newFrameIndex);
-    if (newFrameIndex <= prevFrameIndex || newFrameIndex >= nextFrameIndex) return;
+    if (newFrameIndex < prevFrameIndex || newFrameIndex >= nextFrameIndex) return;
     tracklet.boxes = tracklet.boxes.map((box) => {
       if (box.frame_index === draggedFrameIndex) {
         box.frame_index = newFrameIndex;

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
@@ -152,9 +152,9 @@ export const toggleObjectDisplayControl = (
 
   // Check if the object is a VideoObject
   if (object.datasetItemType === "video") {
-    if (properties.includes("bbox") && object.displayControl) {
+    if (properties.includes("bbox")) {
       object.displayControl = {
-        ...object.displayControl,
+        ...(object.displayControl || {}),
         [displayControlProperty]: value,
       };
     }

--- a/ui/tools/storybook/stories/components/workspaces/VideoWorkspace.stories.ts
+++ b/ui/tools/storybook/stories/components/workspaces/VideoWorkspace.stories.ts
@@ -20,11 +20,7 @@ import DatasetItemWorkspace from "@pixano/dataset-item-workspace/src/DatasetItem
 import { interactiveSegmenterModel } from "@pixano/dataset-item-workspace/src/lib/stores/datasetItemWorkspaceStores";
 
 import { MockInteractiveImageSegmenter } from "./mocks";
-import {
-  mockedCurrentDataset,
-  mockHandleSaveItem,
-  mockedVideoDatasetItem,
-} from "./datasetItemWorkspaceMocks";
+import { mockHandleSaveItem, mockedVideoDatasetItem } from "./datasetItemWorkspaceMocks";
 
 type Story = StoryObj<typeof meta>;
 
@@ -48,7 +44,7 @@ export const BasicVideoWorkspace: Story = {
     shouldSaveCurrentItem: false,
     models: [],
     handleSaveItem: mockHandleSaveItem,
-    currentDataset: mockedCurrentDataset,
     selectedItem: mockedVideoDatasetItem,
+    featureValues: { main: {}, objects: {} },
   },
 };

--- a/ui/tools/storybook/stories/components/workspaces/datasetItemWorkspaceMocks.ts
+++ b/ui/tools/storybook/stories/components/workspaces/datasetItemWorkspaceMocks.ts
@@ -494,6 +494,8 @@ const track: Tracklet[] = [
         is_normalized: true,
         confidence: 1,
         frame_index: 0,
+        is_key: true,
+        is_thumbnail: true,
       },
       {
         coords: [0.5914342337390056, 0.2693339921343171, 0.09993766916635072, 0.18671048750633337],
@@ -501,6 +503,7 @@ const track: Tracklet[] = [
         is_normalized: true,
         confidence: 1,
         frame_index: 73,
+        is_key: true,
       },
     ],
   },
@@ -538,7 +541,8 @@ export const mockedVideoDatasetItem: VideoDatasetItem = {
           value: 338,
         },
       },
-      uri: image,
+      // remove first caracter of image
+      uri: image.slice(1),
     })),
   },
   objects: [
@@ -555,12 +559,12 @@ export const mockedVideoDatasetItem: VideoDatasetItem = {
         category_name: {
           name: "category_name",
           dtype: "str",
-          value: "Flower",
+          value: "Type",
         },
         category: {
           name: "category",
           dtype: "str",
-          value: "nature",
+          value: "Vehicle",
         },
         category_id: {
           name: "category_id",


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #267 

## Description
- improve thumbnail display
- play videos on storybook
- improve storybook display
- allow dragging tracklet to first frame
- resize image canvas when dragging video inspector size
- reset video to first frame when changing dataset item

