### PR TITLE
feat(front) : Add an image smoothing toggle in settings

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -60,7 +60,7 @@
   export let selectedTool: SelectionTool;
   export let newShape: Shape;
   export let imagesPerView: Record<string, HTMLImageElement[]>;
-  export let imageSmoothing: Writable<boolean> = writable<boolean>(false);
+  export let imageSmoothing: boolean = false;
 
   let isReady = false;
 
@@ -1009,7 +1009,7 @@
   >
     {#each Object.entries(imagesPerView) as [viewId, images]}
       <Layer
-        config={{ id: viewId, imageSmoothingEnabled: $imageSmoothing }}
+        config={{ id: viewId, imageSmoothingEnabled: imageSmoothing }}
         on:wheel={(event) => handleWheelOnImage(event.detail.evt, viewId)}
       >
         {#each images as image}

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -59,7 +59,7 @@
   export let selectedTool: SelectionTool;
   export let newShape: Shape;
   export let imagesPerView: Record<string, HTMLImageElement[]>;
-  export let imageSmoothing: boolean = false;
+  export let imageSmoothing: boolean = true;
 
   let isReady = false;
 

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -20,6 +20,7 @@
   import { nanoid } from "nanoid";
   import { afterUpdate, onMount, onDestroy } from "svelte";
   import { Group, Image as KonvaImage, Layer, Stage } from "svelte-konva";
+  import { writable, type Writable } from "svelte/store";
 
   import { WarningModal, utils } from "@pixano/core";
   import { cn } from "@pixano/core/src";
@@ -59,6 +60,7 @@
   export let selectedTool: SelectionTool;
   export let newShape: Shape;
   export let imagesPerView: Record<string, HTMLImageElement[]>;
+  export let imageSmoothing: Writable<boolean> = writable<boolean>(false);
 
   let isReady = false;
 
@@ -1007,7 +1009,7 @@
   >
     {#each Object.entries(imagesPerView) as [viewId, images]}
       <Layer
-        config={{ id: viewId }}
+        config={{ id: viewId, imageSmoothingEnabled: $imageSmoothing }}
         on:wheel={(event) => handleWheelOnImage(event.detail.evt, viewId)}
       >
         {#each images as image}

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -20,7 +20,6 @@
   import { nanoid } from "nanoid";
   import { afterUpdate, onMount, onDestroy } from "svelte";
   import { Group, Image as KonvaImage, Layer, Stage } from "svelte-konva";
-  import { writable, type Writable } from "svelte/store";
 
   import { WarningModal, utils } from "@pixano/core";
   import { cn } from "@pixano/core/src";

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -55,7 +55,7 @@
     {imagesPerView}
     selectedItemId={selectedItem.id}
     {colorRange}
-    {imageSmoothing}
+    imageSmoothing={$imageSmoothing}
     bboxes={$itemBboxes}
     masks={$itemMasks}
     {embeddings}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -23,6 +23,7 @@
     itemBboxes,
     itemMasks,
     selectedTool,
+    imageSmoothing
   } from "../../lib/stores/datasetItemWorkspaceStores";
 
   export let selectedItem: ImageDatasetItem;
@@ -54,6 +55,7 @@
     {imagesPerView}
     selectedItemId={selectedItem.id}
     {colorRange}
+    {imageSmoothing}
     bboxes={$itemBboxes}
     masks={$itemMasks}
     {embeddings}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -23,7 +23,7 @@
     itemBboxes,
     itemMasks,
     selectedTool,
-    imageSmoothing
+    imageSmoothing,
   } from "../../lib/stores/datasetItemWorkspaceStores";
 
   export let selectedItem: ImageDatasetItem;

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -20,6 +20,7 @@
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
   import { Canvas2D } from "@pixano/canvas2d";
   import {
+    imageSmoothing,
     itemBboxes,
     itemMasks,
     itemObjects,
@@ -101,6 +102,7 @@
         selectedItemId={selectedItem.id}
         {imagesPerView}
         {colorRange}
+        {imageSmoothing}
         bboxes={$itemBboxes}
         masks={$itemMasks}
         {embeddings}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -102,7 +102,7 @@
         selectedItemId={selectedItem.id}
         {imagesPerView}
         {colorRange}
-        {imageSmoothing}
+        imageSmoothing={$imageSmoothing}
         bboxes={$itemBboxes}
         masks={$itemMasks}
         {embeddings}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
@@ -16,9 +16,9 @@
 
   import { Pencil } from "lucide-svelte";
 
-  import { IconButton, type ItemView } from "@pixano/core/src";
+  import { IconButton, Switch, type ItemView } from "@pixano/core/src";
 
-  import { canSave, itemMetas } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { canSave, imageSmoothing, itemMetas } from "../../lib/stores/datasetItemWorkspaceStores";
   import UpdateFeatureInputs from "../Features/UpdateFeatureInputs.svelte";
 
   import { createFeature } from "../../lib/api/featuresApi";
@@ -116,4 +116,13 @@
       </div>
     </div>
   {/each}
+</div>
+<div class="border-t-2 border-t-slate-500 p-4 pb-8 text-slate-800">
+  <h3 class="uppercase font-medium h-10">
+    <span>SETTINGS</span>
+  </h3>
+  <div class="mx-4 flex items-center justify-between">
+    <label for="smoothing" class="select-none cursor-pointer"> Image smoothing </label>
+    <Switch id="smoothing" bind:checked={$imageSmoothing} onChange={() => {}}></Switch>
+  </div>
 </div>

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -49,6 +49,7 @@ export const modelsStore = writable<ModelSelection>({
   currentModalOpen: "none",
   selectedModelName: "",
 });
+export const imageSmoothing = writable<boolean>(true);
 
 export const itemBboxes = derived([itemObjects, itemMetas], ([$itemObjects, $itemMetas]) =>
   $itemObjects.reduce((acc, object) => {


### PR DESCRIPTION
## Issue

Fixes #277 

## Description

Added an image smoothing toggle to improve the accuracy of visual representation for tasks that require precise pixel-level annotations.

The toggle can be found in the Scene tab of the inspector, it is enabled by default.

![image](https://github.com/pixano/pixano/assets/50866369/af6f2c82-015f-457b-b2a3-749059785296)
