### PR TITLE
Fix base64 conversion when format is None

### DIFF
--- a/pixano/app/routers/browser.py
+++ b/pixano/app/routers/browser.py
@@ -103,11 +103,12 @@ async def get_browser(
         row: dict[str, Any] = {}
         # VIEWS -> thumbnails previews
         for view in tables_view:
-            if item_first_media[view][item.id] is not None:
+            curr_view = item_first_media[view][item.id]
+            if curr_view is not None:
                 try:
-                    row_view = item_first_media[view][item.id].open(settings.media_dir, output_type="image")
+                    row_view = curr_view.open(settings.media_dir, output_type="image")
                     row_view = get_image_thumbnail(row_view, (128, 128))
-                    row_view_base64 = image_to_base64(row_view)
+                    row_view_base64 = image_to_base64(row_view, curr_view.format)
                 except ValueError:
                     row_view_base64 = ""
 

--- a/pixano/features/utils/image.py
+++ b/pixano/features/utils/image.py
@@ -252,7 +252,7 @@ def rle_to_urle(rle: dict[str, list[int] | bytes]) -> dict[str, list[int]]:
     return urle
 
 
-def image_to_base64(image: Image.Image) -> str:
+def image_to_base64(image: Image.Image, format: str | None = None) -> str:
     """Encode image from Pillow to base64.
 
     The image is returned as a base64 string formatted as
@@ -260,14 +260,22 @@ def image_to_base64(image: Image.Image) -> str:
 
     Args:
         image: Pillow image.
+        format: Image format.
 
     Returns:
         Image as base64.
     """
+    if image.format is None and format is None:
+        raise ValueError("Image format is not defined")
+
     buffered = io.BytesIO()
-    image.save(buffered, format=image.format, quality=100, subsampling=0)
+    out_format = format or image.format
+
+    image.save(buffered, format=out_format)
+
     encoded = base64.b64encode(buffered.getvalue()).decode("utf-8")
-    return f"data:image/{image.format.lower()};base64,{encoded}"
+
+    return f"data:image/{out_format.lower()};base64,{encoded}"
 
 
 def base64_to_image(base64_image: str) -> Image.Image:

--- a/tests/features/utils/test_image.py
+++ b/tests/features/utils/test_image.py
@@ -116,6 +116,16 @@ def test_base64_to_image():
     assert image.format == converted_image.format
     assert image.size == converted_image.size
 
+    image.format = None
+    base64_image = image_to_base64(image, "PNG")
+    converted_image = base64_to_image(base64_image)
+    assert isinstance(converted_image, PILImage)
+    assert converted_image.format == "PNG"
+    assert image.size == converted_image.size
+
+    with pytest.raises(ValueError, match="Image format is not defined"):
+        base64_image = image_to_base64(image, None)
+
 
 def test_get_image_thumbnail():
     image = Image.open_url("sample_data/image_jpg.jpg", ASSETS_DIRECTORY, "image")


### PR DESCRIPTION
## Description

When an image is read, sometimes the format is lost and base64 couldn't convert on its own.

In this PR we allow base64 to receive a format  to allow conversion.
