### PR TITLE
Grouped deletion

### DIFF
--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -131,7 +131,9 @@ License: CECILL-C
         return 1;
       else return 0;
     });
-    for (const savedItem of data) {
+
+    const no_delete_data = data.filter((d) => d.change_type !== "delete");
+    for (const savedItem of no_delete_data) {
       let no_table = false;
       let route = savedItem.object.table_info.group;
       if (route === "item") {
@@ -141,14 +143,40 @@ License: CECILL-C
       //remove ui field  ('ui' is not used, it's OK -- so we disable linters for the line)
       // @ts-expect-error Property ui may not exist, but we don't care as we don't use it
       const { ui, ...bodyObj } = savedItem.object; // eslint-disable-line @typescript-eslint/no-unused-vars
-      if (savedItem.change_type === "delete") {
-        await api.deleteSchema(route, selectedDataset.id, bodyObj as Schema, no_table);
-      }
       if (savedItem.change_type === "add") {
         await api.addSchema(route, selectedDataset.id, bodyObj as Schema, no_table);
       }
       if (savedItem.change_type === "update") {
         await api.updateSchema(route, selectedDataset.id, bodyObj as Schema, no_table);
+      }
+    }
+    //gather deletes by group and table
+    //-- if we delete a track, there is many things to delete, so it's more efficient to delete them all at once
+    const delete_data = data.filter((d) => d.change_type === "delete");
+    const delete_ids_by_group_and_table = delete_data.reduce(
+      (acc, item, index) => {
+        const group = item.object.table_info.group;
+        const table = item.object.table_info.name;
+        if (!acc[group]) {
+          acc[group] = {};
+        }
+        if (!acc[group][table]) {
+          acc[group][table] = [];
+        }
+        acc[group][table].push(item.object.id);
+        return acc;
+      },
+      {} as Record<string, Record<string, string[]>>,
+    );
+    for (const group in delete_ids_by_group_and_table) {
+      for (const [table, ids] of Object.entries(delete_ids_by_group_and_table[group])) {
+        let no_table = false;
+        let route = group;
+        if (route === "item") {
+          route = "items";
+          no_table = true;
+        }
+        await api.deleteSchemasByIds(route, selectedDataset.id, ids, table, no_table);
       }
     }
     saveCurrentItemStore.update((old) => ({ ...old, shouldSave: false }));

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -154,7 +154,7 @@ License: CECILL-C
     //-- if we delete a track, there is many things to delete, so it's more efficient to delete them all at once
     const delete_data = data.filter((d) => d.change_type === "delete");
     const delete_ids_by_group_and_table = delete_data.reduce(
-      (acc, item, index) => {
+      (acc, item) => {
         const group = item.object.table_info.group;
         const table = item.object.table_info.name;
         if (!acc[group]) {

--- a/ui/components/core/src/api.ts
+++ b/ui/components/core/src/api.ts
@@ -228,33 +228,17 @@ export async function getItemEmbeddings(
   return item;
 }
 
-// export async function postDatasetItem(datasetId: string, item: DatasetItemSave) {
-//   try {
-//     const response = await fetch(`/datasets/${datasetId}/items/${item.id}`, {
-//       headers: {
-//         Accept: "application/json",
-//         "Content-Type": "application/json",
-//       },
-//       body: JSON.stringify(item),
-//       method: "POST",
-//     });
-//     if (response.ok) {
-//       console.log(
-//         "api.postDatasetItem -",
-//         response.status,
-//         response.statusText,
-//         await response.text(),
-//       );
-//     }
-//   } catch (e) {
-//     console.log("api.postDatasetItem -", e);
-//   }
-// }
-
-export async function deleteSchema(route: string, ds_id: string, sch: Schema, no_table: boolean) {
+export async function deleteSchemasByIds(
+  route: string,
+  ds_id: string,
+  sch_ids: string[],
+  table_name: string,
+  no_table: boolean,
+) {
+  const ids_query = sch_ids.join("&ids=");
   const url = no_table
-    ? `/${route}/${ds_id}/${sch.id}`
-    : `/${route}/${ds_id}/${sch.table_info.name}/${sch.id}`;
+    ? `/${route}/${ds_id}/?ids=${ids_query}`
+    : `/${route}/${ds_id}/${table_name}/?ids=${ids_query}`;
   try {
     const response = await fetch(url, {
       method: "DELETE",


### PR DESCRIPTION
## Issue

Deleting multiple items is managed item by item.
When we delete a whole track, it's too much REST API calls

## Description

We take advantage of the route that accept a list of ids instead of multiple call to the single id route,
by grouping ids to delete by group and table
