### PR TITLE
ability to choose top entity + bugfixes/enhancements

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
@@ -31,7 +31,8 @@ License: CECILL-C
   export let objectProperties: { [key: string]: FeatureValues } = {};
   export let initialValues: Record<string, ItemFeature> = {};
   export let isAutofocusEnabled: boolean = true;
-
+  export let entitiesCombo: { id: string; name: string }[] = [{ id: "new", name: "New" }];
+  export let selectedEntity: { id: string; name: string } = entitiesCombo[0];
   let objectValidationSchema: CreateObjectSchema;
 
   datasetSchema.subscribe((schema) => {
@@ -50,7 +51,7 @@ License: CECILL-C
         //TODO: custom fields from other types
         for (const feat in sch.fields) {
           if (!nonFeatsFields.includes(feat)) {
-            if (["int", "float", "str", "bool", "list"].includes(sch.fields[feat].type)) {
+            if (["int", "float", "str", "bool"].includes(sch.fields[feat].type)) {
               featuresArray.push({
                 name: feat,
                 required: false, //TODO (info not in datasetSchema (nowhere yet))
@@ -101,6 +102,21 @@ License: CECILL-C
     return "";
   };
 </script>
+
+{#if entitiesCombo.length > 0}
+  <span>Select attached Entity</span>
+  <select
+    class="py-1 px-2 border rounded focus:outline-none
+bg-slate-100 border-slate-300 focus:border-main"
+    bind:value={selectedEntity.id}
+  >
+    {#each entitiesCombo as { id, name }}
+      <option value={id}>
+        {name}
+      </option>
+    {/each}
+  </select>
+{/if}
 
 {#each formInputs as feature, i}
   {#if feature.type === "bool"}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -122,7 +122,11 @@ License: CECILL-C
       ) || false;
   });
 
-  const handleIconClick = (displayControlProperty: keyof DisplayControl, value: boolean) => {
+  const handleIconClick = (
+    displayControlProperty: keyof DisplayControl,
+    value: boolean,
+    kind: string | null = null,
+  ) => {
     annotations.update((anns) =>
       anns.map((ann) => {
         if (displayControlProperty === "editing") {
@@ -137,9 +141,11 @@ License: CECILL-C
             editing: false,
           };
         }
-        if (getTopEntity(ann, $entities).id === entity.id) {
+        if (
+          getTopEntity(ann, $entities).id === entity.id &&
+          (!kind || (kind && ann.table_info.base_schema === kind))
+        )
           ann = toggleObjectDisplayControl(ann, displayControlProperty, value);
-        }
         return ann;
       }),
     );
@@ -282,7 +288,7 @@ License: CECILL-C
                   <div class="flex gap-2 mt-2 items-center">
                     <p class="font-light first-letter:uppercase">Box</p>
                     <Checkbox
-                      handleClick={() => handleIconClick("hidden", boxIsVisible)}
+                      handleClick={() => handleIconClick("hidden", boxIsVisible, "BBox")}
                       bind:checked={boxIsVisible}
                       title={boxIsVisible ? "Hide" : "Show"}
                       class="mx-1"
@@ -293,7 +299,7 @@ License: CECILL-C
                   <div class="flex gap-2 mt-2 items-center">
                     <p class="font-light first-letter:uppercase">Mask</p>
                     <Checkbox
-                      handleClick={() => handleIconClick("hidden", maskIsVisible)}
+                      handleClick={() => handleIconClick("hidden", maskIsVisible, "CompressedRLE")}
                       bind:checked={maskIsVisible}
                       title={maskIsVisible ? "Hide" : "Show"}
                       class="mx-1"
@@ -304,7 +310,7 @@ License: CECILL-C
                   <div class="flex gap-2 mt-2 items-center">
                     <p class="font-light first-letter:uppercase">Key points</p>
                     <Checkbox
-                      handleClick={() => handleIconClick("hidden", keypointsIsVisible)}
+                      handleClick={() => handleIconClick("hidden", keypointsIsVisible, "Keypoints")}
                       bind:checked={keypointsIsVisible}
                       title={keypointsIsVisible ? "Hide" : "Show"}
                       class="mx-1"

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -36,7 +36,7 @@ License: CECILL-C
   const handleAnnotationSortedByModel = () => {
     allEntitiesSortedBySource = {};
     sourceStruct = {};
-    //console.log("ObjectInspector refresh fired", $annotations, $entities);
+    console.log("ObjectInspector refresh fired", $annotations, $entities);
     $annotations.forEach((ann) => {
       let kind: string = "other";
       let srcId: string = "unknown";
@@ -102,40 +102,38 @@ License: CECILL-C
           />
         {/key}
       {/if}
-      {#key sourceStruct}
-        {#each Object.keys(sourceStruct) as kind}
-          {#if kind === "model" && selectedModelId}
+      {#each Object.keys(sourceStruct) as kind}
+        {#if kind === "model" && selectedModelId}
+          <ObjectsModelSection
+            source={sourceStruct[kind][selectedModelId]}
+            numberOfItem={allEntitiesSortedBySource[kind][selectedModelId].length}
+          >
+            <Combobox
+              slot="modelSelection"
+              bind:value={selectedModelId}
+              width="w-[150px]"
+              listItems={Object.keys(allEntitiesSortedBySource[kind]).map((sourceId) => ({
+                value: sourceId,
+                label: sourceId,
+              }))}
+            />
+            {#each allEntitiesSortedBySource[kind][selectedModelId] as entity}
+              <ObjectCard bind:entity />
+            {/each}
+          </ObjectsModelSection>
+        {:else}
+          {#each Object.keys(sourceStruct[kind]) as src_id}
             <ObjectsModelSection
-              source={sourceStruct[kind][selectedModelId]}
-              numberOfItem={allEntitiesSortedBySource[kind][selectedModelId].length}
+              source={sourceStruct[kind][src_id]}
+              numberOfItem={allEntitiesSortedBySource[kind][src_id].length}
             >
-              <Combobox
-                slot="modelSelection"
-                bind:value={selectedModelId}
-                width="w-[150px]"
-                listItems={Object.keys(allEntitiesSortedBySource[kind]).map((sourceId) => ({
-                  value: sourceId,
-                  label: sourceId,
-                }))}
-              />
-              {#each allEntitiesSortedBySource[kind][selectedModelId] as entity}
+              {#each allEntitiesSortedBySource[kind][src_id] as entity}
                 <ObjectCard bind:entity />
               {/each}
             </ObjectsModelSection>
-          {:else}
-            {#each Object.keys(sourceStruct[kind]) as src_id}
-              <ObjectsModelSection
-                source={sourceStruct[kind][src_id]}
-                numberOfItem={allEntitiesSortedBySource[kind][src_id].length}
-              >
-                {#each allEntitiesSortedBySource[kind][src_id] as entity}
-                  <ObjectCard bind:entity />
-                {/each}
-              </ObjectsModelSection>
-            {/each}
-          {/if}
-        {/each}
-      {/key}
+          {/each}
+        {/if}
+      {/each}
     </div>
   {/if}
 </div>

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -30,7 +30,7 @@ License: CECILL-C
   import {
     interactiveSegmenterModel,
     newShape,
-    modelsStore,
+    modelsUiStore,
     selectedTool,
   } from "../lib/stores/datasetItemWorkspaceStores";
   import { onMount } from "svelte";
@@ -47,7 +47,7 @@ License: CECILL-C
   const handleSmartToolClick = () => {
     if (!showSmartTools) {
       selectTool(addSmartPointTool);
-      modelsStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
+      modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
     } else selectTool(panTool);
     showSmartTools = !showSmartTools;
   };

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -35,7 +35,7 @@ export const views = writable<Record<string, Image | SequenceFrame[]>>({});
 export const interactiveSegmenterModel = writable<InteractiveImageSegmenter>();
 export const itemMetas = writable<ItemsMeta>();
 export const preAnnotationIsActive = writable<boolean>(false);
-export const modelsStore = writable<ModelSelection>({
+export const modelsUiStore = writable<ModelSelection>({
   currentModalOpen: "none",
   selectedModelName: "",
 });

--- a/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
@@ -57,7 +57,13 @@ export type Feature = CheckboxFeature | TextFeature | NumberFeature | ListFeatur
 export type Embeddings = Record<string, ort.Tensor>;
 
 export type ModelSelection = {
-  currentModalOpen: "selectModel" | "selectEmbeddingsTable" | "noModel" | "noEmbeddings" | "none";
+  currentModalOpen:
+    | "selectModel"
+    | "selectEmbeddingsTable"
+    | "noModel"
+    | "noEmbeddings"
+    | "loading"
+    | "none";
   selectedModelName: string;
 };
 


### PR DESCRIPTION
## Issue

When we create a new annotation (web app), it always create a new Entity.
We want the ability to attach it to an existing entity

Fixes https://github.com/pixano/pixano-project-manager/issues/81

## Description

Added a selector ("New" + list of available Top Entities) in the "Save Shape Form" to select an existing top entity for a newly created annotation.

TODO: Manage sub-entities

## unrelated bugfixes/enhancements:
- model selector select first item
- loading indicator while loading model
- sort embedding tables: model names including "sam" first, for easier selection
- bbox/kaypoints/mask visibility checkbox was broken (applied to every childs) -- fixed
- entity card would always close after any action -- fixed
