### PR TITLE
Prevent docker workflow to launch every time, fix update_version for PR only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "pixano/**"
+      - "ui/**"
+      - ".github/workflows/docker.yml"
+      - "pyproject.toml"
 
 env:
   TEST_TAG: pixano/pixano:test

--- a/.github/workflows/update_versions.yml
+++ b/.github/workflows/update_versions.yml
@@ -1,7 +1,7 @@
 name: Update versions triggered by VERSION file
 
 on:
-  push:
+  pull_request:
     paths:
       - "VERSION"
     branches:


### PR DESCRIPTION
## Description

Prevent docker workflow to launch every time

update_version launch for PR only and not push on main that is protected
