### PR TITLE
feat(front): Improve Table component scrolling

### DIFF
--- a/ui/components/table/src/Table.svelte
+++ b/ui/components/table/src/Table.svelte
@@ -27,12 +27,11 @@
   import { createEventDispatcher } from "svelte";
   import { readable } from "svelte/store";
   import SortableList from "svelte-sortable-list";
-  import { createTable, Subscribe, Render, createRender } from "svelte-headless-table";
+  import { createTable, Subscribe, Render, DataBodyCell, type RenderConfig } from "svelte-headless-table";
   import { addColumnOrder, addHiddenColumns } from "svelte-headless-table/plugins";
 
   // Exports
   export let items: TableData;
-  console.log(items);
 
   // Add data into a readable store and create table object
   const data = readable(items.rows);
@@ -142,7 +141,7 @@
   </div>
 </div>
 <div
-  class="h-full w-full overflow-y-auto overflow-x-auto
+  class="h-[75vh] w-full overflow-y-auto overflow-x-auto
     rounded-sm bg-white border border-slate-300 shadow-sm shadow-slate-300 font-Montserrat"
 >
   <table {...$tableAttrs} class="table-auto z-0 w-full text-center text-base text-slate-800">
@@ -152,7 +151,7 @@
         <Subscribe rowAttrs={headerRow.attrs()} let:rowAttrs>
           <tr
             {...rowAttrs}
-            class="sticky top-0 z-10 bg-white shadow-sm shadow-slate-300 border-b border-b-slate-400"
+            class="sticky top-0 bg-white shadow-sm shadow-slate-300 border-b border-b-slate-400"
           >
             {#each headerRow.cells as cell (cell.id)}
               <Subscribe attrs={cell.attrs()} let:attrs>

--- a/ui/components/table/src/TableCell.ts
+++ b/ui/components/table/src/TableCell.ts
@@ -21,9 +21,12 @@ import NumberCell from "./TableCells/NumberCell.svelte";
 import BooleanCell from "./TableCells/BooleanCell.svelte";
 import TextCell from "./TableCells/TextCell.svelte";
 import { createRender } from "svelte-headless-table";
+import type { DatasetStat } from "@pixano/core";
+
+type cellType = string | number | boolean | DatasetStat;
 
 // Generic function to create render function for a given component
-const createRenderFunction = (Cell) => (value) => {
+const createRenderFunction = (Cell) => (value: { value: cellType }) => {
   return createRender(Cell, {
     value: value.value,
   });


### PR DESCRIPTION
## Issue

Fixes #31 

## Description

The Table component now scrolls with a sticky header for column names, rather than scroll the whole page.
Having the Table component fixed and scrollable allows the page navigation buttons below to be always accessible at a fixed point. This allows moving through large datasets quicker by clicking repeatedly on next or previous page buttons without having to scroll down each time.
![image](https://github.com/pixano/pixano/assets/50866369/4fda39fe-65ca-483b-bb42-cdb118d7b9d7)

