### PR TITLE
Add integrity checks

### DIFF
--- a/pixano/app/routers/items_info.py
+++ b/pixano/app/routers/items_info.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pixano.app.models import ItemInfoModel, ItemModel
 from pixano.app.settings import Settings, get_settings
 from pixano.datasets.queries import TableQueryBuilder
-from pixano.datasets.utils import DatasetAccessError, DatasetOffsetLimitError, DatasetPaginationError
+from pixano.datasets.utils import DatasetAccessError, DatasetPaginationError
 from pixano.features.schemas.schema_group import SchemaGroup
 from pixano.utils.python import to_sql_list
 
@@ -53,8 +53,6 @@ async def get_items_info(
 
     try:
         item_rows = get_rows(dataset, SchemaGroup.ITEM.value, ids, None, limit, skip)
-    except DatasetOffsetLimitError as err:
-        raise HTTPException(status_code=404, detail="Invalid query parameters. " + str(err))
     except DatasetPaginationError as err:
         raise HTTPException(status_code=400, detail=str(err))
     except DatasetAccessError as err:

--- a/pixano/app/routers/utils.py
+++ b/pixano/app/routers/utils.py
@@ -233,20 +233,20 @@ def update_rows(
     try:
         schema: type[BaseSchema] = dataset.schema.schemas[table] if table != SchemaGroup.SOURCE.value else Source
         rows: list[BaseSchema] = BaseSchemaModel.to_rows(models, schema)
-    except Exception:
+    except Exception as err:
         raise HTTPException(
             status_code=400,
-            detail="Invalid data.",
+            detail="Invalid data.\n" + str(err),
         )
 
     try:
         updated_rows = dataset.update_data(table, rows)
     except DatasetIntegrityError as err:
         raise HTTPException(status_code=400, detail="Dataset integrity compromised.\n" + str(err))
-    except ValueError:
+    except ValueError as err:
         raise HTTPException(
             status_code=400,
-            detail="Invalid data.",
+            detail="Invalid data.\n" + str(err),
         )
 
     # TODO: return updated rows instead of input rows
@@ -272,20 +272,20 @@ def create_rows(
     try:
         schema: type[BaseSchema] = dataset.schema.schemas[table] if table != SchemaGroup.SOURCE.value else Source
         rows: list[BaseSchema] = BaseSchemaModel.to_rows(models, schema)
-    except Exception:
+    except Exception as err:
         raise HTTPException(
             status_code=400,
-            detail="Invalid data.",
+            detail="Invalid data.\n" + str(err),
         )
 
     try:
         created_rows = dataset.add_data(table, rows)
     except DatasetIntegrityError as err:
         raise HTTPException(status_code=400, detail="Dataset integrity compromised.\n" + str(err))
-    except ValueError:
+    except ValueError as err:
         raise HTTPException(
             status_code=400,
-            detail="Invalid data.",
+            detail="Invalid data.\n" + str(err),
         )
 
     return created_rows

--- a/pixano/datasets/builders/dataset_builder.py
+++ b/pixano/datasets/builders/dataset_builder.py
@@ -73,7 +73,7 @@ class DatasetBuilder(ABC):
         mode: Literal["add", "create", "overwrite"] = "create",
         flush_every_n_samples: int | None = None,
         compact_every_n_transactions: int | None = None,
-        check_integrity: Literal["raise", "warn", "none"] = "none",
+        check_integrity: Literal["raise", "warn", "none"] = "raise",
     ) -> Dataset:
         """Build the dataset.
 

--- a/pixano/datasets/builders/dataset_builder.py
+++ b/pixano/datasets/builders/dataset_builder.py
@@ -15,6 +15,7 @@ import tqdm
 from lancedb.table import Table
 
 from pixano.datasets import Dataset, DatasetFeaturesValues, DatasetInfo, DatasetItem, DatasetSchema
+from pixano.datasets.utils.integrity import check_dataset_integrity, handle_integrity_errors
 from pixano.features import BaseSchema, Item, SchemaGroup
 from pixano.features.schemas.source import Source
 
@@ -72,6 +73,7 @@ class DatasetBuilder(ABC):
         mode: Literal["add", "create", "overwrite"] = "create",
         flush_every_n_samples: int | None = None,
         compact_every_n_transactions: int | None = None,
+        check_integrity: Literal["raise", "warn", "none"] = "none",
     ) -> Dataset:
         """Build the dataset.
 
@@ -87,11 +89,26 @@ class DatasetBuilder(ABC):
                 flush in tables. If None, data are inserted at each iteration.
             compact_every_n_transactions: The number of transactions before compacting the dataset.
                 If None, the dataset is compacted only at the end.
-
+            check_integrity: The integrity check to perform after building the dataset. It can be "raise",
+                "warn" or "none":
+                    - "raise": Raise an error if integrity errors are found.
+                    - "warn": Print a warning if integrity errors are found.
+                    - "none": Do not check integrity.
 
         Returns:
             The built dataset.
         """
+        if mode not in ["add", "create", "overwrite"]:
+            raise ValueError(f"mode should be 'add', 'create' or 'overwrite' but got {mode}")
+        if check_integrity not in ["raise", "warn", "none"]:
+            raise ValueError(f"check_integrity should be 'raise', 'warn' or 'none' but got {check_integrity}")
+        if flush_every_n_samples is not None and flush_every_n_samples <= 0:
+            raise ValueError(f"flush_every_n_samples should be greater than 0 but got {flush_every_n_samples}")
+        if compact_every_n_transactions is not None and compact_every_n_transactions <= 0:
+            raise ValueError(
+                f"compact_every_n_transactions should be greater than 0 but got {compact_every_n_transactions}"
+            )
+
         if mode == "add":
             tables = self.open_tables()
         else:
@@ -154,7 +171,12 @@ class DatasetBuilder(ABC):
         # save schema.json
         self.dataset_schema.to_json(self.target_dir / Dataset._SCHEMA_FILE)
 
-        return Dataset(self.target_dir)
+        dataset = Dataset(self.target_dir)
+
+        if check_integrity != "none":
+            handle_integrity_errors(check_dataset_integrity(dataset), raise_or_warn=check_integrity)
+
+        return dataset
 
     def compact_table(self, table_name: str) -> None:
         """Compact a table in the database by cleaning up old versions and compacting files.

--- a/pixano/datasets/dataset.py
+++ b/pixano/datasets/dataset.py
@@ -20,7 +20,7 @@ from pydantic import ConfigDict
 
 from pixano.datasets.queries import TableQueryBuilder
 from pixano.datasets.utils.errors import DatasetAccessError, DatasetPaginationError
-from pixano.datasets.utils.integrity import IntegrityCheck, check_table_integrity, handle_errors
+from pixano.datasets.utils.integrity import IntegrityCheck, check_table_integrity, handle_integrity_errors
 from pixano.features import SchemaGroup, Source, ViewEmbedding, is_view_embedding
 from pixano.utils.python import to_sql_list
 
@@ -507,7 +507,7 @@ class Dataset:
 
         table = self.open_table(table_name)
         if raise_or_warn != "none":
-            handle_errors(
+            handle_integrity_errors(
                 check_table_integrity(table, table_name, self, data, False, ignore_integrity_checks), raise_or_warn
             )
         for d in data:
@@ -673,7 +673,7 @@ class Dataset:
 
         table = self.open_table(table_name)
         if raise_or_warn != "none":
-            handle_errors(
+            handle_integrity_errors(
                 check_table_integrity(table, table_name, self, data, True, ignore_integrity_checks), raise_or_warn
             )
         set_ids = {item.id for item in data}

--- a/pixano/datasets/dataset.py
+++ b/pixano/datasets/dataset.py
@@ -508,7 +508,7 @@ class Dataset:
         table = self.open_table(table_name)
         if raise_or_warn != "none":
             handle_integrity_errors(
-                check_table_integrity(table, table_name, self, data, False, ignore_integrity_checks), raise_or_warn
+                check_table_integrity(table_name, self, data, False, ignore_integrity_checks), raise_or_warn
             )
         for d in data:
             d.created_at = datetime.now()
@@ -530,7 +530,7 @@ class Dataset:
     ) -> list[DatasetItem] | DatasetItem:
         """Add dataset items.
 
-        .. warning::
+        Warn:
             Does not test for integrity of the data.
 
         Args:
@@ -565,8 +565,8 @@ class Dataset:
                 self.add_data(
                     table_name,
                     table_data,
-                    [IntegrityCheck.REF_ID, IntegrityCheck.REF_NAME, IntegrityCheck.REF_TYPE],
-                    raise_or_warn,
+                    [],
+                    "none",
                 )
         return dataset_items if batch else dataset_items[0]
 
@@ -674,7 +674,7 @@ class Dataset:
         table = self.open_table(table_name)
         if raise_or_warn != "none":
             handle_integrity_errors(
-                check_table_integrity(table, table_name, self, data, True, ignore_integrity_checks), raise_or_warn
+                check_table_integrity(table_name, self, data, True, ignore_integrity_checks), raise_or_warn
             )
         set_ids = {item.id for item in data}
         ids_found: dict[str, datetime] = {}
@@ -723,7 +723,7 @@ class Dataset:
     ) -> list[DatasetItem] | tuple[list[DatasetItem], list[DatasetItem]]:
         """Update dataset items.
 
-        .. warning::
+        Warn:
             Does not test for integrity of the data.
 
         Args:
@@ -760,8 +760,8 @@ class Dataset:
                     table_name,
                     table_data,
                     return_separately=True,
-                    ignore_integrity_checks=[IntegrityCheck.REF_ID, IntegrityCheck.REF_NAME, IntegrityCheck.REF_TYPE],
-                    raise_or_warn=raise_or_warn,
+                    ignore_integrity_checks=[],
+                    raise_or_warn="none",
                 )
                 for row in updated:
                     updated_ids.add(row.item_ref.id if table_name != SchemaGroup.ITEM.value else row.id)

--- a/pixano/datasets/utils/__init__.py
+++ b/pixano/datasets/utils/__init__.py
@@ -6,6 +6,12 @@
 
 from .errors import DatasetAccessError, DatasetPaginationError, DatasetWriteError
 from .image import image_to_thumbnail
+from .integrity import (
+    check_dataset_integrity,
+    check_table_integrity,
+    get_integry_checks_from_schemas,
+    handle_integrity_errors,
+)
 from .labels import coco_ids_80to91, coco_names_80, coco_names_91, dota_ids, voc_names
 from .video import create_video_preview
 
@@ -14,11 +20,15 @@ __all__ = [
     "DatasetAccessError",
     "DatasetPaginationError",
     "DatasetWriteError",
+    "check_dataset_integrity",
+    "check_table_integrity",
     "create_video_preview",
     "coco_ids_80to91",
     "coco_names_80",
     "coco_names_91",
     "dota_ids",
+    "get_integry_checks_from_schemas",
+    "handle_integrity_errors",
     "image_to_thumbnail",
     "voc_names",
 ]

--- a/pixano/datasets/utils/__init__.py
+++ b/pixano/datasets/utils/__init__.py
@@ -4,7 +4,7 @@
 # License: CECILL-C
 # =====================================
 
-from .errors import DatasetAccessError, DatasetOffsetLimitError, DatasetPaginationError, DatasetWriteError
+from .errors import DatasetAccessError, DatasetPaginationError, DatasetWriteError
 from .image import image_to_thumbnail
 from .labels import coco_ids_80to91, coco_names_80, coco_names_91, dota_ids, voc_names
 from .video import create_video_preview
@@ -12,7 +12,6 @@ from .video import create_video_preview
 
 __all__ = [
     "DatasetAccessError",
-    "DatasetOffsetLimitError",
     "DatasetPaginationError",
     "DatasetWriteError",
     "create_video_preview",

--- a/pixano/datasets/utils/errors.py
+++ b/pixano/datasets/utils/errors.py
@@ -11,12 +11,6 @@ class DatasetPaginationError(ValueError):
     pass
 
 
-class DatasetOffsetLimitError(DatasetPaginationError):
-    """Error raised when offset reached the limit while paginating a dataset."""
-
-    pass
-
-
 class DatasetAccessError(ValueError):
     """Error raised when accessing a dataset."""
 
@@ -25,5 +19,11 @@ class DatasetAccessError(ValueError):
 
 class DatasetWriteError(ValueError):
     """Error raised when writing to a dataset."""
+
+    pass
+
+
+class DatasetIntegrityError(ValueError):
+    """Error raised when dataset integrity is compromised."""
 
     pass

--- a/pixano/datasets/utils/integrity.py
+++ b/pixano/datasets/utils/integrity.py
@@ -277,7 +277,7 @@ def check_dataset_integrity(dataset: "Dataset") -> list[tuple[IntegrityCheck, st
     return check_errors
 
 
-def handle_errors(
+def handle_integrity_errors(
     check_errors: list[tuple[IntegrityCheck, str, str, str, Any]],
     raise_or_warn: Literal["raise", "warn"] = "raise",
 ):

--- a/pixano/datasets/utils/integrity.py
+++ b/pixano/datasets/utils/integrity.py
@@ -1,0 +1,299 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import warnings
+from enum import Enum
+from types import GenericAlias
+from typing import Any, Literal, cast
+
+import shortuuid
+from lancedb.pydantic import LanceModel
+from lancedb.table import LanceTable
+from pydantic import create_model
+from typing_extensions import TYPE_CHECKING
+
+from pixano.datasets.queries import TableQueryBuilder
+from pixano.datasets.utils.errors import DatasetIntegrityError
+from pixano.features import (
+    AnnotationRef,
+    BaseSchema,
+    EmbeddingRef,
+    EntityRef,
+    SchemaGroup,
+    SchemaRef,
+    Source,
+    ViewRef,
+    is_annotation_ref,
+    is_embedding_ref,
+    is_entity_ref,
+    is_item_ref,
+    is_schema_ref,
+    is_source_ref,
+    is_view_ref,
+)
+
+
+if TYPE_CHECKING:
+    from pixano.datasets import Dataset
+
+
+class IntegrityCheck(Enum):
+    """Integrity check types.
+
+    Attributes:
+        DEFINED_ID: Check if the id field is defined.
+        UNIQUE_ID: Check if the id field is unique.
+        REF_NAME: Check if the ref name is defined in the schema.
+        REF_TYPE: Check if the ref type is defined in the schema.
+        REF_ID: Check if the ref id is stored in the referenced table.
+    """
+
+    DEFINED_ID = 0
+    UNIQUE_ID = 1
+    REF_NAME = 2
+    REF_TYPE = 3
+    REF_ID = 4
+
+
+def get_integry_checks_from_schemas(
+    schemas: list[BaseSchema], table_name: str
+) -> list[list[tuple[str, str, str, str, Any]]]:
+    """Get the integrity checks to perform on a table.
+
+    Args:
+        schemas: List of schemas.
+        table_name: Table name.
+
+    Returns:
+        List of integrity checks to perform on the table. The checks are grouped by type.
+        - check_id: Check id (unique identifier for the checks). It is used to avoid checking subsequent checks with
+            the same id when an error is found.
+        - table: Table name.
+        - schema_id: Schema id (id field).
+        - field_name: Field name.
+        - field: Field value.
+    """
+    checks: list[list[tuple[str, str, str, str, Any]]] = [[] for check in IntegrityCheck]
+    for schema in schemas:
+        schema_id = schema.id
+        check_id = shortuuid.uuid()
+        checks[IntegrityCheck.DEFINED_ID.value].append((check_id, table_name, schema_id, "id", schema_id))
+        checks[IntegrityCheck.UNIQUE_ID.value].append((check_id, table_name, schema_id, "id", schema_id))
+        for field_name, field in schema.model_fields.items():
+            if field_name == "id":
+                continue
+            if isinstance(field.annotation, GenericAlias):
+                continue
+            type_field = field.annotation
+            if is_schema_ref(type_field):
+                checks[IntegrityCheck.REF_NAME.value].append(
+                    (check_id, table_name, schema_id, field_name, getattr(schema, field_name))
+                )
+                checks[IntegrityCheck.REF_TYPE.value].append(
+                    (check_id, table_name, schema_id, field_name, getattr(schema, field_name))
+                )
+                checks[IntegrityCheck.REF_ID.value].append(
+                    (check_id, table_name, schema_id, field_name, getattr(schema, field_name))
+                )
+
+    return checks
+
+
+def check_table_integrity(
+    table: LanceTable,
+    table_name: str,
+    dataset: "Dataset",
+    schemas: list[BaseSchema] | None = None,
+    updating: bool = False,
+    ignore_checks: list[IntegrityCheck] | None = None,
+) -> dict[str, tuple[IntegrityCheck, str, str, str, Any]]:
+    """Check the integrity of a table.
+
+    Args:
+        table: Table to check.
+        table_name: Table name.
+        dataset: Dataset.
+        schemas: List of schemas to insert in table. If None, the schemas are extracted from the table.
+        updating: If True, the table is being updated.
+        ignore_checks: List of integrity checks to ignore.
+
+    Returns:
+        Dictionary with the integrity check errors as values and the check id as key. The errors are tuples with the
+        following values:
+        - check_type: Check type.
+        - table: Table name.
+        - field_name: Field name.
+        - schema_id: Schema id.
+        - field: Field value.
+    """
+    if ignore_checks is not None:
+        ignore_checks_set: set[IntegrityCheck] = {IntegrityCheck(check) for check in ignore_checks}
+    else:
+        ignore_checks_set = set()
+    table_schema = Source if table_name == "source" else dataset.schema.schemas[table_name]
+
+    if schemas is None:
+        if updating:
+            raise ValueError("schemas must be provided when updating a table.")
+        table_schema = cast(BaseSchema, table_schema)
+        fields_to_check = ["id"] + [
+            field_name
+            for field_name, field in table_schema.model_fields.items()
+            if field_name != "id"
+            and not isinstance(field.annotation, GenericAlias)
+            and is_schema_ref(field.annotation)
+        ]
+        model = create_model(
+            "_Schema",
+            __base__=LanceModel,
+            **{field_name: (table_schema.model_fields[field_name].annotation, ...) for field_name in fields_to_check},
+        )
+        schemas = TableQueryBuilder(table).select(fields_to_check).to_pydantic(model)
+        table_ids = [schema.id for schema in schemas]
+    else:
+        if updating:
+            table_ids = [schema.id for schema in schemas]
+        else:
+            table_ids = [row["id"] for row in TableQueryBuilder(table).select(["id"]).to_list()] + [
+                schema.id for schema in schemas
+            ]
+    count_ids: dict[str, int] = {}
+    for id in table_ids:
+        count_ids[id] = count_ids.get(id, 0) + 1
+    integrity_checks = get_integry_checks_from_schemas(schemas, table_name)
+    check_errors: dict[str, tuple[IntegrityCheck, str, str, str, Any]] = {}
+    schemas_refs_to_check: dict[str, list[tuple[str, str, SchemaRef, str]]] = {}
+
+    for check_type_id, checks in enumerate(integrity_checks):
+        check_type = IntegrityCheck(check_type_id)
+        if check_type in ignore_checks_set:
+            continue
+        for check_id, _, schema_id, field_name, field in checks:
+            if check_id in check_errors:
+                continue
+            if check_type == IntegrityCheck.DEFINED_ID and field == "":  # id is not defined
+                check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+            elif check_type == IntegrityCheck.UNIQUE_ID and count_ids[schema_id] > 1:  # id is not unique
+                check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+            elif check_type == IntegrityCheck.REF_NAME:
+                field = cast(SchemaRef, field)
+                if field.name != "" and field.name not in (
+                    list(dataset.schema.schemas.keys()) + ["source"]
+                ):  # ref name is not defined
+                    check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+            elif check_type == IntegrityCheck.REF_TYPE:
+                field = cast(SchemaRef, field)
+                if field.name == "":
+                    continue
+                field_type = type(field)
+                if is_view_ref(field_type):  # field is a view ref
+                    field = cast(ViewRef, field)
+                    if field.name not in dataset.schema.groups[SchemaGroup.VIEW]:  # field name is not a view
+                        check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+                elif is_annotation_ref(field_type):  # field is an annotation ref
+                    field = cast(AnnotationRef, field)
+                    if (
+                        field.name not in dataset.schema.groups[SchemaGroup.ANNOTATION]
+                    ):  # field name is not an annotation
+                        check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+                elif is_embedding_ref(field_type):  # field is an embedding ref
+                    field = cast(EmbeddingRef, field)
+                    if (
+                        field.name not in dataset.schema.groups[SchemaGroup.EMBEDDING]
+                    ):  # field name is not an embedding
+                        check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+                elif is_entity_ref(field_type):  # field is an entity ref
+                    field = cast(EntityRef, field)
+                    if field.name not in dataset.schema.groups[SchemaGroup.ENTITY]:  # field name is not an entity
+                        check_errors[check_id] = (check_type, table_name, field_name, schema_id, field)
+                elif is_item_ref(field_type) or is_source_ref(field_type):
+                    pass  # item_ref and source_ref are validated before.
+            elif check_type == IntegrityCheck.REF_ID:  # ref id and ref item relation checked below
+                field = cast(SchemaRef, field)
+                if field_name == "":
+                    continue
+                if field.name not in schemas_refs_to_check:
+                    schemas_refs_to_check[field.name] = []
+                schemas_refs_to_check[field.name].append((check_id, schema_id, field, field_name))
+
+    if len(check_errors) == len(
+        {check_id for check_id, *_ in integrity_checks[IntegrityCheck.REF_ID.value]}
+    ):  # all checks failed, no need to check later checks that are costly
+        return check_errors
+
+    for ref_schema_name, refs in schemas_refs_to_check.items():
+        if ref_schema_name == "":
+            continue
+        ref_all_ids = set(dataset.get_all_ids(ref_schema_name))
+        for check_id, schema_id, field_ref, field_name in refs:
+            if field_ref.id not in ref_all_ids:
+                check_errors[check_id] = (
+                    IntegrityCheck.REF_ID,
+                    table_name,
+                    field_name,
+                    schema_id,
+                    field_ref,
+                )
+
+    return check_errors
+
+
+def check_dataset_integrity(dataset: "Dataset") -> dict[str, tuple[IntegrityCheck, str, str, str, Any]]:
+    """Check the integrity of a dataset.
+
+    Args:
+        dataset: Dataset.
+
+    Returns:
+        Dictionary with the integrity check errors as values and the check id as key. The errors are tuples with the
+        following values:
+        - check_type: Check type.
+        - table: Table name.
+        - field_name: Field name.
+        - schema_id: Schema id.
+        - field: Field value.
+    """
+    check_errors: dict[str, tuple[IntegrityCheck, str, str, str, Any]] = {}
+    for table_name, table in dataset.open_tables(names=None, exclude_embeddings=False).items():
+        check_errors.update(check_table_integrity(table, table_name, dataset))
+    return check_errors
+
+
+def handle_errors(
+    check_errors: dict[str, tuple[IntegrityCheck, str, str, str, Any]],
+    raise_or_warn: Literal["raise", "warn"] = "raise",
+):
+    """Handle integrity check errors.
+
+    Args:
+        check_errors: Dictionary with the integrity check errors as values and the check id as key.
+        raise_or_warn: If "raise", raise a ValueError with the errors. If "warn", warns a UserWarning with the errors.
+    """
+    if len(check_errors) == 0:
+        return
+    message = "Integrity check errors:\n"
+    for check_id, (check_type, table_name, field_name, schema_id, field) in check_errors.items():
+        message += "- "
+        if check_type == IntegrityCheck.DEFINED_ID:
+            message += f"An id is not defined in table {table_name}.\n"
+        elif check_type == IntegrityCheck.UNIQUE_ID:
+            message += f"The id {schema_id} is not unique in table {table_name}.\n"
+        elif check_type == IntegrityCheck.REF_NAME:
+            message += f"The reference {field_name} from {schema_id} to the table {field.name} does not exist.\n"
+        elif check_type == IntegrityCheck.REF_TYPE:
+            message += (
+                f"The reference {field_name} from {schema_id} to the table {field.name} is to an invalid type. "
+                f"Got {type(field)}.\n"
+            )
+        elif check_type == IntegrityCheck.REF_ID:
+            message += (
+                f"The reference {field_name} from {schema_id} to the table {field.name} has an invalid id. Got "
+                f"{field.id}.\n"
+            )
+    if raise_or_warn == "raise":
+        raise DatasetIntegrityError(message)
+    else:
+        warnings.warn(message, category=UserWarning)

--- a/tests/app/routers/test_utils.py
+++ b/tests/app/routers/test_utils.py
@@ -173,7 +173,7 @@ def test_update_rows(
     with pytest.raises(HTTPException) as error:
         update_rows(dataset_multi_view_tracking_and_image_copy, "bbox_image", ["wrong_input"])
     assert error.value.status_code == 400
-    assert error.value.detail == "Invalid data."
+    assert error.value.detail == "Invalid data.\n'str' object has no attribute 'to_row'"
 
     # Test wrong data
     with pytest.raises(HTTPException) as error:
@@ -209,7 +209,7 @@ def test_create_rows(
     with pytest.raises(HTTPException) as error:
         create_rows(dataset_multi_view_tracking_and_image_copy, "bbox_image", ["wrong_input"])
     assert error.value.status_code == 400
-    assert error.value.detail == "Invalid data."
+    assert error.value.detail == "Invalid data.\n'str' object has no attribute 'to_row'"
 
     # Test wrong data
     with pytest.raises(HTTPException) as error:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,9 @@ from tests.fixtures.features.bbox import (
 )
 from tests.fixtures.features.compressed_rle import counts, rle, size
 from tests.fixtures.features.embedding import dumb_embedding_function, embedding_8, view_embedding_8
-from tests.fixtures.features.entity import entity_category
+from tests.fixtures.features.entity import (
+    entity_category,
+    two_image_entities_from_dataset_multiview_tracking_and_image,
+)
 from tests.fixtures.features.item import item_categories, item_categories_name_index, item_metadata
 from tests.fixtures.features.sequence_frame import sequence_frame_category

--- a/tests/datasets/builders/test_dataset_builder.py
+++ b/tests/datasets/builders/test_dataset_builder.py
@@ -67,6 +67,7 @@ class TestDatasetBuilder:
             flush_every_n_samples=flush_every_n_samples,
             compact_every_n_transactions=compact_every_n_transactions,
             mode="create",
+            check_integrity=check_integrity,
         )
         assert dataset_builder_image_bboxes_keypoint.info.description == "Description dataset_image_bboxes_keypoint."
 

--- a/tests/datasets/builders/test_dataset_builder.py
+++ b/tests/datasets/builders/test_dataset_builder.py
@@ -48,8 +48,14 @@ class TestDatasetBuilder:
     @pytest.mark.parametrize("mode", ["create", "overwrite", "add"])
     @pytest.mark.parametrize("flush_every_n_samples", [None, 3])
     @pytest.mark.parametrize("compact_every_n_transactions", [None, 2])
+    @pytest.mark.parametrize("check_integrity", ["raise", "warn", "none"])
     def test_build(
-        self, dataset_builder_image_bboxes_keypoint, mode, flush_every_n_samples, compact_every_n_transactions
+        self,
+        dataset_builder_image_bboxes_keypoint,
+        mode,
+        flush_every_n_samples,
+        compact_every_n_transactions,
+        check_integrity,
     ):
         # Mock the compact method to register the call count
         compact_dataset_mock = MagicMock()
@@ -91,6 +97,7 @@ class TestDatasetBuilder:
                     flush_every_n_samples=flush_every_n_samples,
                     compact_every_n_transactions=compact_every_n_transactions,
                     mode=mode,
+                    check_integrity=check_integrity,
                 )
             return
 
@@ -110,6 +117,7 @@ class TestDatasetBuilder:
             flush_every_n_samples=flush_every_n_samples,
             compact_every_n_transactions=compact_every_n_transactions,
             mode=mode,
+            check_integrity="none",
         )
 
         assert dataset.num_rows == 6 if mode == "overwrite" else 11
@@ -128,7 +136,7 @@ class TestDatasetBuilder:
         for mock in table_mocks:
             mock.call_count == 2 if flush_every_n_samples is None else 1
 
-    def test_build_error(self):
+    def test_build_error(self, dataset_builder_image_bboxes_keypoint):
         class WrongIdBuilder(DatasetBuilder):
             def generate_data(self):
                 yield {
@@ -146,3 +154,17 @@ class TestDatasetBuilder:
             WrongSchemaNameBuilder(
                 tempfile.mkdtemp(), DatasetItem, DatasetInfo(name="test", description="test")
             ).build()
+
+        with pytest.raises(ValueError, match="mode should be 'add', 'create' or 'overwrite' but got wrong_mode"):
+            dataset_builder_image_bboxes_keypoint.build(mode="wrong_mode")
+
+        with pytest.raises(
+            ValueError, match="check_integrity should be 'raise', 'warn' or 'none' but got wrong_check_integrity"
+        ):
+            dataset_builder_image_bboxes_keypoint.build(check_integrity="wrong_check_integrity")
+
+        with pytest.raises(ValueError, match="flush_every_n_samples should be greater than 0 but got -1"):
+            dataset_builder_image_bboxes_keypoint.build(flush_every_n_samples=-1)
+
+        with pytest.raises(ValueError, match="compact_every_n_transactions should be greater than 0 but got -1"):
+            dataset_builder_image_bboxes_keypoint.build(compact_every_n_transactions=-1)

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -17,6 +17,7 @@ from pixano.datasets import Dataset
 from pixano.datasets.dataset_features_values import DatasetFeaturesValues
 from pixano.datasets.dataset_info import DatasetInfo
 from pixano.datasets.dataset_schema import DatasetItem, DatasetSchema, SchemaRelation
+from pixano.datasets.utils.errors import DatasetIntegrityError
 from pixano.features import BBox, Image, Item
 from pixano.features.schemas.embeddings.embedding import ViewEmbedding
 from pixano.features.types.schema_reference import ItemRef, ViewRef
@@ -333,7 +334,7 @@ class TestDataset:
                     {
                         "id": "bbox_2_1_0_0",
                         "item_ref": {"name": "item", "id": "2"},
-                        "view_ref": {"name": "video", "id": "video_2_1"},
+                        "view_ref": {"name": "video", "id": "video_2_0"},
                         "entity_ref": {"name": "entities_video", "id": "entity_video_2_1_0"},
                         "source_ref": {"id": "source_0", "name": "source"},
                         "coords": [0.0, 0.0, 0.0, 0.0],
@@ -346,7 +347,7 @@ class TestDataset:
                     {
                         "id": "bbox_2_1_0_1",
                         "item_ref": {"name": "item", "id": "2"},
-                        "view_ref": {"name": "video", "id": "video_2_1"},
+                        "view_ref": {"name": "video", "id": "video_2_0"},
                         "entity_ref": {"name": "entities_video", "id": "entity_video_2_1_0"},
                         "source_ref": {"id": "source_0", "name": "source"},
                         "coords": [1.0, 1.0, 25.0, 25.0],
@@ -825,11 +826,20 @@ class TestDataset:
             dataset_image_bboxes_keypoint_copy.add_data("item", data)
 
         data = [new_item]
-        with pytest.raises(ValueError, match=re.escape("IDs ['0'] already exist in the table item.")):
+        with pytest.raises(
+            DatasetIntegrityError,
+            match=re.escape("Integrity check errors:\n- The id 0 is not unique in table item.\n"),
+        ):
             dataset_image_bboxes_keypoint_copy.add_data("item", data)
 
         data = [new_item, new_item]
-        with pytest.raises(ValueError, match="All data must have unique ids."):
+        with pytest.raises(
+            DatasetIntegrityError,
+            match=(
+                "Integrity check errors:\n- The id 0 is not unique in table item.\n- The id 0 is not unique in "
+                "table item.\n"
+            ),
+        ):
             dataset_image_bboxes_keypoint_copy.add_data("item", data)
 
     def test_add_dataset_items(self, dataset_image_bboxes_keypoint_copy: Dataset):
@@ -873,11 +883,20 @@ class TestDataset:
             dataset_image_bboxes_keypoint_copy.add_dataset_items(data)
 
         data = [new_item]
-        with pytest.raises(ValueError, match=re.escape("IDs ['image_1'] already exist in the table image.")):
+        with pytest.raises(
+            DatasetIntegrityError,
+            match=re.escape("Integrity check errors:\n- The id image_1 is not unique in table image.\n"),
+        ):
             dataset_image_bboxes_keypoint_copy.add_dataset_items(data)
 
         data = [new_item, new_item]
-        with pytest.raises(ValueError, match="All data must have unique ids."):
+        with pytest.raises(
+            DatasetIntegrityError,
+            match=(
+                "Integrity check errors:\n- The id image_1 is not unique in table image.\n- The id image_1 "
+                "is not unique in table image.\n"
+            ),
+        ):
             dataset_image_bboxes_keypoint_copy.add_dataset_items(data)
 
     def test_delete_data(self, dataset_image_bboxes_keypoint_copy: Dataset):
@@ -933,7 +952,13 @@ class TestDataset:
         updated_item = item.model_copy()
         updated_item.id = "1"
 
-        with pytest.raises(ValueError, match="All data must have unique ids."):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Integrity check errors:\n- The id 1 is not unique in table item.\n- The "
+                "id 1 is not unique in table item.\n"
+            ),
+        ):
             dataset_image_bboxes_keypoint_copy.update_data("item", [updated_item, updated_item])
 
         data = [updated_item, "0"]
@@ -992,7 +1017,13 @@ class TestDataset:
         updated_item = item.model_copy()
         updated_item.id = "0"
 
-        with pytest.raises(ValueError, match="All data must have unique ids."):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Integrity check errors:\n- The id image_1 is not unique in table image.\n- The id image_1 "
+                "is not unique in table image.\n"
+            ),
+        ):
             dataset_image_bboxes_keypoint_copy.update_dataset_items([updated_item, updated_item])
 
         data = [updated_item, "0"]

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -882,23 +882,6 @@ class TestDataset:
         with pytest.raises(ValueError, match="All data must be instances of the same DatasetItem."):
             dataset_image_bboxes_keypoint_copy.add_dataset_items(data)
 
-        data = [new_item]
-        with pytest.raises(
-            DatasetIntegrityError,
-            match=re.escape("Integrity check errors:\n- The id image_1 is not unique in table image.\n"),
-        ):
-            dataset_image_bboxes_keypoint_copy.add_dataset_items(data)
-
-        data = [new_item, new_item]
-        with pytest.raises(
-            DatasetIntegrityError,
-            match=(
-                "Integrity check errors:\n- The id image_1 is not unique in table image.\n- The id image_1 "
-                "is not unique in table image.\n"
-            ),
-        ):
-            dataset_image_bboxes_keypoint_copy.add_dataset_items(data)
-
     def test_delete_data(self, dataset_image_bboxes_keypoint_copy: Dataset):
         dataset_image_bboxes_keypoint_copy.get_data("item", ids=["0", "1"])[0]
         ids_not_found = dataset_image_bboxes_keypoint_copy.delete_data("item", ids=["0", "1", "-1"])
@@ -1016,15 +999,6 @@ class TestDataset:
         item = dataset_image_bboxes_keypoint_copy.get_dataset_items(ids=["1"])[0]
         updated_item = item.model_copy()
         updated_item.id = "0"
-
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Integrity check errors:\n- The id image_1 is not unique in table image.\n- The id image_1 "
-                "is not unique in table image.\n"
-            ),
-        ):
-            dataset_image_bboxes_keypoint_copy.update_dataset_items([updated_item, updated_item])
 
         data = [updated_item, "0"]
         with pytest.raises(ValueError, match="All data must be instances of the same DatasetItem."):

--- a/tests/datasets/utils/test_integrity.py
+++ b/tests/datasets/utils/test_integrity.py
@@ -101,14 +101,14 @@ def test_check_table_integrity_defined_id(
 ):
     table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
-    assert errors == {}
+    assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = ""
     bboxes[1].id = "unique_id"
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
-    assert list(errors.values())[0] == (IntegrityCheck.DEFINED_ID, "bbox_image", "id", "", "")
+    assert errors[0] == (IntegrityCheck.DEFINED_ID, "bbox_image", "id", "", "")
 
 
 def test_check_table_integrity_defined_ref_ignore(
@@ -116,7 +116,7 @@ def test_check_table_integrity_defined_ref_ignore(
 ):
     table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
-    assert errors == {}
+    assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = ""
@@ -124,7 +124,7 @@ def test_check_table_integrity_defined_ref_ignore(
     errors = check_table_integrity(
         table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes, ignore_checks=[IntegrityCheck.DEFINED_ID]
     )
-    assert errors == {}
+    assert errors == []
 
 
 def test_check_table_integrity_unique_id(
@@ -133,18 +133,18 @@ def test_check_table_integrity_unique_id(
     # Test no error
     table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
-    assert errors == {}
+    assert errors == []
 
     # Test one error with updating is False
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[1].id = "unique_id"
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
-    assert list(errors.values())[0] == (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "bbox_image_0", "bbox_image_0")
+    assert errors[0] == (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "bbox_image_0", "bbox_image_0")
 
     # Test updating is True
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes, True)
-    assert errors == {}
+    assert errors == []
 
     # Test two errors
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
@@ -152,7 +152,7 @@ def test_check_table_integrity_unique_id(
     bboxes[1].id = "not_unique_id"
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 2
-    assert list(errors.values()) == [
+    assert errors == [
         (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "not_unique_id", "not_unique_id"),
         (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "not_unique_id", "not_unique_id"),
     ]
@@ -163,7 +163,7 @@ def test_check_table_integrity_ref_name(
 ):
     table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
-    assert errors == {}
+    assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = "unique_id_0"
@@ -171,7 +171,7 @@ def test_check_table_integrity_ref_name(
     bboxes[0].view_ref.name = "not_image"
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
-    assert list(errors.values())[0] == (
+    assert errors[0] == (
         IntegrityCheck.REF_NAME,
         "bbox_image",
         "view_ref",
@@ -189,7 +189,7 @@ def test_check_table_integrity_ref_type(
 ):
     table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
-    assert errors == {}
+    assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = "unique_id_0"
@@ -199,7 +199,7 @@ def test_check_table_integrity_ref_type(
     setattr(bboxes[0], ref_attribute, ref_attr)
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
-    assert list(errors.values())[0] == (
+    assert errors[0] == (
         IntegrityCheck.REF_TYPE,
         "bbox_image",
         ref_attribute,
@@ -214,7 +214,7 @@ def test_check_table_integrity_ref_id(
 ):
     table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
-    assert errors == {}
+    assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = "unique_id_0"
@@ -223,7 +223,7 @@ def test_check_table_integrity_ref_id(
     bboxes[1].source_ref.id = "not_source_id"
     errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 2
-    assert list(errors.values()) == [
+    assert errors == [
         (
             IntegrityCheck.REF_ID,
             "bbox_image",
@@ -247,7 +247,7 @@ def test_check_dataset_integrity(
     two_image_entities_from_dataset_multiview_tracking_and_image,
 ):
     errors = check_dataset_integrity(dataset_multi_view_tracking_and_image_copy)
-    assert errors == {}
+    assert errors == []
 
     bboxes = [
         dataset_multi_view_tracking_and_image_copy.schema.schemas["bbox_image"].model_validate(bbox.model_dump())
@@ -275,7 +275,7 @@ def test_check_dataset_integrity(
     errors = check_dataset_integrity(dataset_multi_view_tracking_and_image_copy)
 
     assert len(errors) == 4
-    assert list(errors.values()) == [
+    assert errors == [
         (IntegrityCheck.REF_NAME, "entity_image", "view_ref", "unique_id_0", ViewRef(name="not_image", id="image_0")),
         (IntegrityCheck.REF_ID, "entity_image", "item_ref", "unique_id_1", ItemRef(name="item", id="not_item_id")),
         (

--- a/tests/datasets/utils/test_integrity.py
+++ b/tests/datasets/utils/test_integrity.py
@@ -1,0 +1,295 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import pytest
+
+from pixano.datasets.utils.integrity import (
+    IntegrityCheck,
+    check_dataset_integrity,
+    check_table_integrity,
+    get_integry_checks_from_schemas,
+)
+from pixano.features import EntityRef, ItemRef, SourceRef, ViewRef
+
+
+def test_get_integrity_checks_from_schemas(two_difficult_bboxes_from_dataset_multiview_tracking_and_image):
+    checks = get_integry_checks_from_schemas(two_difficult_bboxes_from_dataset_multiview_tracking_and_image, "bbox")
+    check_ids = [check[0] for check in checks[0]]
+    assert checks == [
+        [
+            (check_ids[0], "bbox", "bbox_image_0", "id", "bbox_image_0"),
+            (check_ids[1], "bbox", "bbox_image_1", "id", "bbox_image_1"),
+        ],
+        [
+            (check_ids[0], "bbox", "bbox_image_0", "id", "bbox_image_0"),
+            (check_ids[1], "bbox", "bbox_image_1", "id", "bbox_image_1"),
+        ],
+        [
+            (check_ids[0], "bbox", "bbox_image_0", "item_ref", ItemRef(name="item", id="0")),
+            (check_ids[0], "bbox", "bbox_image_0", "view_ref", ViewRef(name="image", id="image_0")),
+            (
+                check_ids[0],
+                "bbox",
+                "bbox_image_0",
+                "entity_ref",
+                EntityRef(name="entity_image", id="entity_image_0"),
+            ),
+            (check_ids[0], "bbox", "bbox_image_0", "source_ref", SourceRef(name="source", id="source_0")),
+            (check_ids[1], "bbox", "bbox_image_1", "item_ref", ItemRef(name="item", id="1")),
+            (check_ids[1], "bbox", "bbox_image_1", "view_ref", ViewRef(name="image", id="image_1")),
+            (
+                check_ids[1],
+                "bbox",
+                "bbox_image_1",
+                "entity_ref",
+                EntityRef(name="entity_image", id="entity_image_1"),
+            ),
+            (check_ids[1], "bbox", "bbox_image_1", "source_ref", SourceRef(name="source", id="source_1")),
+        ],
+        [
+            (check_ids[0], "bbox", "bbox_image_0", "item_ref", ItemRef(name="item", id="0")),
+            (check_ids[0], "bbox", "bbox_image_0", "view_ref", ViewRef(name="image", id="image_0")),
+            (
+                check_ids[0],
+                "bbox",
+                "bbox_image_0",
+                "entity_ref",
+                EntityRef(name="entity_image", id="entity_image_0"),
+            ),
+            (check_ids[0], "bbox", "bbox_image_0", "source_ref", SourceRef(name="source", id="source_0")),
+            (check_ids[1], "bbox", "bbox_image_1", "item_ref", ItemRef(name="item", id="1")),
+            (check_ids[1], "bbox", "bbox_image_1", "view_ref", ViewRef(name="image", id="image_1")),
+            (
+                check_ids[1],
+                "bbox",
+                "bbox_image_1",
+                "entity_ref",
+                EntityRef(name="entity_image", id="entity_image_1"),
+            ),
+            (check_ids[1], "bbox", "bbox_image_1", "source_ref", SourceRef(name="source", id="source_1")),
+        ],
+        [
+            (check_ids[0], "bbox", "bbox_image_0", "item_ref", ItemRef(name="item", id="0")),
+            (check_ids[0], "bbox", "bbox_image_0", "view_ref", ViewRef(name="image", id="image_0")),
+            (
+                check_ids[0],
+                "bbox",
+                "bbox_image_0",
+                "entity_ref",
+                EntityRef(name="entity_image", id="entity_image_0"),
+            ),
+            (check_ids[0], "bbox", "bbox_image_0", "source_ref", SourceRef(name="source", id="source_0")),
+            (check_ids[1], "bbox", "bbox_image_1", "item_ref", ItemRef(name="item", id="1")),
+            (check_ids[1], "bbox", "bbox_image_1", "view_ref", ViewRef(name="image", id="image_1")),
+            (
+                check_ids[1],
+                "bbox",
+                "bbox_image_1",
+                "entity_ref",
+                EntityRef(name="entity_image", id="entity_image_1"),
+            ),
+            (check_ids[1], "bbox", "bbox_image_1", "source_ref", SourceRef(name="source", id="source_1")),
+        ],
+    ]
+
+
+def test_check_table_integrity_defined_id(
+    dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
+):
+    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    assert errors == {}
+
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[0].id = ""
+    bboxes[1].id = "unique_id"
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    assert len(errors) == 1
+    assert list(errors.values())[0] == (IntegrityCheck.DEFINED_ID, "bbox_image", "id", "", "")
+
+
+def test_check_table_integrity_defined_ref_ignore(
+    dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
+):
+    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    assert errors == {}
+
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[0].id = ""
+    bboxes[1].id = "unique_id"
+    errors = check_table_integrity(
+        table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes, ignore_checks=[IntegrityCheck.DEFINED_ID]
+    )
+    assert errors == {}
+
+
+def test_check_table_integrity_unique_id(
+    dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
+):
+    # Test no error
+    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    assert errors == {}
+
+    # Test one error with updating is False
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[1].id = "unique_id"
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    assert len(errors) == 1
+    assert list(errors.values())[0] == (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "bbox_image_0", "bbox_image_0")
+
+    # Test updating is True
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes, True)
+    assert errors == {}
+
+    # Test two errors
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[0].id = "not_unique_id"
+    bboxes[1].id = "not_unique_id"
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    assert len(errors) == 2
+    assert list(errors.values()) == [
+        (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "not_unique_id", "not_unique_id"),
+        (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "not_unique_id", "not_unique_id"),
+    ]
+
+
+def test_check_table_integrity_ref_name(
+    dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
+):
+    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    assert errors == {}
+
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[0].id = "unique_id_0"
+    bboxes[1].id = "unique_id_1"
+    bboxes[0].view_ref.name = "not_image"
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    assert len(errors) == 1
+    assert list(errors.values())[0] == (
+        IntegrityCheck.REF_NAME,
+        "bbox_image",
+        "view_ref",
+        "unique_id_0",
+        bboxes[0].view_ref,
+    )
+
+
+@pytest.mark.parametrize("ref_attribute, ref_name", (("view_ref", "entity_image"), ("entity_ref", "image")))
+def test_check_table_integrity_ref_type(
+    dataset_multi_view_tracking_and_image,
+    two_difficult_bboxes_from_dataset_multiview_tracking_and_image,
+    ref_attribute,
+    ref_name,
+):
+    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    assert errors == {}
+
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[0].id = "unique_id_0"
+    bboxes[1].id = "unique_id_1"
+    ref_attr = getattr(bboxes[0], ref_attribute)
+    ref_attr.name = ref_name
+    setattr(bboxes[0], ref_attribute, ref_attr)
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    assert len(errors) == 1
+    assert list(errors.values())[0] == (
+        IntegrityCheck.REF_TYPE,
+        "bbox_image",
+        ref_attribute,
+        "unique_id_0",
+        ref_attr,
+    )
+
+
+def test_check_table_integrity_ref_id(
+    dataset_multi_view_tracking_and_image,
+    two_difficult_bboxes_from_dataset_multiview_tracking_and_image,
+):
+    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    assert errors == {}
+
+    bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
+    bboxes[0].id = "unique_id_0"
+    bboxes[1].id = "unique_id_1"
+    bboxes[0].view_ref.id = "not_image_id"
+    bboxes[1].source_ref.id = "not_source_id"
+    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    assert len(errors) == 2
+    assert list(errors.values()) == [
+        (
+            IntegrityCheck.REF_ID,
+            "bbox_image",
+            "view_ref",
+            "unique_id_0",
+            bboxes[0].view_ref,
+        ),
+        (
+            IntegrityCheck.REF_ID,
+            "bbox_image",
+            "source_ref",
+            "unique_id_1",
+            bboxes[1].source_ref,
+        ),
+    ]
+
+
+def test_check_dataset_integrity(
+    dataset_multi_view_tracking_and_image_copy,
+    two_difficult_bboxes_from_dataset_multiview_tracking_and_image,
+    two_image_entities_from_dataset_multiview_tracking_and_image,
+):
+    errors = check_dataset_integrity(dataset_multi_view_tracking_and_image_copy)
+    assert errors == {}
+
+    bboxes = [
+        dataset_multi_view_tracking_and_image_copy.schema.schemas["bbox_image"].model_validate(bbox.model_dump())
+        for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image
+    ]
+    bboxes[0].id = "unique_id_0"
+    bboxes[1].id = "unique_id_1"
+    bboxes[0].entity_ref.name = "not_entity_image"
+    bboxes[1].source_ref.id = "not_source_id"
+
+    entities = [
+        dataset_multi_view_tracking_and_image_copy.schema.schemas["entity_image"].model_validate(entity.model_dump())
+        for entity in two_image_entities_from_dataset_multiview_tracking_and_image
+    ]
+    entities[0].id = "unique_id_0"
+    entities[1].id = "unique_id_1"
+    entities[0].view_ref.name = "not_image"
+    entities[1].item_ref.id = "not_item_id"
+
+    bbox_table = dataset_multi_view_tracking_and_image_copy.open_table("bbox_image")
+    bbox_table.add(bboxes)
+    entity_table = dataset_multi_view_tracking_and_image_copy.open_table("entity_image")
+    entity_table.add(entities)
+
+    errors = check_dataset_integrity(dataset_multi_view_tracking_and_image_copy)
+
+    assert len(errors) == 4
+    assert list(errors.values()) == [
+        (IntegrityCheck.REF_NAME, "entity_image", "view_ref", "unique_id_0", ViewRef(name="not_image", id="image_0")),
+        (IntegrityCheck.REF_ID, "entity_image", "item_ref", "unique_id_1", ItemRef(name="item", id="not_item_id")),
+        (
+            IntegrityCheck.REF_NAME,
+            "bbox_image",
+            "entity_ref",
+            "unique_id_0",
+            EntityRef(name="not_entity_image", id="entity_image_0"),
+        ),
+        (
+            IntegrityCheck.REF_ID,
+            "bbox_image",
+            "source_ref",
+            "unique_id_1",
+            SourceRef(name="source", id="not_source_id"),
+        ),
+    ]

--- a/tests/datasets/utils/test_integrity.py
+++ b/tests/datasets/utils/test_integrity.py
@@ -99,14 +99,13 @@ def test_get_integrity_checks_from_schemas(two_difficult_bboxes_from_dataset_mul
 def test_check_table_integrity_defined_id(
     dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
 ):
-    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, None)
     assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = ""
     bboxes[1].id = "unique_id"
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
     assert errors[0] == (IntegrityCheck.DEFINED_ID, "bbox_image", "id", "", "")
 
@@ -114,15 +113,14 @@ def test_check_table_integrity_defined_id(
 def test_check_table_integrity_defined_ref_ignore(
     dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
 ):
-    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, None)
     assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = ""
     bboxes[1].id = "unique_id"
     errors = check_table_integrity(
-        table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes, ignore_checks=[IntegrityCheck.DEFINED_ID]
+        "bbox_image", dataset_multi_view_tracking_and_image, bboxes, ignore_checks=[IntegrityCheck.DEFINED_ID]
     )
     assert errors == []
 
@@ -131,26 +129,25 @@ def test_check_table_integrity_unique_id(
     dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
 ):
     # Test no error
-    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, None)
     assert errors == []
 
     # Test one error with updating is False
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[1].id = "unique_id"
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
     assert errors[0] == (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "bbox_image_0", "bbox_image_0")
 
     # Test updating is True
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes, True)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes, True)
     assert errors == []
 
     # Test two errors
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = "not_unique_id"
     bboxes[1].id = "not_unique_id"
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 2
     assert errors == [
         (IntegrityCheck.UNIQUE_ID, "bbox_image", "id", "not_unique_id", "not_unique_id"),
@@ -161,15 +158,14 @@ def test_check_table_integrity_unique_id(
 def test_check_table_integrity_ref_name(
     dataset_multi_view_tracking_and_image, two_difficult_bboxes_from_dataset_multiview_tracking_and_image
 ):
-    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, None)
     assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
     bboxes[0].id = "unique_id_0"
     bboxes[1].id = "unique_id_1"
     bboxes[0].view_ref.name = "not_image"
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
     assert errors[0] == (
         IntegrityCheck.REF_NAME,
@@ -187,8 +183,7 @@ def test_check_table_integrity_ref_type(
     ref_attribute,
     ref_name,
 ):
-    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, None)
     assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
@@ -197,7 +192,7 @@ def test_check_table_integrity_ref_type(
     ref_attr = getattr(bboxes[0], ref_attribute)
     ref_attr.name = ref_name
     setattr(bboxes[0], ref_attribute, ref_attr)
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 1
     assert errors[0] == (
         IntegrityCheck.REF_TYPE,
@@ -212,8 +207,7 @@ def test_check_table_integrity_ref_id(
     dataset_multi_view_tracking_and_image,
     two_difficult_bboxes_from_dataset_multiview_tracking_and_image,
 ):
-    table = dataset_multi_view_tracking_and_image.open_table("bbox_image")
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, None)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, None)
     assert errors == []
 
     bboxes = [bbox.model_copy(deep=True) for bbox in two_difficult_bboxes_from_dataset_multiview_tracking_and_image]
@@ -221,7 +215,7 @@ def test_check_table_integrity_ref_id(
     bboxes[1].id = "unique_id_1"
     bboxes[0].view_ref.id = "not_image_id"
     bboxes[1].source_ref.id = "not_source_id"
-    errors = check_table_integrity(table, "bbox_image", dataset_multi_view_tracking_and_image, bboxes)
+    errors = check_table_integrity("bbox_image", dataset_multi_view_tracking_and_image, bboxes)
     assert len(errors) == 2
     assert errors == [
         (

--- a/tests/fixtures/app/routers/models/annotations.py
+++ b/tests/fixtures/app/routers/models/annotations.py
@@ -23,7 +23,7 @@ def two_difficult_bboxes_models_from_dataset_multiview_tracking_and_image():
                 "data": {
                     "item_ref": {"name": "item", "id": "0"},
                     "view_ref": {"name": "image", "id": "image_0"},
-                    "entity_ref": {"name": "entities_image", "id": "entity_image_0"},
+                    "entity_ref": {"name": "entity_image", "id": "entity_image_0"},
                     "source_ref": {"id": "source_0", "name": "source"},
                     "coords": [0.0, 0.0, 0.0, 0.0],
                     "format": "xywh",
@@ -42,7 +42,7 @@ def two_difficult_bboxes_models_from_dataset_multiview_tracking_and_image():
                 "data": {
                     "item_ref": {"name": "item", "id": "1"},
                     "view_ref": {"name": "image", "id": "image_1"},
-                    "entity_ref": {"name": "entities_image", "id": "entity_image_1"},
+                    "entity_ref": {"name": "entity_image", "id": "entity_image_1"},
                     "source_ref": {"id": "source_1", "name": "source"},
                     "coords": [1.0, 1.0, 25.0, 25.0],
                     "format": "xywh",

--- a/tests/fixtures/datasets/builders/builder.py
+++ b/tests/fixtures/datasets/builders/builder.py
@@ -175,27 +175,27 @@ def generate_data_multi_view_tracking_and_image(num_rows: int, schemas: dict[str
                         updated_at=datetime(2021, 1, 1, 0, 0, 0),
                     )
                 )
-                tracklets.append(
-                    schemas["tracklets"](
-                        id=f"tracklet_{i}_{j}",
-                        item_ref=ItemRef(id=item_id),
-                        parent_ref=ViewRef(id=f"track_{i}_{j}", name="tracks"),
-                        view_ref=ViewRef(id=f"video_{i}_{j}", name="video"),
-                        start_timestep=j,
-                        end_timestep=j * 4,
-                        start_timestamp=j * 0.1,
-                        end_timestamp=j * 4 * 0.1,
-                        created_at=datetime(2021, 1, 1, 0, 0, 0),
-                        updated_at=datetime(2021, 1, 1, 0, 0, 0),
-                    )
-                )
                 for k in range(num_frames):
+                    tracklets.append(
+                        schemas["tracklets"](
+                            id=f"tracklet_{i}_{j}_{k}",
+                            item_ref=ItemRef(id=item_id),
+                            parent_ref=ViewRef(id=f"track_{i}_{j}", name="tracks"),
+                            view_ref=ViewRef(id=f"video_{i}_{k}", name="video"),
+                            start_timestep=j,
+                            end_timestep=j * 4,
+                            start_timestamp=j * 0.1,
+                            end_timestamp=j * 4 * 0.1,
+                            created_at=datetime(2021, 1, 1, 0, 0, 0),
+                            updated_at=datetime(2021, 1, 1, 0, 0, 0),
+                        )
+                    )
                     ## Entity video
                     entities_video.append(
                         schemas["entities_video"](
                             id=f"entity_video_{i}_{j}_{k}",
                             item_ref=ItemRef(id=item_id),
-                            view_ref=ViewRef(id=f"video_{i}_{j}", name="video"),
+                            view_ref=ViewRef(id=f"video_{i}_{k}", name="video"),
                             parent_ref=EntityRef(id=f"track_{i}_{j}", name="tracks"),
                             created_at=datetime(2021, 1, 1, 0, 0, 0),
                             updated_at=datetime(2021, 1, 1, 0, 0, 0),
@@ -212,7 +212,7 @@ def generate_data_multi_view_tracking_and_image(num_rows: int, schemas: dict[str
                                 confidence=0.25 * m,
                                 id=f"bbox_{i}_{j}_{k}_{m}",
                                 item_ref=ItemRef(id=item_id),
-                                view_ref=ViewRef(id=f"video_{i}_{j}", name="video"),
+                                view_ref=ViewRef(id=f"video_{i}_{k}", name="video"),
                                 entity_ref=EntityRef(id=f"entity_video_{i}_{j}_{k}", name="entities_video"),
                                 source_ref=SourceRef(id="source_0"),
                                 created_at=datetime(2021, 1, 1, 0, 0, 0),
@@ -227,7 +227,7 @@ def generate_data_multi_view_tracking_and_image(num_rows: int, schemas: dict[str
                                 states=["visible" if m % 2 == 0 else "invisible"],
                                 id=f"keypoints_video_{i}_{j}_{k}_{m}",
                                 item_ref=ItemRef(id=item_id),
-                                view_ref=ViewRef(id=f"video_{i}_{j}", name="video"),
+                                view_ref=ViewRef(id=f"video_{i}_{k}", name="video"),
                                 entity_ref=EntityRef(id=f"entity_video_{i}_{j}_{k}", name="entities_video"),
                                 source_ref=SourceRef(id="source_1"),
                                 created_at=datetime(2021, 1, 1, 0, 0, 0),
@@ -269,7 +269,7 @@ def generate_data_multi_view_tracking_and_image(num_rows: int, schemas: dict[str
                 id=f"bbox_image_{i}",
                 item_ref=ItemRef(id=item_id),
                 view_ref=ViewRef(id=f"image_{i}", name="image"),
-                entity_ref=EntityRef(id=f"entity_image_{i}", name="entities_image"),
+                entity_ref=EntityRef(id=f"entity_image_{i}", name="entity_image"),
                 source_ref=SourceRef(id=f"source_{i % 3}"),
                 created_at=datetime(2021, 1, 1, 0, 0, 0),
                 updated_at=datetime(2021, 1, 1, 0, 0, 0),
@@ -280,7 +280,7 @@ def generate_data_multi_view_tracking_and_image(num_rows: int, schemas: dict[str
                 id=f"mask_image_{i}",
                 item_ref=ItemRef(id=item_id),
                 view_ref=ViewRef(id=f"image_{i}", name="image"),
-                entity_ref=EntityRef(id=f"entity_image_{i}", name="entities_image"),
+                entity_ref=EntityRef(id=f"entity_image_{i}", name="entity_image"),
                 size=[100 * i, 100 * i],
                 counts=b"\x01\x02\x03",
                 source_ref=SourceRef(id=f"source_{i % 3}"),
@@ -300,7 +300,7 @@ def generate_data_multi_view_tracking_and_image(num_rows: int, schemas: dict[str
                         id=f"keypoints_image_{i}_{j}",
                         item_ref=ItemRef(id=item_id),
                         view_ref=ViewRef(id=f"image_{i}", name="image"),
-                        entity_ref=EntityRef(id=f"entity_image_{i}", name="entities_image"),
+                        entity_ref=EntityRef(id=f"entity_image_{i}", name="entity_image"),
                         source_ref=SourceRef(id=f"source_{i % 3}"),
                         created_at=datetime(2021, 1, 1, 0, 0, 0),
                         updated_at=datetime(2021, 1, 1, 0, 0, 0),

--- a/tests/fixtures/datasets/dataset.py
+++ b/tests/fixtures/datasets/dataset.py
@@ -39,7 +39,7 @@ def dataset_image_bboxes_keypoint(dataset_item_image_bboxes_keypoint) -> Dataset
     dataset_builder_image_bboxes_keypoint.db = lancedb.connect(
         dataset_builder_image_bboxes_keypoint.target_dir / Dataset._DB_PATH
     )
-    return dataset_builder_image_bboxes_keypoint.build(mode="overwrite")
+    return dataset_builder_image_bboxes_keypoint.build(mode="overwrite", check_integrity="none")
 
 
 @pytest.fixture(scope="session")
@@ -56,7 +56,7 @@ def dataset_multi_view_tracking_and_image(dataset_item_multi_view_tracking_and_i
         target_dir=LIBRARY_DIR / "dataset_multi_view_tracking_and_image",
         schemas=schemas,
     )
-    return dataset_builder_multi_view_tracking_and_image.build(mode="overwrite")
+    return dataset_builder_multi_view_tracking_and_image.build(mode="overwrite", check_integrity="none")
 
 
 @pytest.fixture(scope="function")

--- a/tests/fixtures/features/entity.py
+++ b/tests/fixtures/features/entity.py
@@ -7,7 +7,8 @@
 
 import pytest
 
-from pixano.features.schemas import Entity
+from pixano.datasets import Dataset
+from pixano.features import Entity
 from tests.utils.schema import register_schema
 
 
@@ -18,3 +19,8 @@ def entity_category():
 
     register_schema(EntityCategory)
     return EntityCategory
+
+
+@pytest.fixture(scope="session")
+def two_image_entities_from_dataset_multiview_tracking_and_image(dataset_multi_view_tracking_and_image: Dataset):
+    return dataset_multi_view_tracking_and_image.get_data("entity_image", limit=2)


### PR DESCRIPTION
## Description

Add integrity checks for:
- analysing a dataset
- analysing a table
- adding or updating data

Integrity checks can be performed when building the dataset.
