### PR TITLE
fix(back): better management of some data errors/specific cases

### DIFF
--- a/pixano/datasets/builders/dataset_builder.py
+++ b/pixano/datasets/builders/dataset_builder.py
@@ -86,9 +86,9 @@ class DatasetBuilder(ABC):
                 accumulate_tables = {table_name: [] for table_name in tables.keys()}
 
             for table_name, table in tables.items():
-                if table_name == "objects" and len(items[table_name]) == 0:
-                    continue
                 if table_name not in items:
+                    continue
+                if table_name == "objects" and len(items[table_name]) == 0:
                     continue
                 # checks for id format: must not contains whitespace (else we have bugs
                 # later...)


### PR DESCRIPTION
## Issue

Need to be more flexible for builders, to yield data as it goes.

## Description

- Allow to provide "incomplete" data (not all DatasetItem tables provided)
- Some additional checks on data and error management
- Corrected a check for media type (image/video) that could be wrong because Image is a subclass of SequenceFrame
- Manage timestep AND/OR timestamp for tracklets (there was only timestep)

- Add a check for track_id == '-1', that is often used to mark "broken" data, in order to skip it. **THIS CHECK IS SUBJECT TO REMOVAL**