### PR TITLE
circular buffer

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -55,6 +55,8 @@ License: CECILL-C
   export let embeddings: Record<string, ort.Tensor>;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
 
+  const IMAGE_BUFFER_SIZE = 10;
+
   $: {
     if (selectedItem) {
       currentFrameIndex.set(0);
@@ -133,79 +135,101 @@ License: CECILL-C
   let imagesPerView: ImagesPerView = {};
   const imagesPerViewBuffer: Record<string, HTMLImage[]> = {};
 
-  let imagesFilesUrls: Record<string, { id: string; url: string }[]> = Object.entries(
-    selectedItem.views,
-  ).reduce(
-    (acc, [key, value]) => {
-      acc[key] = (value as SequenceFrame[]).map((view) => {
-        return { id: view.id, url: view.data.url };
-      });
-      return acc;
-    },
-    {} as Record<string, { id: string; url: string }[]>,
-  );
+  let imagesFilesUrlsByFrame: Record<string, { id: string; url: string } | undefined>[] = [];
 
   let isLoaded = false;
 
-  async function preloadImagesProgressively(
-    imagesFilesUrls: Record<string, { id: string; url: string }[]>,
-  ) {
-    // Initialize the buffer structure with arrays for each view
-    for (const [viewKey, frames] of Object.entries(imagesFilesUrls)) {
-      imagesPerViewBuffer[viewKey] = new Array<HTMLImage>(frames.length);
+  async function preloadViewsImage(index: number) {
+    Object.entries(imagesFilesUrlsByFrame[index]).map(([viewKey, im_ref]) => {
+      if (im_ref && !imagesPerViewBuffer[viewKey][index]) {
+        new Promise<void>((resolve, reject) => {
+          const img = new Image();
+          img.src = `/${im_ref.url}`;
+          img.onload = () => {
+            imagesPerViewBuffer[viewKey][index] = {
+              id: im_ref.id,
+              element: img,
+            } as HTMLImage;
+            // console.log(
+            //   `Image ${im_ref.id} for ${viewKey} loaded and added to buffer at index ${index}.`,
+            // );
+            resolve();
+          };
+          img.onerror = () => {
+            console.warn(`Failed to load image: ${im_ref.url}`);
+            reject(new Error(`Failed to load image: ${im_ref.url}`));
+          };
+        });
+      }
+    });
+  }
+
+  async function preloadImagesProgressively(currentIndex: number = 0) {
+    const previous: number[] = [];
+    const next: number[] = [];
+
+    const previousCount = 5;
+    const nextCount = 50;
+    const num_frames = $lastFrameIndex + 1;
+    // previous (inverted and circular)
+    for (let i = 1; i <= previousCount; i++) {
+      previous.push((currentIndex - i + num_frames) % num_frames);
     }
-    // Create an array of promises for loading images
-    const loadPromises = Object.entries(imagesFilesUrls).flatMap(([viewKey, frames]) =>
-      frames.map(
-        ({ id, url }, index) =>
-          new Promise<void>((resolve, reject) => {
-            const img = new Image();
-            img.src = `/${url}`;
-            img.onload = () => {
-              imagesPerViewBuffer[viewKey][index] = { id, element: img } as HTMLImage;
-              //console.log(`Image ${id} for ${viewKey} loaded and added to buffer at index ${index}.`);
-              resolve();
-            };
-            img.onerror = () => {
-              console.warn(`Failed to load image: ${url}`);
-              reject(new Error(`Failed to load image: ${url}`));
-            };
-          }),
-      ),
+    // next (inculing current, circular)
+    for (let i = 0; i < nextCount; i++) {
+      next.push((currentIndex + i) % num_frames);
+    }
+    for (const i of next) {
+      preloadViewsImage(i);
+    }
+    for (const i of previous) {
+      preloadViewsImage(i);
+    }
+    //delete buffered images out of currentIndex window (currentIndex -10 : currentIndex + 30)
+    const includedIndices = new Set([...previous, ...next]);
+    const excludedIndices = Array.from({ length: num_frames }, (_, i) => i).filter(
+      (index) => !includedIndices.has(index),
     );
-    // Await all images to finish loading, without holding up the buffer population
-    await Promise.allSettled(loadPromises);
+    Object.keys(imagesPerViewBuffer).forEach((viewKey) => {
+      for (const i of excludedIndices) {
+        if (i in imagesPerViewBuffer[viewKey]) {
+          delete imagesPerViewBuffer[viewKey][i];
+        }
+      }
+    });
   }
 
   onMount(() => {
-    Object.entries(imagesFilesUrls).forEach(([key, urls]) => {
-      const image = new Image();
-      image.src = `/${urls[0].url}`;
-      imagesPerView = {
-        ...imagesPerView,
-        [key]: [{ id: urls[0].id, element: image }],
-      };
+    const longestView = Math.max(
+      ...Object.values(selectedItem.views).map((view) => (view as SequenceFrame[]).length),
+    );
+    //build imagesFilesUrlByFrame
+    imagesFilesUrlsByFrame = Array.from({ length: longestView }).map((_, i) => {
+      return Object.entries(selectedItem.views).reduce(
+        (acc, [key, value]) => {
+          const viewFrames = value as SequenceFrame[];
+          acc[key] = viewFrames[i]
+            ? { id: viewFrames[i].id, url: viewFrames[i].data.url }
+            : undefined;
+          return acc;
+        },
+        {} as Record<string, { id: string; url: string } | undefined>,
+      );
     });
+    // Initialize the buffer structure with arrays for each view
+    for (const viewKey in selectedItem.views) {
+      imagesPerViewBuffer[viewKey] = [];
+    }
 
     isLoaded = true;
-    const longestView = Object.values(imagesFilesUrls).reduce(
-      (acc, urls) => (urls.length > acc ? urls.length : acc),
-      0,
-    );
-    lastFrameIndex.set(longestView - 1);
 
-    //preload buffer
-    preloadImagesProgressively(imagesFilesUrls)
-      .then(() => {
-        console.log("Progressive loading complete.");
-      })
-      .catch((error) => {
-        console.error("Error during progressive loading:", error);
-      });
+    lastFrameIndex.set(longestView - 1);
+    updateView(0);
   });
 
   const updateView = (imageIndex: number) => {
-    Object.entries(imagesFilesUrls).forEach(([key, urls]) => {
+    preloadImagesProgressively(imageIndex);
+    Object.entries(imagesFilesUrlsByFrame[imageIndex]).forEach(([key, im_ref]) => {
       if (
         key in imagesPerViewBuffer &&
         imagesPerViewBuffer[key][imageIndex] &&
@@ -216,17 +240,19 @@ License: CECILL-C
           [key]: [...(imagesPerView[key] || []), imagesPerViewBuffer[key][imageIndex]].slice(-2),
         };
       } else {
-        const image = new Image();
-        const src = `/${urls[imageIndex].url}`;
-        if (!src) return;
-        image.src = src;
-        //NOTE double image, avoid flashing by "swapping" with previous image
-        imagesPerView = {
-          ...imagesPerView,
-          [key]: [...(imagesPerView[key] || []), { id: urls[imageIndex].id, element: image }].slice(
-            -2,
-          ),
-        };
+        if (im_ref) {
+          const image = new Image();
+          const src = `/${im_ref.url}`;
+          if (!src) return;
+          image.src = src;
+          //NOTE double image, avoid flashing by "swapping" with previous image
+          imagesPerView = {
+            ...imagesPerView,
+            [key]: [...(imagesPerView[key] || []), { id: im_ref.id, element: image }].slice(-2),
+          };
+        } else {
+          //console.warn("Media not present")
+        }
       }
     });
   };

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -57,7 +57,7 @@ License: CECILL-C
 
   // buffer
   const ratioOfBackwardBuffer = 0.1;
-  const buffer_size = 200;
+  const bufferSize = 200;
   let previousCount: number = 0;
   let nextCount: number = 0;
   let timerId: ReturnType<typeof setTimeout>;
@@ -230,8 +230,8 @@ License: CECILL-C
     }
 
     const n_view = Object.keys(imagesPerViewBuffer).length;
-    previousCount = Math.round((ratioOfBackwardBuffer * buffer_size) / n_view);
-    nextCount = Math.round(((1 - ratioOfBackwardBuffer) * buffer_size) / n_view);
+    previousCount = Math.round((ratioOfBackwardBuffer * bufferSize) / n_view);
+    nextCount = Math.round(((1 - ratioOfBackwardBuffer) * bufferSize) / n_view);
 
     isLoaded = true;
 

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -137,10 +137,10 @@ License: CECILL-C
 
   let isLoaded = false;
 
-  async function preloadViewsImage(index: number) {
+  function preloadViewsImage(index: number) {
     Object.entries(imagesFilesUrlsByFrame[index]).map(([viewKey, im_ref]) => {
       if (im_ref && !imagesPerViewBuffer[viewKey][index]) {
-        new Promise<void>((resolve, reject) => {
+        void new Promise<void>((resolve, reject) => {
           const img = new Image();
           img.src = `/${im_ref.url}`;
           img.onload = () => {
@@ -162,7 +162,7 @@ License: CECILL-C
     });
   }
 
-  async function preloadImagesProgressively(currentIndex: number = 0) {
+  function preloadImagesProgressively(currentIndex: number = 0) {
     const previous: number[] = [];
     const next: number[] = [];
 

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -55,8 +55,6 @@ License: CECILL-C
   export let embeddings: Record<string, ort.Tensor>;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
 
-  const IMAGE_BUFFER_SIZE = 10;
-
   $: {
     if (selectedItem) {
       currentFrameIndex.set(0);


### PR DESCRIPTION
## Issue

Pixano app do not have a max size for media buffer, leading to crash (memory full)

Fixes #366 

## Description

Implement a circular buffer (actually 50 frames after and 5 frames before current frame)
-- this settings are currently hard coded

tech detail: the 50 next (including current) and 5 previous are loaded at start, and each time we change current frame index. If any of the required buffer frames are not present, load it. frmaes outside of this range are removed from buffer, so it always have a size of 55 frames ( * nb views) --- please note that we add before deleting, so at max we can have 55 * 2 images in the buffer. -- in usual cases (play or step forward/backward), only one frame is added / removed each time

