### PR TITLE
front save rework

### DIFF
--- a/pixano/datasets/dataset.py
+++ b/pixano/datasets/dataset.py
@@ -259,10 +259,17 @@ class Dataset:
 
     @overload
     def get_data(
-        self, table_name: str, ids: list[str] | None = None, limit: int | None = None, offset: int = 0
+        self,
+        table_name: str,
+        ids: list[str] | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        item_ids: list[str] | None = None,
     ) -> list[BaseSchema]: ...
     @overload
-    def get_data(self, table_name: str, ids: str, limit: int | None = None, offset: int = 0) -> BaseSchema | None: ...
+    def get_data(
+        self, table_name: str, ids: str, limit: int | None = None, offset: int = 0, item_ids: None = None
+    ) -> BaseSchema | None: ...
 
     def get_data(
         self,

--- a/pixano/datasets/features/schemas/annotations/camcalibration.py
+++ b/pixano/datasets/features/schemas/annotations/camcalibration.py
@@ -4,17 +4,20 @@
 # License: CECILL-C
 # =====================================
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import ConfigDict, model_validator
 from typing_extensions import Self
 
 from pixano.datasets.utils import issubclass_strict
 
+from ...types import BaseType
+from ...types.registry import _register_type_internal
 from ...types.schema_reference import EntityRef, ItemRef, ViewRef
 from ..registry import _register_schema_internal
-from .annotation import Annotation
+from . import Annotation
 
 
-class BaseIntrinsics(BaseModel):
+@_register_type_internal
+class BaseIntrinsics(BaseType):
     """BaseIntrinsics (TODO: description?).
 
     Attributes:
@@ -44,7 +47,8 @@ class BaseIntrinsics(BaseModel):
         return self
 
 
-class Intrinsics(BaseModel):
+@_register_type_internal
+class Intrinsics(BaseType):
     """Intrinsics (TODO: description?).
 
     Attributes:
@@ -76,7 +80,8 @@ class Intrinsics(BaseModel):
         return self
 
 
-class Extrinsics(BaseModel):
+@_register_type_internal
+class Extrinsics(BaseType):
     """Extrinsics (TODO: description?).
 
     Attributes:
@@ -197,6 +202,7 @@ def create_cam_calibration(
     item_ref: ItemRef = ItemRef.none(),
     view_ref: ViewRef = ViewRef.none(),
     entity_ref: EntityRef = EntityRef.none(),
+    validate: bool = True,
 ) -> CamCalibration:
     """Create a CamCalibration instance.
 
@@ -224,6 +230,7 @@ def create_cam_calibration(
         item_ref: Item reference.
         view_ref: View reference.
         entity_ref: Entity reference.
+        validate: set to False to skip pydantic validation. Defaults to True.
 
     Returns:
         The created `CamCalibration` instance.
@@ -290,35 +297,70 @@ def create_cam_calibration(
             "pixel_aspect_ratio must be defined but not both"
         )
     if any(not_none_field_conditions):
-        base_intrinsics = BaseIntrinsics(
-            cx_offset_px=cx_offset_px,
-            cy_offset_px=cy_offset_px,
-            img_height_px=img_height_px,
-            img_width_px=img_width_px,
-        )
-        extrinsics = Extrinsics(
-            pos_x_m=pos_x_m,
-            pos_y_m=pos_y_m,
-            pos_z_m=pos_z_m,
-            rot_x_deg=rot_x_deg,
-            rot_z1_deg=rot_z1_deg,
-            rot_z2_deg=rot_z2_deg,
-        )
-        intrinsics = Intrinsics(
-            c1=c1,
-            c2=c2,
-            c3=c3,
-            c4=c4,
-            pixel_aspect_ratio=pixel_aspect_ratio,
-        )
+        if validate:
+            base_intrinsics = BaseIntrinsics(
+                cx_offset_px=cx_offset_px,
+                cy_offset_px=cy_offset_px,
+                img_height_px=img_height_px,
+                img_width_px=img_width_px,
+            )
+            extrinsics = Extrinsics(
+                pos_x_m=pos_x_m,
+                pos_y_m=pos_y_m,
+                pos_z_m=pos_z_m,
+                rot_x_deg=rot_x_deg,
+                rot_z1_deg=rot_z1_deg,
+                rot_z2_deg=rot_z2_deg,
+            )
+            intrinsics = Intrinsics(
+                c1=c1,
+                c2=c2,
+                c3=c3,
+                c4=c4,
+                pixel_aspect_ratio=pixel_aspect_ratio,
+            )
+        else:
+            base_intrinsics = BaseIntrinsics.construct(
+                cx_offset_px=cx_offset_px,
+                cy_offset_px=cy_offset_px,
+                img_height_px=img_height_px,
+                img_width_px=img_width_px,
+            )
+            extrinsics = Extrinsics.construct(
+                pos_x_m=pos_x_m,
+                pos_y_m=pos_y_m,
+                pos_z_m=pos_z_m,
+                rot_x_deg=rot_x_deg,
+                rot_z1_deg=rot_z1_deg,
+                rot_z2_deg=rot_z2_deg,
+            )
+            intrinsics = Intrinsics.construct(
+                c1=c1,
+                c2=c2,
+                c3=c3,
+                c4=c4,
+                pixel_aspect_ratio=pixel_aspect_ratio,
+            )
 
-    return CamCalibration(
-        type=type,
-        base_intrinsics=base_intrinsics,
-        extrinsics=extrinsics,
-        intrinsics=intrinsics,
-        id=id,
-        item_ref=item_ref,
-        view_ref=view_ref,
-        entity_ref=entity_ref,
-    )
+    if validate:
+        return CamCalibration(
+            type=type,
+            base_intrinsics=base_intrinsics,
+            extrinsics=extrinsics,
+            intrinsics=intrinsics,
+            id=id,
+            item_ref=item_ref,
+            view_ref=view_ref,
+            entity_ref=entity_ref,
+        )
+    else:
+        return CamCalibration.construct(
+            type=type,
+            base_intrinsics=base_intrinsics,
+            extrinsics=extrinsics,
+            intrinsics=intrinsics,
+            id=id,
+            item_ref=item_ref,
+            view_ref=view_ref,
+            entity_ref=entity_ref,
+        )

--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { goto, beforeNavigate } from "$app/navigation";
+  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { ArrowLeftCircleIcon, ArrowRight, ArrowLeft, Loader2Icon } from "lucide-svelte";
 
@@ -114,6 +114,8 @@ License: CECILL-C
   //(pixano site internal navigation is already covered)
   //first one on browser refresh (for this one, we can't (?) customize the message)
   //second one on browser navigation (back/forward)
+  // parameter is given, but we don't need it -- if we don't take it, tslint warns...
+  // eslint-disable-next-line
   function preventUnsavedUnload(_: HTMLElement) {
     function checkNavigation(e: BeforeUnloadEvent) {
       if (canSaveCurrentItem) {
@@ -129,6 +131,8 @@ License: CECILL-C
   }
 
   // this one is bugged... disabled for now
+  // require:  import { beforeNavigate } from "$app/navigation";
+  //
   // beforeNavigate(({to, cancel}) => {
   //   if (to) {
   //     cancel();

--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -110,8 +110,6 @@ License: CECILL-C
     await goto(route);
   };
 
-
-
   //Note: the two following function aims to prevent losing unsaved changes after BROWSER actions
   //(pixano site internal navigation is already covered)
   //first one on browser refresh (for this one, we can't (?) customize the message)
@@ -142,10 +140,6 @@ License: CECILL-C
   //   //   cancel()
   //   // }
   // });
-
-
-
-
 </script>
 
 <header class="w-full fixed z-40 font-Montserrat">

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -7,7 +7,12 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { page } from "$app/stores";
-  import { type DatasetItem, type DatasetInfo, type DatasetItemSave, PrimaryButton } from "@pixano/core/src";
+  import {
+    type DatasetItem,
+    type DatasetInfo,
+    type DatasetItemSave,
+    PrimaryButton,
+  } from "@pixano/core/src";
   import DatasetItemWorkspace from "@pixano/dataset-item-workspace/src/DatasetItemWorkspace.svelte";
   import { api } from "@pixano/core/src";
   import {

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -7,7 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { page } from "$app/stores";
-  import { type DatasetItem, type DatasetInfo, PrimaryButton } from "@pixano/core/src";
+  import { type DatasetItem, type DatasetInfo, type DatasetItemSave, PrimaryButton } from "@pixano/core/src";
   import DatasetItemWorkspace from "@pixano/dataset-item-workspace/src/DatasetItemWorkspace.svelte";
   import { api } from "@pixano/core/src";
   import {
@@ -78,7 +78,7 @@ License: CECILL-C
     isLoadingNewItem = value;
   });
 
-  async function handleSaveItem(savedItem: DatasetItem) {
+  async function handleSaveItem(savedItem: DatasetItemSave) {
     await api.postDatasetItem(selectedDataset.id, savedItem);
     handleSelectItem(selectedDataset, currentItemId);
     saveCurrentItemStore.update((old) => ({ ...old, shouldSave: false }));

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -634,13 +634,13 @@ License: CECILL-C
       const viewLayer: Konva.Layer = stage.findOne(`#${viewId}`);
 
       const pos = viewLayer.getRelativePointerPosition();
-      const x = newShape.status === "creating" && newShape.type === "keypoint" ? newShape.x : pos.x;
-      const y = newShape.status === "creating" && newShape.type === "keypoint" ? newShape.y : pos.y;
+      const x = newShape.status === "creating" && newShape.type === "keypoints" ? newShape.x : pos.x;
+      const y = newShape.status === "creating" && newShape.type === "keypoints" ? newShape.y : pos.y;
       const width = pos.x - x;
       const height = pos.y - y;
       newShape = {
         status: "creating",
-        type: "keypoint",
+        type: "keypoints",
         x,
         y,
         width,
@@ -655,9 +655,9 @@ License: CECILL-C
     if (selectedTool?.type == "KEY_POINT") {
       const viewLayer: Konva.Layer = stage.findOne(`#${viewId}`);
       const rect: Konva.Rect = stage.findOne("#move-keyPoints-group");
-      if (rect && newShape.status === "creating" && newShape.type === "keypoint") {
+      if (rect && newShape.status === "creating" && newShape.type === "keypoints") {
         const vertices = newShape.keypoints.vertices.map((vertex) => {
-          if (newShape.status === "creating" && newShape.type === "keypoint")
+          if (newShape.status === "creating" && newShape.type === "keypoints")
             return {
               ...vertex,
               x: newShape.x + vertex.x * newShape.width,
@@ -666,7 +666,7 @@ License: CECILL-C
         });
         newShape = {
           status: "saving",
-          type: "keypoint",
+          type: "keypoints",
           viewId,
           itemId: selectedItemId,
           imageWidth: getCurrentImage(viewId).width,
@@ -930,13 +930,11 @@ License: CECILL-C
       const viewLayer: Konva.Layer = stage.findOne(`#${viewId}`);
 
       const pos = viewLayer.getRelativePointerPosition();
-      const x =
-        newShape.status === "creating" && newShape.type === "rectangle" ? newShape.x : pos.x;
-      const y =
-        newShape.status === "creating" && newShape.type === "rectangle" ? newShape.y : pos.y;
+      const x = newShape.status === "creating" && newShape.type === "bbox" ? newShape.x : pos.x;
+      const y = newShape.status === "creating" && newShape.type === "bbox" ? newShape.y : pos.y;
       newShape = {
         status: "creating",
-        type: "rectangle",
+        type: "bbox",
         x,
         y,
         width: pos.x - x,
@@ -971,7 +969,7 @@ License: CECILL-C
                 width: correctedRect.width,
                 height: correctedRect.height,
               },
-              type: "rectangle",
+              type: "bbox",
               viewId,
               itemId: selectedItemId,
               imageWidth: getCurrentImage(viewId).width,
@@ -1218,6 +1216,7 @@ License: CECILL-C
       console.log("Canvas2D - Infos");
       console.log("masks", masks);
       console.log("bboxes", bboxes);
+      console.log("keypoints", keypoints);
       console.log("currentAnn", currentAnn);
       console.log("stage", stage);
       for (const viewId of Object.keys(imagesPerView)) {
@@ -1266,7 +1265,7 @@ License: CECILL-C
         <Group config={{ id: "currentAnnotation" }} />
         <Group config={{ id: "input" }} />
         <Group config={{ id: "bboxes" }}>
-          {#if (newShape.status === "creating" && newShape.type === "rectangle") || (newShape.status === "saving" && newShape.type === "rectangle")}
+          {#if (newShape.status === "creating" && newShape.type === "bbox") || (newShape.status === "saving" && newShape.type === "bbox")}
             <CreateRectangle zoomFactor={zoomFactor[viewId]} {newShape} {stage} {viewId} />
           {/if}
           {#each bboxes as bbox}
@@ -1308,7 +1307,7 @@ License: CECILL-C
           {/each}
         </Group>
         <Group config={{ id: "keypoints" }}>
-          {#if (newShape.status === "creating" && newShape.type === "keypoint") || (newShape.status === "saving" && newShape.type === "keypoint")}
+          {#if (newShape.status === "creating" && newShape.type === "keypoints") || (newShape.status === "saving" && newShape.type === "keypoints")}
             <CreateKeypoint zoomFactor={zoomFactor[viewId]} bind:newShape {stage} {viewId} />
           {/if}
           <ShowKeypoints

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -634,8 +634,10 @@ License: CECILL-C
       const viewLayer: Konva.Layer = stage.findOne(`#${viewId}`);
 
       const pos = viewLayer.getRelativePointerPosition();
-      const x = newShape.status === "creating" && newShape.type === "keypoints" ? newShape.x : pos.x;
-      const y = newShape.status === "creating" && newShape.type === "keypoints" ? newShape.y : pos.y;
+      const x =
+        newShape.status === "creating" && newShape.type === "keypoints" ? newShape.x : pos.x;
+      const y =
+        newShape.status === "creating" && newShape.type === "keypoints" ? newShape.y : pos.y;
       const width = pos.x - x;
       const height = pos.y - y;
       newShape = {

--- a/ui/components/canvas2d/src/components/Rectangle.svelte
+++ b/ui/components/canvas2d/src/components/Rectangle.svelte
@@ -34,7 +34,7 @@ License: CECILL-C
     const coords = getNewRectangleDimensions(rect, stage, viewId);
     newShape = {
       status: "editing",
-      type: "rectangle",
+      type: "bbox",
       shapeId: bbox.id,
       viewId,
       coords,

--- a/ui/components/canvas2d/src/components/ShowKeypoint.svelte
+++ b/ui/components/canvas2d/src/components/ShowKeypoint.svelte
@@ -40,7 +40,7 @@ License: CECILL-C
     }));
     newShape = {
       status: "editing",
-      type: "keypoint",
+      type: "keypoints",
       vertices: normalizedVertices,
       shapeId: id,
       viewId,

--- a/ui/components/core/src/api.ts
+++ b/ui/components/core/src/api.ts
@@ -9,6 +9,7 @@ import type {
   DatasetInfo,
   DatasetItems,
   DatasetItem,
+  DatasetItemSave,
   ExplorerData,
 } from "./lib/types/datasetTypes";
 
@@ -175,7 +176,7 @@ export async function getItemEmbeddings(
   return item;
 }
 
-export async function postDatasetItem(datasetId: string, item: DatasetItem) {
+export async function postDatasetItem(datasetId: string, item: DatasetItemSave) {
   try {
     const response = await fetch(`/datasets/${datasetId}/items/${item.id}`, {
       headers: {

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -118,7 +118,7 @@ export type DatasetItemSave = {
   split: string;
   item_features: Record<string, ItemFeature>;
   save_data: SaveItem[];
-}
+};
 
 export interface DatasetItems {
   items: Array<DatasetItem>;
@@ -171,14 +171,33 @@ export type TrackletItem = {
   hidden?: boolean;
 };
 
-export interface SaveItem {
-  change_type: "add_or_update" | "delete";
+export interface SaveItemAddUpdate {
+  change_type: "add_or_update";
   ref_name: string;
   is_video: boolean;
-  data: (Record<string, string[]> | ItemBBox | VideoItemBBox | Keypoints | VideoKeypoints | ItemRLE | Tracklet | ItemObjectBase) & {
-    entity_ref?: Record<string, string>
+  data: (
+    | ItemBBox
+    | VideoItemBBox
+    | Keypoints
+    | VideoKeypoints
+    | ItemRLE
+    | Tracklet
+    | ItemObjectBase
+  ) & {
+    entity_ref?: Record<string, string>;
   };
 }
+
+export interface SaveItemDelete {
+  change_type: "delete";
+  ref_name: string;
+  is_video: boolean;
+  data: Record<string, string[]> & {
+    entity_ref?: Record<string, string>;
+  };
+}
+
+export type SaveItem = SaveItemAddUpdate | SaveItemDelete;
 
 export type VideoItemBBox = ItemBBox & TrackletItem;
 export type VideoKeypoints = Keypoints & TrackletItem;

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -113,6 +113,13 @@ export type ThreeDimensionsDatasetItem = BaseDatasetItem & {
 
 export type DatasetItem = ImageDatasetItem | VideoDatasetItem | ThreeDimensionsDatasetItem;
 
+export type DatasetItemSave = {
+  id: string;
+  split: string;
+  item_features: Record<string, ItemFeature>;
+  save_data: SaveItem[];
+}
+
 export interface DatasetItems {
   items: Array<DatasetItem>;
   total: number;
@@ -164,6 +171,15 @@ export type TrackletItem = {
   hidden?: boolean;
 };
 
+export interface SaveItem {
+  change_type: "add_or_update" | "delete";
+  ref_name: string;
+  is_video: boolean;
+  data: (Record<string, string[]> | ItemBBox | VideoItemBBox | Keypoints | VideoKeypoints | ItemRLE | Tracklet | ItemObjectBase) & {
+    entity_ref?: Record<string, string>
+  };
+}
+
 export type VideoItemBBox = ItemBBox & TrackletItem;
 export type VideoKeypoints = Keypoints & TrackletItem;
 export interface Tracklet {
@@ -196,6 +212,8 @@ export type ImageObject = ItemObjectBase & {
 export type ItemObject = ImageObject | VideoObject;
 
 export interface ItemRLE {
+  id: string;
+  ref_name: string;
   view_id?: string;
   counts: Array<number>;
   size: Array<number>;
@@ -203,6 +221,8 @@ export interface ItemRLE {
 }
 
 export interface ItemBBox {
+  id: string;
+  ref_name: string;
   view_id?: string;
   coords: Array<number>;
   format: string;

--- a/ui/components/core/src/lib/types/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/datasetTypes.ts
@@ -171,19 +171,20 @@ export type TrackletItem = {
   hidden?: boolean;
 };
 
+export type SaveDataAddUpdate =
+  | ItemBBox
+  | VideoItemBBox
+  | Keypoints
+  | VideoKeypoints
+  | ItemRLE
+  | Tracklet
+  | ItemObjectBase;
+
 export interface SaveItemAddUpdate {
   change_type: "add_or_update";
   ref_name: string;
   is_video: boolean;
-  data: (
-    | ItemBBox
-    | VideoItemBBox
-    | Keypoints
-    | VideoKeypoints
-    | ItemRLE
-    | Tracklet
-    | ItemObjectBase
-  ) & {
+  data: SaveDataAddUpdate & {
     entity_ref?: Record<string, string>;
   };
 }

--- a/ui/components/core/src/lib/types/objectTypes.ts
+++ b/ui/components/core/src/lib/types/objectTypes.ts
@@ -23,12 +23,12 @@ export type SaveShapeBase = {
 };
 
 export type SaveKeyBoxShape = SaveShapeBase & {
-  type: "keypoint";
+  type: "keypoints";
   keypoints: KeypointsTemplate;
 };
 
 export type SaveRectangleShape = SaveShapeBase & {
-  type: "rectangle";
+  type: "bbox";
   attrs: {
     x: number;
     y: number;
@@ -68,6 +68,7 @@ export type Vertex = {
 };
 
 export type Keypoints = {
+  id: string;
   view_id?: string;
   template_id: string;
   vertices: Vertex[];
@@ -87,7 +88,7 @@ export type KeypointsTemplate = {
 
 export type CreateKeypointShape = {
   status: "creating";
-  type: "keypoint";
+  type: "keypoints";
   viewId: string;
   x: number;
   y: number;
@@ -105,7 +106,7 @@ export type CreateMaskShape = {
 
 export type CreateRectangleShape = {
   status: "creating";
-  type: "rectangle";
+  type: "bbox";
   x: number;
   y: number;
   width: number;
@@ -121,12 +122,12 @@ export type EditMaskShape = {
 };
 
 export type EditRectangleShape = {
-  type: "rectangle";
+  type: "bbox";
   coords: number[];
 };
 
 export type EditKeypointsShape = {
-  type: "keypoint";
+  type: "keypoints";
   vertices: KeypointsTemplate["vertices"];
 };
 

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -73,8 +73,8 @@ License: CECILL-C
       id: selectedItem.id,
       split: selectedItem.split,
       save_data: $saveData,
-      item_features: $itemMetas.mainFeatures
-    }
+      item_features: $itemMetas.mainFeatures,
+    };
     await handleSaveItem(savedItem);
     saveData.set([]);
     canSave.set(false);

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import type { ItemObject, DatasetItem, FeaturesValues } from "@pixano/core";
+  import type { ItemObject, DatasetItem, FeaturesValues, DatasetItemSave } from "@pixano/core";
 
   import Toolbar from "./components/Toolbar.svelte";
   import Inspector from "./components/Inspector/InspectorInspector.svelte";
@@ -16,6 +16,7 @@ License: CECILL-C
     itemMetas,
     newShape,
     canSave,
+    saveData,
   } from "./lib/stores/datasetItemWorkspaceStores";
   import "./index.css";
   import type { Embeddings } from "./lib/types/datasetItemWorkspaceTypes";
@@ -25,7 +26,7 @@ License: CECILL-C
   export let featureValues: FeaturesValues;
   export let selectedItem: DatasetItem;
   export let models: string[] = [];
-  export let handleSaveItem: (item: DatasetItem) => Promise<void>;
+  export let handleSaveItem: (item: DatasetItemSave) => Promise<void>;
   export let isLoading: boolean;
   export let canSaveCurrentItem: boolean;
   export let shouldSaveCurrentItem: boolean;
@@ -64,15 +65,18 @@ License: CECILL-C
     }
   }
 
+  //$: console.log("Change in SaveData", $saveData);
+
   const onSave = async () => {
     isSaving = true;
-    const objects = $itemObjects;
-    let savedItem = { ...selectedItem, objects } as DatasetItem;
-
-    itemMetas.subscribe((value) => {
-      savedItem.features = value.mainFeatures;
-    });
+    const savedItem: DatasetItemSave = {
+      id: selectedItem.id,
+      split: selectedItem.split,
+      save_data: $saveData,
+      item_features: $itemMetas.mainFeatures
+    }
     await handleSaveItem(savedItem);
+    saveData.set([]);
     canSave.set(false);
     isSaving = false;
   };

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -206,7 +206,7 @@ License: CECILL-C
         $objectIdBeingEdited,
       );
       $itemObjects = objects;
-      saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_data));
+      if (save_data) saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_data));
       newShape.set({ status: "none" });
     } else {
       itemObjects.update((objects) => updateExistingObject(objects, shape));

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -26,6 +26,7 @@ License: CECILL-C
     itemKeypoints,
     selectedKeypointsTemplate,
     imageSmoothing,
+    saveData,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     lastFrameIndex,
@@ -35,7 +36,7 @@ License: CECILL-C
 
   import { onMount } from "svelte";
   import VideoInspector from "../VideoPlayer/VideoInspector.svelte";
-  import { updateExistingObject } from "../../lib/api/objectsApi";
+  import { updateExistingObject, addOrUpdateSaveItem } from "../../lib/api/objectsApi";
   import {
     boxLinearInterpolation,
     editKeyItemInTracklet,
@@ -197,10 +198,15 @@ License: CECILL-C
 
   const updateOrCreateBox = (shape: EditShape) => {
     const currentFrame = $currentFrameIndex;
-    if (shape.type === "rectangle" || shape.type === "keypoint") {
-      itemObjects.update((objects) =>
-        editKeyItemInTracklet(objects, shape, currentFrame, $objectIdBeingEdited),
+    if (shape.type === "bbox" || shape.type === "keypoints") {
+      let { objects, save_data } = editKeyItemInTracklet(
+        $itemObjects,
+        shape,
+        currentFrame,
+        $objectIdBeingEdited,
       );
+      $itemObjects = objects;
+      saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_data));
       newShape.set({ status: "none" });
     } else {
       itemObjects.update((objects) => updateExistingObject(objects, shape));

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -10,10 +10,11 @@ License: CECILL-C
 
   import { cn, IconButton, Checkbox } from "@pixano/core/src";
   import { Thumbnail } from "@pixano/canvas2d";
-  import type { DisplayControl, ItemObject, ObjectThumbnail } from "@pixano/core";
+  import type { DisplayControl, ItemObject, ObjectThumbnail, SaveItem } from "@pixano/core";
 
   import {
     canSave,
+    saveData,
     itemObjects,
     selectedTool,
     colorScale,
@@ -26,10 +27,12 @@ License: CECILL-C
     defineObjectThumbnail,
   } from "../../lib/api/objectsApi";
   import { createFeature } from "../../lib/api/featuresApi";
+  import { addOrUpdateSaveItem } from "../../lib/api/objectsApi";
 
   import UpdateFeatureInputs from "../Features/UpdateFeatureInputs.svelte";
   import { panTool } from "../../lib/settings/selectionTools";
   import { objectIdBeingEdited } from "../../lib/stores/videoViewerStores";
+  import { Item } from "@pixano/core/src/components/ui/command";
 
   export let itemObject: ItemObject;
 
@@ -74,10 +77,40 @@ License: CECILL-C
 
   const deleteObject = () => {
     itemObjects.update((oldObjects) => oldObjects.filter((object) => object.id !== itemObject.id));
+    let del_ids: Record<string, string[]> = {};
+    if (itemObject.datasetItemType === "video") {
+      if (itemObject.keypoints) {
+        del_ids["keypoints"] = itemObject.keypoints.map((kpt) => kpt.id);
+      }
+      if (itemObject.boxes) {
+        del_ids["bbox"] = itemObject.boxes.map((box) => box.id);
+      }
+      del_ids["tracklet"] = itemObject.track.map((tracklet) => tracklet.id);
+      del_ids["top_entity"] = [itemObject.id];
+    } else {
+      if (itemObject.keypoints) {
+        del_ids["keypoints"] = [itemObject.keypoints.id];
+      }
+      if (itemObject.bbox) {
+        del_ids["bbox"] = [itemObject.bbox.id];
+      }
+      if (itemObject.mask) {
+        del_ids["mask"] = [itemObject.mask.id];
+      }
+      del_ids["top_entity"] = [itemObject.id];
+    }
+    const save_item: SaveItem = {
+      change_type: "delete",
+      ref_name: "", //don't need
+      is_video: itemObject.datasetItemType === "video",
+      data: del_ids,
+    };
+    saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
     canSave.set(true);
   };
 
   const saveInputChange = (value: string | boolean | number, propertyName: string) => {
+    let changedObj = false;
     itemObjects.update((oldObjects) =>
       oldObjects.map((object) => {
         if (object.id === itemObject.id) {
@@ -88,11 +121,27 @@ License: CECILL-C
               value,
             },
           };
+          const save_item: SaveItem = {
+            change_type: "add_or_update",
+            ref_name: "top_entity",
+            is_video: itemObject.datasetItemType === "video",
+            data: {
+              id: object.id,
+              item_id: object.item_id,
+              source_id: object.source_id,
+              features: object.features,
+              ref_name: "top_entity",
+              entity_ref: { id: "", name: "" },
+            },
+          };
+          saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
         }
         return object;
       }),
     );
-    canSave.set(true);
+    if (changedObj) {
+      canSave.set(true);
+    }
   };
 
   const onColoredDotClick = () =>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -32,7 +32,6 @@ License: CECILL-C
   import UpdateFeatureInputs from "../Features/UpdateFeatureInputs.svelte";
   import { panTool } from "../../lib/settings/selectionTools";
   import { objectIdBeingEdited } from "../../lib/stores/videoViewerStores";
-  import { Item } from "@pixano/core/src/components/ui/command";
 
   export let itemObject: ItemObject;
 
@@ -135,6 +134,7 @@ License: CECILL-C
             },
           };
           saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+          changedObj = true;
         }
         return object;
       }),

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
@@ -82,7 +82,7 @@ License: CECILL-C
       };
       return newMetas;
     });
-    $canSave = true;
+    canSave.set(true);
   };
 </script>
 

--- a/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -8,13 +8,14 @@ License: CECILL-C
   // Imports
   import { Button } from "@pixano/core/src";
 
-  import type { ItemObject, Shape } from "@pixano/core";
+  import type { ItemObject, Shape, SaveItem } from "@pixano/core";
 
   import {
     newShape,
     itemObjects,
     itemMetas,
     canSave,
+    saveData,
   } from "../../lib/stores/datasetItemWorkspaceStores";
 
   import type {
@@ -24,7 +25,7 @@ License: CECILL-C
   import { mapShapeInputsToFeatures, addNewInput } from "../../lib/api/featuresApi";
   import CreateFeatureInputs from "../Features/CreateFeatureInputs.svelte";
   import { currentFrameIndex, objectIdBeingEdited } from "../../lib/stores/videoViewerStores";
-  import { defineCreatedObject } from "../../lib/api/objectsApi";
+  import { defineCreatedObject, addOrUpdateSaveItem } from "../../lib/api/objectsApi";
 
   export let currentTab: "scene" | "objects";
   let shape: Shape;
@@ -49,6 +50,114 @@ License: CECILL-C
         highlighted: "none",
         displayControl: { ...object.displayControl, editing: false },
       }));
+
+      if (newObject) {
+        console.log("FormSubmit newObject:", newObject);
+        if (newObject.datasetItemType === "video") {
+          // for video, there is 2 bbox|keypoints, 1 track, 1 tracklet
+          if (shape.type === "bbox" && newObject.boxes) {
+            for (let box of newObject.boxes) {
+              const save_item: SaveItem = {
+                change_type: "add_or_update",
+                ref_name: shape.type, //this should represent the annotation table to be refered...?
+                is_video: true,
+                data: { ...box, entity_ref: { id: newObject.id, name: "top_entity" } },
+              };
+              saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+            }
+          }
+          if (shape.type === "keypoints" && newObject.keypoints) {
+            for (let kpt of newObject.keypoints) {
+              const save_item: SaveItem = {
+                change_type: "add_or_update",
+                ref_name: shape.type, //this should represent the annotation table to be refered...?
+                is_video: true,
+                data: { ...kpt, entity_ref: { id: newObject.id, name: "top_entity" } },
+              };
+              saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+            }
+          }
+          //add Tracklet
+          const save_item_tracklet: SaveItem = {
+            change_type: "add_or_update",
+            ref_name: "tracklet",
+            is_video: true,
+            data: {
+              ...newObject.track[0],
+              entity_ref: { id: newObject.id, name: "top_entity" },
+            },
+          };
+          saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_tracklet));
+          //add Track
+          const save_item_track: SaveItem = {
+            change_type: "add_or_update",
+            ref_name: "top_entity",
+            is_video: true,
+            data: {
+              id: newObject.id,
+              item_id: newObject.item_id,
+              source_id: newObject.source_id,
+              features: newObject.features,
+              view_id: newObject.track[0].view_id,
+              entity_ref: { id: "", name: "" }, //no parent for track
+              ref_name: "top_entity",
+            },
+          };
+          saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_track));
+          //TODO Note: we may have to manage "spatial object" entity too...
+        } else {
+          if (shape.type === "bbox" && newObject.bbox) {
+            const save_item: SaveItem = {
+              change_type: "add_or_update",
+              ref_name: shape.type, //this should represent the annotation table to be refered...?
+              is_video: false,
+              data: { ...newObject.bbox, entity_ref: { id: newObject.id, name: "top_entity" } },
+            };
+            saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+            const save_item_entity: SaveItem = {
+              change_type: "add_or_update",
+              ref_name: "top_entity", //this should represent the annotation table to be refered...?
+              is_video: false,
+              data: {
+                id: newObject.id,
+                item_id: newObject.item_id,
+                source_id: newObject.source_id,
+                features: newObject.features,
+                ref_name: "top_entity",
+                entity_ref: { id: "", name: "" },
+              },
+            };
+            saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_entity));
+          }
+          if (shape.type === "keypoints" && newObject.keypoints) {
+            const save_item: SaveItem = {
+              change_type: "add_or_update",
+              ref_name: shape.type, //this should represent the annotation table to be refered...?
+              is_video: false,
+              data: {
+                ...newObject.keypoints,
+                entity_ref: { id: newObject.id, name: "top_entity" },
+              },
+            };
+            saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+            const save_item_entity: SaveItem = {
+              change_type: "add_or_update",
+              ref_name: "top_entity", //this should represent the annotation table to be refered...?
+              is_video: false,
+              data: {
+                id: newObject.id,
+                item_id: newObject.item_id,
+                source_id: newObject.source_id,
+                features: newObject.features,
+                ref_name: "top_entity",
+                entity_ref: { id: "", name: "" },
+              },
+            };
+            saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_entity));
+          }
+        }
+      }
+
       return [...objectsWithoutHighlighted, ...(newObject ? [newObject] : [])];
     });
 
@@ -57,7 +166,6 @@ License: CECILL-C
         addNewInput($itemMetas.featuresList, "objects", feat, objectProperties[feat] as string);
       }
     }
-
     newShape.set({ status: "none", shouldReset: true });
     canSave.set(true);
     currentTab = "objects";

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -105,7 +105,7 @@ License: CECILL-C
       );
       //svelte hack to detect change in trackWithItems
       for (const i in trackWithItems) {
-        trackWithItems[i] = {...trackWithItems[i]};  //destructuration required, else optimizer(?) remove it...
+        trackWithItems[i] = { ...trackWithItems[i] }; //destructuration required, else optimizer(?) remove it...
       }
 
       onEditKeyItemClick(rightClickFrameIndex);

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -103,7 +103,8 @@ License: CECILL-C
           return obj;
         }),
       );
-      //svelte hack to detect change in trackWithItems
+      //svelte hack to detect change in trackWithItems -- it requires a for-in loop
+      // eslint-disable-next-line
       for (const i in trackWithItems) {
         trackWithItems[i] = { ...trackWithItems[i] }; //destructuration required, else optimizer(?) remove it...
       }

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -14,7 +14,7 @@ License: CECILL-C
     VideoItemBBox,
     VideoObject,
   } from "@pixano/core";
-  import { itemObjects, selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { itemObjects, selectedTool, canSave } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     lastFrameIndex,
     currentFrameIndex,
@@ -82,45 +82,92 @@ License: CECILL-C
     );
   };
 
-  const onAddKeyItemClick = () => {
-    trackWithItems = addKeyItem(rightClickFrameIndex, $lastFrameIndex, trackWithItems);
+  const onAddKeyItemClick = (tracklet: TrackletWithItems | MouseEvent) => {
+    if ("view_id" in tracklet) {
+      trackWithItems = addKeyItem(
+        rightClickFrameIndex,
+        $lastFrameIndex,
+        trackWithItems,
+        tracklet.view_id,
+      );
+      itemObjects.update((objects) =>
+        objects.map((obj) => {
+          if (obj.id === object.id && obj.datasetItemType === "video") {
+            const { boxes, keypoints } = mapTrackItemsToObject(
+              trackWithItems,
+              object,
+              rightClickFrameIndex,
+            );
+            return { ...obj, track: trackWithItems, boxes, keypoints };
+          }
+          return obj;
+        }),
+      );
+      //svelte hack to detect change in trackWithItems
+      for (const i in trackWithItems) {
+        trackWithItems[i] = {...trackWithItems[i]};  //destructuration required, else optimizer(?) remove it...
+      }
+
+      onEditKeyItemClick(rightClickFrameIndex);
+      canSave.set(true);
+    } else {
+      //MouseEvent, need to determine view_id
+      //TODO
+      confirm("Adding a key point outside of a tracklet is forbidden for now");
+    }
+  };
+
+  //like findNeighborItems, but "better" (return existing neighbors)
+  const findPreviousAndNext = (items: TrackletItem[], targetIndex: number): [number, number] => {
+    let low = 0;
+    let high = items.length - 1;
+    let mid;
+    let previousItem: TrackletItem | null = null;
+    let nextItem: TrackletItem | null = null;
+
+    while (low <= high) {
+      mid = Math.floor((low + high) / 2);
+      if (items[mid].frame_index <= targetIndex) {
+        previousItem = items[mid];
+        low = mid + 1;
+      } else {
+        nextItem = items[mid];
+        high = mid - 1;
+      }
+    }
+    return [
+      previousItem ? previousItem.frame_index : targetIndex,
+      nextItem ? nextItem.frame_index : targetIndex + 1,
+    ];
+  };
+
+  const onSplitTrackletClick = (tracklet: TrackletWithItems) => {
+    const [prev, next] = findPreviousAndNext(tracklet.items, rightClickFrameIndex);
+    trackWithItems = splitTrackletInTwo(
+      trackWithItems,
+      tracklet,
+      rightClickFrameIndex,
+      prev,
+      next,
+      object.id,
+    );
     itemObjects.update((objects) =>
       objects.map((obj) => {
         if (obj.id === object.id && obj.datasetItemType === "video") {
-          const { boxes, keypoints } = mapTrackItemsToObject(
-            trackWithItems,
-            object,
-            rightClickFrameIndex,
-          );
+          const { boxes, keypoints } = mapSplittedTrackToObject(trackWithItems, object);
           return { ...obj, track: trackWithItems, boxes, keypoints };
         }
         return obj;
       }),
     );
-    onEditKeyItemClick(rightClickFrameIndex);
+    object.track = trackWithItems;
+    canSave.set(true);
   };
 
-  const onSplitTrackletClick = (trackletIndex: number) => {
-    trackWithItems = splitTrackletInTwo(trackWithItems, trackletIndex, rightClickFrameIndex);
-    itemObjects.update((objects) =>
-      objects.map((obj) => {
-        if (obj.id === object.id && obj.datasetItemType === "video") {
-          const { boxes, keypoints } = mapSplittedTrackToObject(
-            trackWithItems,
-            object,
-            rightClickFrameIndex,
-          );
-          return { ...obj, track: trackWithItems, boxes, keypoints };
-        }
-        return obj;
-      }),
-    );
-  };
-
-  const onDeleteTrackletClick = (trackletIndex: number) => {
-    itemObjects.update((objects) =>
-      deleteTracklet(objects, object.id, trackletIndex, trackWithItems),
-    );
+  const onDeleteTrackletClick = (tracklet: TrackletWithItems) => {
+    itemObjects.update((objects) => deleteTracklet(objects, object.id, tracklet));
+    updateTracks();
+    canSave.set(true);
   };
 
   const findNeighborItems = (frameIndex: VideoItemBBox["frame_index"]): [number, number] => {
@@ -152,13 +199,12 @@ License: CECILL-C
   };
 
   const updateTracks = () => {
-    console.log("UpdTrack");
     trackWithItems = [];
     for (const tracklet of object.track) {
       const boxes = object.boxes
         ? object.boxes.filter(
             (box) =>
-              box.view_id == tracklet.view_id &&
+              box.view_id === tracklet.view_id &&
               box.frame_index >= tracklet.start &&
               box.frame_index <= tracklet.end,
           )
@@ -166,7 +212,7 @@ License: CECILL-C
       const keypoints = object.keypoints
         ? object.keypoints.filter(
             (kp) =>
-              kp.view_id == tracklet.view_id &&
+              kp.view_id === tracklet.view_id &&
               kp.frame_index >= tracklet.start &&
               kp.frame_index <= tracklet.end,
           )
@@ -208,21 +254,26 @@ License: CECILL-C
       <ContextMenu.Trigger class="h-full w-full absolute left-0" style={`width: ${totalWidth}%`}>
         <p on:contextmenu|preventDefault={(e) => onContextMenu(e)} class="h-full w-full" />
       </ContextMenu.Trigger>
+      <!--  //TODO we don't allow adding a point outside of a tracklet right now
+            //you can extend tracket to add a point inside, and split if needed
       <ContextMenu.Content>
         <ContextMenu.Item inset on:click={onAddKeyItemClick}>Add a point</ContextMenu.Item>
       </ContextMenu.Content>
+      -->
     </ContextMenu.Root>
-    {#each trackWithItems as tracklet, i}
+    {#each trackWithItems as tracklet (tracklet)}
       <ObjectTracklet
         {tracklet}
         {object}
         {views}
-        {onAddKeyItemClick}
+        onAddKeyItemClick={() => onAddKeyItemClick(tracklet)}
         {onContextMenu}
         {onEditKeyItemClick}
-        onSplitTrackletClick={() => onSplitTrackletClick(i)}
-        onDeleteTrackletClick={() => onDeleteTrackletClick(i)}
+        {getTrackletItem}
+        onSplitTrackletClick={() => onSplitTrackletClick(tracklet)}
+        onDeleteTrackletClick={() => onDeleteTrackletClick(tracklet)}
         {findNeighborItems}
+        {updateTracks}
         {updateView}
         {moveCursorToPosition}
       />

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -155,7 +155,7 @@ License: CECILL-C
       const item = getTrackletItem(ann);
       if (!items.find((it) => it.frame_index == item.frame_index)) items.push(getTrackletItem(ann));
     }
-    const new_tracklet = object.track.find((trklet)=>trklet.id === tracklet.id);
+    const new_tracklet = object.track.find((trklet) => trklet.id === tracklet.id);
     tracklet = {
       ...(new_tracklet ? new_tracklet : tracklet),
       items: items,
@@ -163,7 +163,6 @@ License: CECILL-C
     console.log("UpdTracklet", object, tracklet);
     updateTracks();
   };
-
 </script>
 
 <ContextMenu.Root>
@@ -183,7 +182,9 @@ License: CECILL-C
     />
   </ContextMenu.Trigger>
   <ContextMenu.Content>
-    <ContextMenu.Item inset on:click={(event) => onAddKeyItemClick(event)}>Add a point</ContextMenu.Item>
+    <ContextMenu.Item inset on:click={(event) => onAddKeyItemClick(event)}
+      >Add a point</ContextMenu.Item
+    >
     <ContextMenu.Item inset on:click={onSplitTrackletClick}>Split tracklet</ContextMenu.Item>
     <ContextMenu.Item inset on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
   </ContextMenu.Content>

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -7,8 +7,8 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { ContextMenu, cn } from "@pixano/core";
-  import type { ItemObject, TrackletItem, VideoItemBBox } from "@pixano/core";
-  import { itemObjects, selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
+  import type { ItemObject, TrackletItem, TrackletWithItems, VideoItemBBox } from "@pixano/core";
+  import { itemObjects, selectedTool, canSave } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
   import { deleteKeyBoxFromTracklet } from "../../lib/api/videoApi";
   import { panTool } from "../../lib/settings/selectionTools";
@@ -21,6 +21,7 @@ License: CECILL-C
   export let top: number;
   export let oneFrameInPixel: number;
   export let onEditKeyItemClick: (frameIndex: TrackletItem["frame_index"]) => void;
+  export let updateTracklet: () => void;
   export let updateTrackletWidth: (
     newIndex: TrackletItem["frame_index"],
     draggedIndex: TrackletItem["frame_index"],
@@ -38,15 +39,20 @@ License: CECILL-C
       item.frame_index === $currentFrameIndex && currentObjectBeingEdited?.id === objectId;
   }
 
-  const onDeleteItemClick = (item: TrackletItem) => {
+  const onDeleteItemClick = () => {
     itemObjects.update((objects) => deleteKeyBoxFromTracklet(objects, item, objectId));
+    //TODO ? check if deleting a key has deleted last tracklet of itemObject => delete it (?)
+    updateTracklet();
+    canSave.set(true);
   };
 
-  const getKeyItemLeftPosition = (frameIndex: VideoItemBBox["frame_index"]) => {
-    const itemFrameIndex = frameIndex > $lastFrameIndex ? $lastFrameIndex : frameIndex;
-    const leftPosition = (itemFrameIndex / ($lastFrameIndex + 1)) * 100;
-    return leftPosition;
-  };
+  export const getKeyItemLeftPosition = (
+  frameIndex: VideoItemBBox["frame_index"],
+) => {
+  const itemFrameIndex = frameIndex > $lastFrameIndex ? $lastFrameIndex : frameIndex;
+  const leftPosition = (itemFrameIndex / ($lastFrameIndex + 1)) * 100;
+  return leftPosition;
+};
 
   let left = getKeyItemLeftPosition(item.frame_index);
 
@@ -82,6 +88,7 @@ License: CECILL-C
       moving = false;
       if (newFrameIndex !== undefined) filterTracklet(newFrameIndex, item.frame_index);
       newFrameIndex = undefined;
+      //TODO canSave.set(true);
     });
   };
 </script>
@@ -98,7 +105,7 @@ License: CECILL-C
     <button class="h-full w-full" use:dragMe />
   </ContextMenu.Trigger>
   <ContextMenu.Content>
-    <ContextMenu.Item inset on:click={() => onDeleteItemClick(item)}>Remove item</ContextMenu.Item>
+    <ContextMenu.Item inset on:click={() => onDeleteItemClick()}>Remove item</ContextMenu.Item>
     {#if !isItemBeingEdited}
       <ContextMenu.Item inset on:click={() => onEditKeyItemClick(item.frame_index)}
         >Edit item</ContextMenu.Item

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -46,13 +46,11 @@ License: CECILL-C
     canSave.set(true);
   };
 
-  export const getKeyItemLeftPosition = (
-  frameIndex: VideoItemBBox["frame_index"],
-) => {
-  const itemFrameIndex = frameIndex > $lastFrameIndex ? $lastFrameIndex : frameIndex;
-  const leftPosition = (itemFrameIndex / ($lastFrameIndex + 1)) * 100;
-  return leftPosition;
-};
+  export const getKeyItemLeftPosition = (frameIndex: VideoItemBBox["frame_index"]) => {
+    const itemFrameIndex = frameIndex > $lastFrameIndex ? $lastFrameIndex : frameIndex;
+    const leftPosition = (itemFrameIndex / ($lastFrameIndex + 1)) * 100;
+    return leftPosition;
+  };
 
   let left = getKeyItemLeftPosition(item.frame_index);
 

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -7,7 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { ContextMenu, cn } from "@pixano/core";
-  import type { ItemObject, TrackletItem, TrackletWithItems, VideoItemBBox } from "@pixano/core";
+  import type { ItemObject, TrackletItem, VideoItemBBox } from "@pixano/core";
   import { itemObjects, selectedTool, canSave } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
   import { deleteKeyBoxFromTracklet } from "../../lib/api/videoApi";

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
@@ -19,8 +19,11 @@ import type {
   VideoItemBBox,
   KeypointsTemplate,
   VideoObject,
+  SaveItem,
 } from "@pixano/core";
 import { mask_utils } from "@pixano/models/src";
+
+import { saveData } from "../../lib/stores/datasetItemWorkspaceStores";
 
 import {
   HIGHLIGHTED_BOX_STROKE_FACTOR,
@@ -215,6 +218,34 @@ export const toggleObjectDisplayControl = (
   return object;
 };
 
+export const addOrUpdateSaveItem = (objects: SaveItem[], newObj: SaveItem) => {
+  if (newObj["change_type"] == "delete") {
+    for (const ttype in newObj["data"]) {
+      objects = objects.filter(
+        (obj) =>
+          !(
+            obj.ref_name == ttype && (newObj["data"][ttype] as Array<string>).includes(obj.data.id)
+          ),
+      );
+    }
+  }
+  let index = -1;
+  // annotations in front are (sometime?) created without an id
+  if ("id" in newObj.data) {
+    index = objects.findIndex((obj) => obj.data.id === newObj.data.id);
+  } else if ("frame_index" in newObj.data) {
+    index = objects.findIndex(
+      (obj) => obj.data.frame_index === newObj.data.frame_index && obj.ref_name == newObj.ref_name,
+    );
+  }
+  if (index !== -1) {
+    objects[index] = newObj;
+  } else {
+    objects.push(newObj);
+  }
+  return objects;
+};
+
 export const sortObjectsByModel = (objects: ItemObject[]) =>
   objects.reduce(
     (acc, object) => {
@@ -251,31 +282,55 @@ export const updateExistingObject = (objects: ItemObject[], newShape: Shape): It
     // Check if the object is an ImageObject
     if (object.datasetItemType === "image") {
       if (newShape.type === "mask" && object.mask) {
-        return {
+        const newObject = {
           ...object,
           mask: {
             ...object.mask,
             counts: newShape.counts,
           },
         };
+        const save_item: SaveItem = {
+          change_type: "add_or_update",
+          ref_name: newShape.type,
+          is_video: false,
+          data: { ...newObject.mask, entity_ref: { id: newObject.id, name: "top_entity" } },
+        };
+        saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+        return newObject;
       }
-      if (newShape.type === "rectangle" && object.bbox) {
-        return {
+      if (newShape.type === "bbox" && object.bbox) {
+        const newObject = {
           ...object,
           bbox: {
             ...object.bbox,
             coords: newShape.coords,
           },
         };
+        const save_item: SaveItem = {
+          change_type: "add_or_update",
+          ref_name: newShape.type,
+          is_video: false,
+          data: { ...newObject.bbox, entity_ref: { id: newObject.id, name: "top_entity" } },
+        };
+        saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+        return newObject;
       }
-      if (newShape.type === "keypoint" && object.keypoints) {
-        return {
+      if (newShape.type === "keypoints" && object.keypoints) {
+        const newObject = {
           ...object,
           keypoints: {
             ...object.keypoints,
             vertices: newShape.vertices,
           },
         };
+        const save_item: SaveItem = {
+          change_type: "add_or_update",
+          ref_name: newShape.type,
+          is_video: false,
+          data: { ...newObject.keypoints, entity_ref: { id: newObject.id, name: "top_entity" } },
+        };
+        saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+        return newObject;
       }
     }
 
@@ -366,7 +421,7 @@ export const defineCreatedObject = (
     source_id: GROUND_TRUTH,
     features,
   };
-  if (shape.type === "rectangle") {
+  if (shape.type === "bbox") {
     const { x, y, width, height } = shape.attrs;
     const coords = [
       x / shape.imageWidth,
@@ -375,11 +430,13 @@ export const defineCreatedObject = (
       height / shape.imageHeight,
     ];
     const bbox = {
+      id: nanoid(10),
       coords,
       format: "xywh",
       is_normalized: true,
       confidence: 1,
       view_id: shape.viewId,
+      ref_name: "bbox",
     };
     const isVideo = videoType === "video";
     if (isVideo) {
@@ -400,7 +457,13 @@ export const defineCreatedObject = (
             is_thumbnail: true,
             tracklet_id: id,
           },
-          { ...bbox, frame_index: currentFrameIndex + 5, is_key: true, tracklet_id: id },
+          {
+            ...bbox,
+            id: nanoid(10),
+            frame_index: currentFrameIndex + 5,
+            is_key: true,
+            tracklet_id: id,
+          },
         ],
         track: [
           {
@@ -408,6 +471,7 @@ export const defineCreatedObject = (
             end: currentFrameIndex + 5,
             id,
             view_id: shape.viewId,
+            ref_name: "tracklet",
           },
         ],
       };
@@ -424,14 +488,17 @@ export const defineCreatedObject = (
       ...baseObject,
       datasetItemType: "image",
       mask: {
+        id: nanoid(10),
         counts: shape.rle.counts,
         size: shape.rle.size,
         view_id: shape.viewId,
+        ref_name: "mask",
       },
     };
   }
-  if (shape.type === "keypoint") {
+  if (shape.type === "keypoints") {
     const keypoints = {
+      id: nanoid(10),
       template_id: shape.keypoints.id,
       vertices: shape.keypoints.vertices.map((vertex) => ({
         ...vertex,
@@ -439,6 +506,7 @@ export const defineCreatedObject = (
         y: vertex.y / shape.imageHeight,
       })),
       view_id: shape.viewId,
+      ref_name: "keypoints",
     };
     if (isVideo) {
       const id = nanoid(5);
@@ -452,8 +520,15 @@ export const defineCreatedObject = (
             tracklet_id: id,
             is_key: true,
             is_thumbnail: true,
+            ref_name: "keypoints",
           },
-          { ...keypoints, frame_index: currentFrameIndex + 5, tracklet_id: id, is_key: true },
+          {
+            ...keypoints,
+            id: nanoid(10),
+            frame_index: currentFrameIndex + 5,
+            tracklet_id: id,
+            is_key: true,
+          },
         ],
         track: [
           {
@@ -461,6 +536,7 @@ export const defineCreatedObject = (
             end: currentFrameIndex + 5,
             id,
             view_id: shape.viewId,
+            ref_name: "tracklet",
           },
         ],
         displayedMKeypoints: [{ ...keypoints, frame_index: 0, tracklet_id: id }],

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi.ts
@@ -223,9 +223,8 @@ export const addOrUpdateSaveItem = (objects: SaveItem[], newObj: SaveItem) => {
     for (const ttype in newObj["data"]) {
       objects = objects.filter(
         (obj) =>
-          !(
-            obj.ref_name == ttype && (newObj["data"][ttype] as Array<string>).includes(obj.data.id)
-          ),
+          obj.change_type == "add_or_update" &&
+          !(obj.ref_name == ttype && newObj["data"][ttype].includes(obj.data.id)),
       );
     }
   }
@@ -235,7 +234,11 @@ export const addOrUpdateSaveItem = (objects: SaveItem[], newObj: SaveItem) => {
     index = objects.findIndex((obj) => obj.data.id === newObj.data.id);
   } else if ("frame_index" in newObj.data) {
     index = objects.findIndex(
-      (obj) => obj.data.frame_index === newObj.data.frame_index && obj.ref_name == newObj.ref_name,
+      (obj) =>
+        "frame_index" in obj.data &&
+        "frame_index" in newObj.data && //required by tslint even if tested before
+        obj.data.frame_index === newObj.data.frame_index &&
+        obj.ref_name == newObj.ref_name,
     );
   }
   if (index !== -1) {
@@ -471,7 +474,6 @@ export const defineCreatedObject = (
             end: currentFrameIndex + 5,
             id,
             view_id: shape.viewId,
-            ref_name: "tracklet",
           },
         ],
       };
@@ -520,7 +522,6 @@ export const defineCreatedObject = (
             tracklet_id: id,
             is_key: true,
             is_thumbnail: true,
-            ref_name: "keypoints",
           },
           {
             ...keypoints,
@@ -536,7 +537,6 @@ export const defineCreatedObject = (
             end: currentFrameIndex + 5,
             id,
             view_id: shape.viewId,
-            ref_name: "tracklet",
           },
         ],
         displayedMKeypoints: [{ ...keypoints, frame_index: 0, tracklet_id: id }],

--- a/ui/components/datasetItemWorkspace/src/lib/api/videoApi.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/videoApi.ts
@@ -14,8 +14,12 @@ import type {
   VideoItemBBox,
   VideoKeypoints,
   VideoObject,
+  SaveItem,
 } from "@pixano/core";
 import { nanoid } from "nanoid";
+
+import { addOrUpdateSaveItem } from "./objectsApi";
+import { saveData } from "../../lib/stores/datasetItemWorkspaceStores";
 
 export const getCurrentImageTime = (imageIndex: number, videoSpeed: number) => {
   const currentTimestamp = imageIndex * videoSpeed;
@@ -49,7 +53,8 @@ export const boxLinearInterpolation = (
   // return no_interpol?no_interpol.coords:null;
 
   const currentTracklet = track.find(
-    (tracklet) => tracklet.start <= imageIndex && tracklet.end >= imageIndex,
+    (tracklet) =>
+      tracklet.start <= imageIndex && tracklet.end >= imageIndex && tracklet.view_id == view,
   );
   if (!currentTracklet) return null;
   const view_boxes = boxes.filter((box) => box.view_id == view);
@@ -89,7 +94,8 @@ export const keypointsLinearInterpolation = (
 
   if (!object.keypoints) return null;
   const currentTracklet = object.track.find(
-    (tracklet) => tracklet.start <= imageIndex && tracklet.end >= imageIndex,
+    (tracklet) =>
+      tracklet.start <= imageIndex && tracklet.end >= imageIndex && tracklet.view_id == view,
   );
   if (!currentTracklet) return null;
   const view_keypoints = object.keypoints?.filter((kp) => kp.view_id == view);
@@ -124,34 +130,82 @@ export const deleteKeyBoxFromTracklet = (
   objectId: ItemObject["id"],
 ) =>
   objects.map((object) => {
+    const del_data = {};
     if (objectId === object.id && object.datasetItemType === "video") {
-      object.boxes = object.boxes?.filter((box) => box.frame_index !== trackletItem.frame_index);
-      object.keypoints = object.keypoints?.filter(
-        (keypoint) => keypoint.frame_index !== trackletItem.frame_index,
-      );
+      const view_id = getViewIdFromTrackletItem(trackletItem, object.track);
+      object.boxes = object.boxes?.filter((box) => {
+        if (box.frame_index !== trackletItem.frame_index || box.view_id !== view_id) {
+          return true;
+        } else {
+          del_data["bbox"] = [box.id];
+          return false;
+        }
+      });
+      object.keypoints = object.keypoints?.filter((keypoint) => {
+        if (keypoint.frame_index !== trackletItem.frame_index || keypoint.view_id !== view_id) {
+          return true;
+        } else {
+          del_data["keypoints"] = [keypoint.id];
+          return false;
+        }
+      });
       object.track = object.track
         .map((tracklet) => {
+          let changed_tracklet = false;
+          if (tracklet.view_id !== view_id) return tracklet;
           if (tracklet.start === trackletItem.frame_index) {
             const nextBoxFrameIndex = object.boxes?.find(
-              (box) => box.frame_index > trackletItem.frame_index,
+              (box) => box.frame_index > trackletItem.frame_index && box.view_id == view_id,
             )?.frame_index;
             const nextKeypointFrameIndex = object.keypoints?.find(
-              (keypoint) => keypoint.frame_index > trackletItem.frame_index,
+              (keypoint) =>
+                keypoint.frame_index > trackletItem.frame_index && keypoint.view_id == view_id,
             )?.frame_index;
-            tracklet.start = nextBoxFrameIndex || nextKeypointFrameIndex || tracklet.end;
+            tracklet.start = Math.min(
+              nextBoxFrameIndex || tracklet.end,
+              nextKeypointFrameIndex || tracklet.end,
+              tracklet.end,
+            );
+            changed_tracklet = true;
           }
           if (tracklet.end === trackletItem.frame_index) {
             const prevBoxFrameIndex = object.boxes
               ?.reverse()
-              .find((box) => box.frame_index < trackletItem.frame_index)?.frame_index;
+              .find(
+                (box) => box.frame_index < trackletItem.frame_index && box.view_id == view_id,
+              )?.frame_index;
             const prevKeypointFrameIndex = object.keypoints
               ?.reverse()
-              .find((keypoint) => keypoint.frame_index < trackletItem.frame_index)?.frame_index;
-            tracklet.end = prevBoxFrameIndex || prevKeypointFrameIndex || tracklet.start;
+              .find(
+                (keypoint) =>
+                  keypoint.frame_index < trackletItem.frame_index && keypoint.view_id == view_id,
+              )?.frame_index;
+            tracklet.end = Math.max(
+              prevBoxFrameIndex || tracklet.start,
+              prevKeypointFrameIndex || tracklet.start,
+              tracklet.start,
+            );
+            changed_tracklet = true;
+          }
+          if (changed_tracklet) {
+            const save_item: SaveItem = {
+              change_type: "add_or_update",
+              ref_name: "tracklet",
+              is_video: true,
+              data: { ...tracklet, entity_ref: { id: objectId, name: "top_entity" } },
+            };
+            saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
           }
           return tracklet;
         })
-        .filter((tracklet) => tracklet.end !== tracklet.start);
+        .filter((tracklet) => tracklet.end !== tracklet.start); //TODO if remove, may also remove track (if no other tracklet on view...)
+      const save_item: SaveItem = {
+        change_type: "delete",
+        ref_name: "",
+        is_video: true,
+        data: del_data,
+      };
+      saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
     }
     return object;
   });
@@ -176,70 +230,87 @@ export const editKeyItemInTracklet = (
   currentFrame: number,
   objectIdBeingEdited: string | null,
 ) => {
-  return objects.map((object) => {
-    if (
-      object.id !== shape.shapeId ||
-      object.datasetItemType !== "video" ||
-      objectIdBeingEdited !== object.id
-    ) {
-      return object;
-    }
-    const currentTracklet = object.track.find(
-      (t) => t.start <= currentFrame && t.end >= currentFrame,
-    );
-    if (shape.type === "keypoint" && object.keypoints) {
-      object.keypoints = object.keypoints.map((kp) => {
-        if (kp.frame_index === currentFrame) {
-          kp.vertices = shape.vertices;
-          kp.is_key = true;
+  let saveData: SaveItem;
+  return {
+    objects: objects.map((object) => {
+      if (
+        object.id !== shape.shapeId ||
+        object.datasetItemType !== "video" ||
+        objectIdBeingEdited !== object.id
+      ) {
+        return object;
+      }
+      const currentTracklet = object.track.find(
+        (t) => t.start <= currentFrame && t.end >= currentFrame && t.view_id == shape.viewId,
+      );
+      let new_obj;
+      if (shape.type === "keypoints" && object.keypoints) {
+        object.keypoints = object.keypoints.map((kp) => {
+          if (kp.frame_index === currentFrame) {
+            kp.vertices = shape.vertices;
+            kp.is_key = true;
+            return kp;
+          }
           return kp;
-        }
-        return kp;
-      });
-      if (currentTracklet && !object.keypoints?.some((b) => b.frame_index === currentFrame)) {
-        object.keypoints?.push({
-          ...object.keypoints[0],
-          vertices: shape.vertices,
-          frame_index: currentFrame,
-          is_key: true,
-          tracklet_id: currentTracklet.id,
         });
-      }
-      object.keypoints?.sort((a, b) => a.frame_index - b.frame_index);
-      object.displayedMKeypoints = object.displayedMKeypoints?.map((kpt) => {
-        if (kpt.view_id == shape.viewId) {
-          return {
-            ...kpt,
+        if (currentTracklet) {
+          new_obj = {
+            ...object.keypoints[0],
             vertices: shape.vertices,
+            frame_index: currentFrame,
+            is_key: true,
+            tracklet_id: currentTracklet.id,
           };
+          if (!object.keypoints?.some((b) => b.frame_index === currentFrame)) {
+            object.keypoints?.push(new_obj);
+          }
         }
-        return kpt;
-      });
-    }
-    if (shape.type === "rectangle" && object.boxes) {
-      object.boxes = editBoxesInTracklet(object.boxes, currentFrame, shape);
-      if (currentTracklet && !object.boxes?.some((b) => b.frame_index === currentFrame)) {
-        object.boxes?.push({
-          ...object.boxes[0],
-          coords: shape.coords,
-          frame_index: currentFrame,
-          is_key: true,
-          tracklet_id: currentTracklet.id,
+        object.keypoints?.sort((a, b) => a.frame_index - b.frame_index);
+        object.displayedMKeypoints = object.displayedMKeypoints?.map((kpt) => {
+          if (kpt.view_id == shape.viewId) {
+            return {
+              ...kpt,
+              vertices: shape.vertices,
+            };
+          }
+          return kpt;
         });
       }
-      object.boxes?.sort((a, b) => a.frame_index - b.frame_index);
-      object.displayedMBox = object.displayedMBox?.map((box) => {
-        if (box.view_id == shape.viewId) {
-          return {
-            ...box,
+      if (shape.type === "bbox" && object.boxes) {
+        object.boxes = editBoxesInTracklet(object.boxes, currentFrame, shape);
+        if (currentTracklet) {
+          new_obj = {
+            ...object.boxes[0],
             coords: shape.coords,
+            frame_index: currentFrame,
+            is_key: true,
+            tracklet_id: currentTracklet.id,
           };
+          if (!object.boxes?.some((b) => b.frame_index === currentFrame)) {
+            object.boxes?.push(new_obj);
+          }
         }
-        return box;
-      });
-    }
-    return object;
-  });
+        object.boxes?.sort((a, b) => a.frame_index - b.frame_index);
+        object.displayedMBox = object.displayedMBox?.map((box) => {
+          if (box.view_id == shape.viewId) {
+            return {
+              ...box,
+              coords: shape.coords,
+            };
+          }
+          return box;
+        });
+      }
+      saveData = {
+        change_type: "add_or_update",
+        ref_name: shape.type, //this should represent the annotation table to be refered...
+        is_video: true,
+        data: new_obj,
+      };
+      return object;
+    }),
+    save_data: saveData,
+  };
 };
 
 const createNewTracklet = (
@@ -247,13 +318,15 @@ const createNewTracklet = (
   frameIndex: number,
   lastFrameIndex: number,
   item: TrackletItem,
+  view_id: string,
 ) => {
-  let nextIntervalStart = track.find((t) => t.start > frameIndex)?.start;
+  let nextIntervalStart = track.find((t) => t.view_id == view_id && t.start > frameIndex)?.start;
   nextIntervalStart = nextIntervalStart ? nextIntervalStart - 1 : lastFrameIndex;
   return {
     start: frameIndex,
     end: nextIntervalStart,
     id: item.tracklet_id,
+    view_id: view_id,
     items: [
       {
         ...item,
@@ -273,17 +346,19 @@ export const addKeyItem = (
   frameIndex: number,
   lastFrameIndex: number,
   track: TrackletWithItems[],
+  view_id: string,
 ) => {
-  const id = nanoid(5);
   const item: TrackletItem = {
     frame_index: frameIndex,
     is_key: true,
-    is_thumbnail: false,
-    tracklet_id: id,
   };
-  const tracklet = track.find((t) => t.start <= frameIndex && t.end >= frameIndex);
+  const tracklet = track.find(
+    (tracklet) =>
+      tracklet.view_id === view_id && tracklet.start <= frameIndex && frameIndex <= tracklet.end,
+  );
   if (!tracklet) {
-    const newTracklet = createNewTracklet(track, frameIndex, lastFrameIndex, item);
+    item.tracklet_id = nanoid(5);
+    const newTracklet = createNewTracklet(track, frameIndex, lastFrameIndex, item, view_id);
     track.push(newTracklet);
   } else {
     tracklet.items.push({ ...item, tracklet_id: tracklet.id });
@@ -306,20 +381,32 @@ export const mapTrackItemsToObject = (
   if (object.displayedMBox) {
     for (const displayedBox of object.displayedMBox) {
       allItems.forEach((item) => {
-        const box = {
-          ...displayedBox,
-          frame_index: item.frame_index,
-          tracklet_id: rightClickFrameIndex, //item.tracklet_id,
-          is_key: true,
-        };
-        const currentBox =
-          object.boxes?.find(
+        let currentBox = null;
+        if (item.frame_index == rightClickFrameIndex) {
+          currentBox = {
+            ...displayedBox,
+            frame_index: item.frame_index,
+            tracklet_id: rightClickFrameIndex, //item.tracklet_id,
+            is_key: true,
+          };
+          const save_item_left: SaveItem = {
+            change_type: "add_or_update",
+            ref_name: "bbox",
+            is_video: true,
+            data: { ...displayedBox, entity_ref: { id: object.id, name: "top_entity" } },
+          };
+          saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_left));
+        } else {
+          currentBox = object.boxes?.find(
             (b) => b.view_id == displayedBox.view_id && b.frame_index === item.frame_index,
-          ) || box;
-        boxes.push({
-          ...item,
-          ...currentBox,
-        } as VideoItemBBox);
+          );
+        }
+        if (currentBox) {
+          boxes.push({
+            ...item,
+            ...currentBox,
+          } as VideoItemBBox);
+        }
       });
     }
   }
@@ -327,20 +414,33 @@ export const mapTrackItemsToObject = (
   if (object.displayedMKeypoints) {
     for (const displayedKeypoints of object.displayedMKeypoints) {
       allItems.forEach((item) => {
-        const keypoint = {
-          ...displayedKeypoints,
-          frame_index: rightClickFrameIndex,
-          is_key: true,
-        } as VideoKeypoints;
-        const currentKeypoint =
-          object.keypoints?.find(
+        let currentKeypoint = null;
+        if (item.frame_index == rightClickFrameIndex) {
+          currentKeypoint = {
+            ...displayedKeypoints,
+            frame_index: item.frame_index,
+            tracklet_id: rightClickFrameIndex, //item.tracklet_id,
+            is_key: true,
+          };
+          const save_item_left: SaveItem = {
+            change_type: "add_or_update",
+            ref_name: "keypoints",
+            is_video: true,
+            data: { ...displayedKeypoints, entity_ref: { id: object.id, name: "top_entity" } },
+          };
+          saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_left));
+        } else {
+          currentKeypoint = object.keypoints?.find(
             (kpt) =>
               kpt.view_id == displayedKeypoints.view_id && kpt.frame_index === item.frame_index,
-          ) || keypoint;
-        keypoints.push({
-          ...item,
-          ...currentKeypoint,
-        } as VideoKeypoints);
+          );
+        }
+        if (currentKeypoint) {
+          boxes.push({
+            ...item,
+            ...currentKeypoint,
+          } as VideoKeypoints);
+        }
       });
     }
   }
@@ -350,54 +450,27 @@ export const mapTrackItemsToObject = (
 export const mapSplittedTrackToObject = (
   trackWithItems: TrackletWithItems[],
   object: VideoObject,
-  rightClickFrameIndex: number,
 ) => {
-  const allItems = trackWithItems.reduce(
-    (acc, tracklet) => [...acc, ...tracklet.items],
-    [] as TrackletItem[],
-  );
-
   const boxes: VideoObject["boxes"] = [];
-  if (object.displayedMBox) {
-    for (const displayedBox of object.displayedMBox) {
-      allItems.forEach((item) => {
-        const box = {
-          ...displayedBox,
-          frame_index: rightClickFrameIndex,
-          is_key: true,
-        } as VideoItemBBox;
-        const currentBox =
-          object.boxes?.find(
-            (box) => box.view_id == displayedBox.view_id && box.tracklet_id === item.tracklet_id,
-          ) || box;
-        boxes.push({
-          ...item,
-          ...currentBox,
-        } as VideoItemBBox);
-      });
-    }
-  }
   const keypoints: VideoObject["keypoints"] = [];
-  if (object.displayedMKeypoints) {
-    for (const displayedKeypoints of object.displayedMKeypoints) {
-      allItems.forEach((item) => {
-        const keypoint = {
-          ...displayedKeypoints,
-          frame_index: rightClickFrameIndex,
-          is_key: true,
-        } as VideoKeypoints;
-        const currentKeypoint =
-          object.keypoints?.find(
-            (kpt) =>
-              kpt.view_id == displayedKeypoints.view_id && kpt.tracklet_id === item.tracklet_id,
-          ) || keypoint;
-        keypoints.push({
-          ...item,
-          ...currentKeypoint,
-        } as VideoKeypoints);
-      });
+  const selectAnn = (
+    ann: VideoItemBBox | VideoKeypoints,
+    tracklet: TrackletWithItems,
+    arr: VideoItemBBox[] | VideoKeypoints[],
+  ) => {
+    if (
+      ann.view_id == tracklet.view_id &&
+      ann.frame_index >= tracklet.start &&
+      ann.frame_index <= tracklet.end
+    ) {
+      ann.tracklet_id = tracklet.id;
+      arr.push(ann);
     }
-  }
+  };
+  trackWithItems.forEach((tracklet) => {
+    object.boxes?.forEach((box) => selectAnn(box, tracklet, boxes));
+    object.keypoints?.forEach((kpt) => selectAnn(kpt, tracklet, keypoints));
+  });
   return { boxes, keypoints };
 };
 
@@ -415,57 +488,57 @@ export const mapTrackletItems = (object: VideoObject, tracklet: TrackletWithItem
   return { boxes, keypoints };
 };
 
-const filterItems = (
-  items: TrackletItem[],
-  newItem: TrackletItem,
-  shouldBeFiltered: (index: VideoItemBBox["frame_index"]) => boolean,
-) =>
-  items.reduce((acc, item, i) => {
-    if (i === 0) {
-      acc.push(newItem);
-    }
-    if (shouldBeFiltered(item.frame_index)) {
-      acc.push(item);
-    }
-    return acc
-      .sort((a, b) => a.frame_index - b.frame_index)
-      .map((item) => ({ ...item, tracklet_id: newItem.tracklet_id }));
-  }, [] as TrackletItem[]);
-
 export const splitTrackletInTwo = (
   previousTrack: TrackletWithItems[],
-  trackletIndex: number,
+  tracklet: TrackletWithItems,
   rightClickFrameIndex: number,
+  prev: number,
+  next: number,
+  entity_id: string,
 ) => {
-  const tracklet = previousTrack[trackletIndex];
-  const startId = nanoid(10);
+  const trackletIndex = previousTrack.findIndex((trklet) => trklet.id === tracklet.id);
   const endId = nanoid(10);
-  const startTracklet: TrackletWithItems = {
-    start: tracklet.start,
-    end: rightClickFrameIndex,
-    id: startId,
-    view_id: tracklet.view_id,
-    items: filterItems(
-      tracklet.items,
-      { tracklet_id: startId, frame_index: rightClickFrameIndex, is_key: true },
-      (index) => index < rightClickFrameIndex,
-    ),
+
+  const leftTracklet: TrackletWithItems = {
+    ...tracklet,
+    end: prev,
+    items: tracklet.items.filter((item) => item.frame_index <= prev),
   };
-  const endTracklet: TrackletWithItems = {
-    start: rightClickFrameIndex + 1,
-    end: tracklet.end,
+  const rightTracklet: TrackletWithItems = {
+    ...tracklet,
     id: endId,
-    view_id: tracklet.view_id,
-    items: filterItems(
-      tracklet.items,
-      { tracklet_id: endId, frame_index: rightClickFrameIndex + 1, is_key: true },
-      (index) => index > rightClickFrameIndex + 1,
-    ),
+    start: next,
+    items: tracklet.items
+      .filter((item) => item.frame_index >= next)
+      .map((item) => {
+        item.tracklet_id = endId;
+        return item;
+      }),
   };
+
+  const getTracklet = (tracklet: TrackletWithItems): Tracklet => {
+    const { items: drop, ...tracklet_without_items } = tracklet;
+    drop; // access drop only to prevent ts-lint warning (! ts-expect-error doesn't work here !)
+    return tracklet_without_items;
+  };
+  const save_item_left: SaveItem = {
+    change_type: "add_or_update",
+    ref_name: "tracklet",
+    is_video: true,
+    data: { ...getTracklet(leftTracklet), entity_ref: { id: entity_id, name: "top_entity" } },
+  };
+  saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_left));
+  const save_item_right: SaveItem = {
+    change_type: "add_or_update",
+    ref_name: "tracklet",
+    is_video: true,
+    data: { ...getTracklet(rightTracklet), entity_ref: { id: entity_id, name: "top_entity" } },
+  };
+  saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item_right));
   return [
     ...previousTrack.slice(0, trackletIndex),
-    startTracklet,
-    endTracklet,
+    leftTracklet,
+    rightTracklet,
     ...previousTrack.slice(trackletIndex + 1),
   ];
 };
@@ -517,20 +590,31 @@ export const filterTrackletItems = (
   return tracklet;
 };
 
+export const getViewIdFromTrackletItem = (
+  trackletItem: TrackletItem,
+  tracklets: Tracklet[],
+): string => {
+  const tracklet = tracklets.find((tracklet) => tracklet.id === trackletItem.tracklet_id);
+  if (tracklet) {
+    return tracklet.view_id;
+  }
+  return "";
+};
+
 export const getNewTrackletValues = (
   isStart: boolean,
   newFrameIndex: number,
   tracklet: TrackletWithItems,
 ): TrackletWithItems => {
-  const startingBox = {
+  const startingBox: TrackletItem = {
     ...tracklet.items?.[0],
     frame_index: isStart ? newFrameIndex : tracklet.start,
   };
-  const endingBox = {
+  const endingBox: TrackletItem = {
     ...tracklet.items?.[tracklet.items.length - 1],
     frame_index: isStart ? tracklet.end : newFrameIndex,
   };
-  const newTracklet = {
+  const newTracklet: TrackletWithItems = {
     ...tracklet,
     items: [startingBox, endingBox],
     start: isStart ? newFrameIndex : tracklet.start,
@@ -542,27 +626,40 @@ export const getNewTrackletValues = (
 export const deleteTracklet = (
   objects: ItemObject[],
   objectId: VideoObject["id"],
-  trackletIndex: number,
-  trackWithItems: TrackletWithItems[],
+  to_del_tracklet: TrackletWithItems,
 ) =>
   objects
     .map((obj) => {
       if (obj.id === objectId && obj.datasetItemType === "video") {
-        obj.track.splice(trackletIndex, 1);
-        obj.boxes = obj.boxes?.filter(
-          (box) =>
-            !(
-              box.frame_index >= trackWithItems[trackletIndex].start &&
-              box.frame_index <= trackWithItems[trackletIndex].end
-            ),
-        );
-        obj.keypoints = obj.keypoints?.filter(
-          (kp) =>
-            !(
-              kp.frame_index >= trackWithItems[trackletIndex].start &&
-              kp.frame_index <= trackWithItems[trackletIndex].end
-            ),
-        );
+        const del_data: Record<string, string[]> = {
+          tracklet: [to_del_tracklet.id],
+          bbox: [],
+          keypoints: [],
+        };
+        obj.track = obj.track.filter((tracklet) => tracklet.id !== to_del_tracklet.id);
+        obj.boxes = obj.boxes?.filter((box) => {
+          if (box.tracklet_id !== to_del_tracklet.id) {
+            return true;
+          } else {
+            del_data["bbox"].push(box.id);
+            return false;
+          }
+        });
+        obj.keypoints = obj.keypoints?.filter((kp) => {
+          if (kp.tracklet_id !== to_del_tracklet.id) {
+            return true;
+          } else {
+            del_data["keypoints"].push(kp.id);
+            return false;
+          }
+        });
+        const save_item: SaveItem = {
+          change_type: "delete",
+          ref_name: "",
+          is_video: true,
+          data: del_data,
+        };
+        saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
       }
       return obj;
     })

--- a/ui/components/datasetItemWorkspace/src/lib/settings/defaultFeatures.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/settings/defaultFeatures.ts
@@ -6,13 +6,13 @@ License: CECILL-C
 
 import type { ItemFeature } from "@pixano/core";
 
-export const DEFAULT_FEATURE = "category";
+export const DEFAULT_FEATURE = "name";
 
 export const defaultObjectFeatures = {
   [DEFAULT_FEATURE]: {
-    name: "category",
+    name: "name",
     dtype: "str",
-    label: "category",
+    label: "name",
   },
 };
 

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -15,6 +15,7 @@ import {
   type SelectionTool,
   utils,
   type KeypointsTemplate,
+  type SaveItem,
 } from "@pixano/core";
 
 import { mapObjectToBBox, mapObjectToKeypoints, mapObjectToMasks } from "../api/objectsApi";
@@ -43,6 +44,8 @@ export const filters = writable<Filters>({
 });
 export const imageSmoothing = writable<boolean>(true);
 export const selectedKeypointsTemplate = writable<KeypointsTemplate["id"] | null>(null);
+
+export const saveData = writable<SaveItem[]>([]);
 
 type ColorScale = [Array<string>, (id: string) => string];
 

--- a/ui/components/models/package.json
+++ b/ui/components/models/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@pixano/core": "workspace:^",
+    "nanoid": "^5.0.7",
     "onnxruntime-node": "~1.15.1",
     "onnxruntime-web": "~1.16.3"
   }

--- a/ui/components/models/src/Sam.ts
+++ b/ui/components/models/src/Sam.ts
@@ -6,7 +6,7 @@ License: CECILL-C
 
 // Imports
 import * as ort from "onnxruntime-web";
-
+import { nanoid } from "nanoid";
 import {
   convertSegmentsToSVG,
   generatePolygonSegments,
@@ -140,7 +140,7 @@ export class SAM implements InteractiveImageSegmenter {
     const masksSVG = convertSegmentsToSVG(maskPolygons);
     return {
       masksImageSVG: masksSVG,
-      rle: { counts: rleMask, size: [imageHeight, imageWidth] },
+      rle: { counts: rleMask, size: [imageHeight, imageWidth], id: nanoid(10), ref_name: "mask" },
       masks: results.mask, //note: actually we don't need this one
     };
   }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 4.2.11
       svelte-check:
         specifier: ^3.6.4
-        version: 3.6.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.38))(postcss@8.4.38)(svelte@4.2.11)
+        version: 3.6.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.35))(postcss@8.4.35)(svelte@4.2.11)
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1
@@ -169,7 +169,7 @@ importers:
         version: 4.2.11
       svelte-check:
         specifier: ^3.6.4
-        version: 3.6.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.38))(postcss@8.4.38)(svelte@4.2.11)
+        version: 3.6.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.35))(postcss@8.4.35)(svelte@4.2.11)
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1
@@ -358,6 +358,9 @@ importers:
       '@pixano/core':
         specifier: workspace:^
         version: link:../core
+      nanoid:
+        specifier: ^5.0.7
+        version: 5.0.7
       onnxruntime-node:
         specifier: ~1.15.1
         version: 1.15.1
@@ -416,7 +419,7 @@ importers:
         version: 4.2.11
       svelte-check:
         specifier: ^3.6.4
-        version: 3.6.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.38))(postcss@8.4.38)(svelte@4.2.11)
+        version: 3.6.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.35))(postcss@8.4.35)(svelte@4.2.11)
       svelte-headless-table:
         specifier: ^0.18.2
         version: 0.18.2(svelte@4.2.11)
@@ -452,7 +455,7 @@ importers:
         version: link:../../components/table
       '@storybook/test':
         specifier: ^8.1.5
-        version: 8.1.5
+        version: 8.1.5(vitest@0.30.1(less@4.2.0)(terser@5.29.2))
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.18(postcss@8.4.36)
@@ -465,10 +468,10 @@ importers:
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^8.1.5
-        version: 8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/addon-interactions':
         specifier: ^8.1.5
-        version: 8.1.5
+        version: 8.1.5(vitest@0.30.1(less@4.2.0)(terser@5.29.2))
       '@storybook/addon-links':
         specifier: ^8.1.5
         version: 8.1.5(react@18.2.0)
@@ -477,13 +480,13 @@ importers:
         version: 8.1.5
       '@storybook/blocks':
         specifier: ^8.1.5
-        version: 8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/svelte':
         specifier: ^8.1.5
-        version: 8.1.5(prettier@3.2.5)(svelte@4.2.12)
+        version: 8.1.5(prettier@3.3.1)(svelte@4.2.12)
       '@storybook/svelte-vite':
         specifier: ^8.1.5
-        version: 8.1.5(@babel/core@7.24.6)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@4.2.12)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2)))(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.36))(postcss@8.4.36)(prettier@3.2.5)(svelte@4.2.12)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))
+        version: 8.1.5(@babel/core@7.24.6)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@4.2.12)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2)))(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.36))(postcss@8.4.36)(prettier@3.3.1)(svelte@4.2.12)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.5.3
         version: 2.5.3(svelte@4.2.12)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))
@@ -8533,9 +8536,9 @@ snapshots:
       memoizerific: 1.11.3
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@storybook/addon-controls@8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@storybook/blocks': 8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/blocks': 8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       dequal: 2.0.3
       lodash: 4.17.21
       ts-dedent: 2.2.0
@@ -8548,11 +8551,11 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@storybook/addon-docs@8.1.5(prettier@3.2.5)':
+  '@storybook/addon-docs@8.1.5(prettier@3.3.1)':
     dependencies:
       '@babel/core': 7.24.6
       '@mdx-js/react': 3.0.1(@types/react@18.2.67)(react@18.2.0)
-      '@storybook/blocks': 8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/blocks': 8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/client-logger': 8.1.5
       '@storybook/components': 8.1.5(@types/react@18.2.67)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/csf-plugin': 8.1.5
@@ -8576,18 +8579,18 @@ snapshots:
       - prettier
       - supports-color
 
-  '@storybook/addon-essentials@8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@storybook/addon-essentials@8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@storybook/addon-actions': 8.1.5
       '@storybook/addon-backgrounds': 8.1.5
-      '@storybook/addon-controls': 8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@storybook/addon-docs': 8.1.5(prettier@3.2.5)
+      '@storybook/addon-controls': 8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/addon-docs': 8.1.5(prettier@3.3.1)
       '@storybook/addon-highlight': 8.1.5
       '@storybook/addon-measure': 8.1.5
       '@storybook/addon-outline': 8.1.5
       '@storybook/addon-toolbars': 8.1.5
       '@storybook/addon-viewport': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/manager-api': 8.1.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/node-logger': 8.1.5
       '@storybook/preview-api': 8.1.5
@@ -8605,11 +8608,11 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/addon-interactions@8.1.5':
+  '@storybook/addon-interactions@8.1.5(vitest@0.30.1(less@4.2.0)(terser@5.29.2))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.1.5
-      '@storybook/test': 8.1.5
+      '@storybook/test': 8.1.5(vitest@0.30.1(less@4.2.0)(terser@5.29.2))
       '@storybook/types': 8.1.5
       polished: 4.3.1
       ts-dedent: 2.2.0
@@ -8652,14 +8655,14 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  '@storybook/blocks@8.1.5(@types/react@18.2.67)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@storybook/blocks@8.1.5(@types/react@18.2.67)(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@storybook/channels': 8.1.5
       '@storybook/client-logger': 8.1.5
       '@storybook/components': 8.1.5(@types/react@18.2.67)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/core-events': 8.1.5
       '@storybook/csf': 0.1.8
-      '@storybook/docs-tools': 8.1.5(prettier@3.2.5)
+      '@storybook/docs-tools': 8.1.5(prettier@3.3.1)
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.2.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/manager-api': 8.1.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -8688,10 +8691,10 @@ snapshots:
       - prettier
       - supports-color
 
-  '@storybook/builder-manager@8.1.5(prettier@3.2.5)':
+  '@storybook/builder-manager@8.1.5(prettier@3.3.1)':
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/manager': 8.1.5
       '@storybook/node-logger': 8.1.5
       '@types/ejs': 3.1.5
@@ -8709,11 +8712,11 @@ snapshots:
       - prettier
       - supports-color
 
-  '@storybook/builder-vite@8.1.5(prettier@3.2.5)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))':
+  '@storybook/builder-vite@8.1.5(prettier@3.3.1)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))':
     dependencies:
       '@storybook/channels': 8.1.5
       '@storybook/client-logger': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/core-events': 8.1.5
       '@storybook/csf-plugin': 8.1.5
       '@storybook/node-logger': 8.1.5
@@ -8750,12 +8753,12 @@ snapshots:
       '@babel/types': 7.24.0
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/core-events': 8.1.5
-      '@storybook/core-server': 8.1.5(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/core-server': 8.1.5(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/csf-tools': 8.1.5
       '@storybook/node-logger': 8.1.5
-      '@storybook/telemetry': 8.1.5(prettier@3.2.5)
+      '@storybook/telemetry': 8.1.5(prettier@3.3.1)
       '@storybook/types': 8.1.5
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -8833,7 +8836,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/core-common@8.1.5(prettier@3.2.5)':
+  '@storybook/core-common@8.1.5(prettier@3.3.1)':
     dependencies:
       '@storybook/core-events': 8.1.5
       '@storybook/csf-tools': 8.1.5
@@ -8865,7 +8868,7 @@ snapshots:
       ts-dedent: 2.2.0
       util: 0.12.5
     optionalDependencies:
-      prettier: 3.2.5
+      prettier: 3.3.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8875,15 +8878,15 @@ snapshots:
       '@storybook/csf': 0.1.8
       ts-dedent: 2.2.0
 
-  '@storybook/core-server@8.1.5(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@storybook/core-server@8.1.5(prettier@3.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.6
       '@babel/parser': 7.24.6
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.5(prettier@3.2.5)
+      '@storybook/builder-manager': 8.1.5(prettier@3.3.1)
       '@storybook/channels': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/core-events': 8.1.5
       '@storybook/csf': 0.1.8
       '@storybook/csf-tools': 8.1.5
@@ -8893,7 +8896,7 @@ snapshots:
       '@storybook/manager-api': 8.1.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/node-logger': 8.1.5
       '@storybook/preview-api': 8.1.5
-      '@storybook/telemetry': 8.1.5(prettier@3.2.5)
+      '@storybook/telemetry': 8.1.5(prettier@3.3.1)
       '@storybook/types': 8.1.5
       '@types/detect-port': 1.3.5
       '@types/diff': 5.2.1
@@ -8959,9 +8962,9 @@ snapshots:
 
   '@storybook/docs-mdx@3.1.0-next.0': {}
 
-  '@storybook/docs-tools@8.1.5(prettier@3.2.5)':
+  '@storybook/docs-tools@8.1.5(prettier@3.3.1)':
     dependencies:
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/core-events': 8.1.5
       '@storybook/preview-api': 8.1.5
       '@storybook/types': 8.1.5
@@ -9046,11 +9049,11 @@ snapshots:
       memoizerific: 1.11.3
       qs: 6.12.0
 
-  '@storybook/svelte-vite@8.1.5(@babel/core@7.24.6)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@4.2.12)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2)))(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.36))(postcss@8.4.36)(prettier@3.2.5)(svelte@4.2.12)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))':
+  '@storybook/svelte-vite@8.1.5(@babel/core@7.24.6)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@4.2.12)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2)))(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.36))(postcss@8.4.36)(prettier@3.3.1)(svelte@4.2.12)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))':
     dependencies:
-      '@storybook/builder-vite': 8.1.5(prettier@3.2.5)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))
+      '@storybook/builder-vite': 8.1.5(prettier@3.3.1)(typescript@5.4.2)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))
       '@storybook/node-logger': 8.1.5
-      '@storybook/svelte': 8.1.5(prettier@3.2.5)(svelte@4.2.12)
+      '@storybook/svelte': 8.1.5(prettier@3.3.1)(svelte@4.2.12)
       '@storybook/types': 8.1.5
       '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@4.2.12)(vite@4.5.2(@types/node@20.14.2)(less@4.2.0)(terser@5.29.2))
       magic-string: 0.30.8
@@ -9076,11 +9079,11 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/svelte@8.1.5(prettier@3.2.5)(svelte@4.2.12)':
+  '@storybook/svelte@8.1.5(prettier@3.3.1)(svelte@4.2.12)':
     dependencies:
       '@storybook/client-logger': 8.1.5
       '@storybook/core-events': 8.1.5
-      '@storybook/docs-tools': 8.1.5(prettier@3.2.5)
+      '@storybook/docs-tools': 8.1.5(prettier@3.3.1)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.5
       '@storybook/types': 8.1.5
@@ -9093,10 +9096,10 @@ snapshots:
       - prettier
       - supports-color
 
-  '@storybook/telemetry@8.1.5(prettier@3.2.5)':
+  '@storybook/telemetry@8.1.5(prettier@3.3.1)':
     dependencies:
       '@storybook/client-logger': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.2.5)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/csf-tools': 8.1.5
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -9108,14 +9111,14 @@ snapshots:
       - prettier
       - supports-color
 
-  '@storybook/test@8.1.5':
+  '@storybook/test@8.1.5(vitest@0.30.1(less@4.2.0)(terser@5.29.2))':
     dependencies:
       '@storybook/client-logger': 8.1.5
       '@storybook/core-events': 8.1.5
       '@storybook/instrumenter': 8.1.5
       '@storybook/preview-api': 8.1.5
       '@testing-library/dom': 9.3.4
-      '@testing-library/jest-dom': 6.4.2
+      '@testing-library/jest-dom': 6.4.2(vitest@0.30.1(less@4.2.0)(terser@5.29.2))
       '@testing-library/user-event': 14.5.2(@testing-library/dom@9.3.4)
       '@vitest/expect': 1.3.1
       '@vitest/spy': 1.4.0
@@ -9276,7 +9279,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2':
+  '@testing-library/jest-dom@6.4.2(vitest@0.30.1(less@4.2.0)(terser@5.29.2))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.24.0
@@ -9286,6 +9289,8 @@ snapshots:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
+    optionalDependencies:
+      vitest: 0.30.1(less@4.2.0)(terser@5.29.2)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4)':
     dependencies:

--- a/ui/tools/storybook/stories/components/workspaces/datasetItemWorkspaceMocks.ts
+++ b/ui/tools/storybook/stories/components/workspaces/datasetItemWorkspaceMocks.ts
@@ -117,8 +117,8 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
           dtype: "str",
           value: "Flower",
         },
-        category: {
-          name: "category",
+        name: {
+          name: "name",
           dtype: "str",
           value: "nature",
         },
@@ -188,8 +188,8 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
           dtype: "str",
           value: "Flower",
         },
-        category: {
-          name: "category",
+        name: {
+          name: "name",
           dtype: "str",
           value: "nature",
         },
@@ -256,8 +256,8 @@ export const mockedImageDatasetItem: ImageDatasetItem = {
           dtype: "str",
           value: "Flower",
         },
-        category: {
-          name: "category",
+        name: {
+          name: "name",
           dtype: "str",
           value: "nature",
         },
@@ -632,8 +632,8 @@ export const mockedVideoDatasetItem: VideoDatasetItem = {
           dtype: "str",
           value: "Type",
         },
-        category: {
-          name: "category",
+        name: {
+          name: "na",
           dtype: "str",
           value: "Vehicle",
         },


### PR DESCRIPTION
## Issue

Save was disabled since Python API refactor
It's now working (but should be further tested)

## Description

Changed the way save is handled: from a complete DatasetItem sent to back, it's now a list of changes, handled by back

Also:
- guard against refresh without save
- various fixes/changes in trackline UI

TODO:
- [ ] sliding (move the edge) tracklet
- [ ] edit a key in multiview (wrong selection)

TOFIX - trackline bugs:
- [ ] bad track kept after delete
- [ ] wrong track color after save / redraw (different color from inspector panel)
- [ ] in some cases the first key(s) of track disappear
- [ ] some hard to reproduce cases where a tracklet is "mixed" (like a split but wrong position)