### PR TITLE
fixed tracklet size

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -311,9 +311,9 @@ License: CECILL-C
 
 {#if track && tracklets}
   <div
-    class="flex gap-5 relative h-12 my-auto z-20"
+    class="flex gap-5 relative my-auto z-20"
     id={`video-object-${track.id}`}
-    style={`width: ${$videoControls.zoomLevel[0]}%`}
+    style={`width: ${$videoControls.zoomLevel[0]}%; height: ${Object.keys(views).length * 20}px;`}
     bind:this={objectTimeTrack}
     role="complementary"
   >

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -8,7 +8,6 @@ License: CECILL-C
   // Imports
   import { ContextMenu, cn } from "@pixano/core";
   import {
-    Track,
     Tracklet,
     SequenceFrame,
     type TrackletItem,


### PR DESCRIPTION
## Issue

At 5 or more views, the tracklet size is too small (track size / n views) in videoInspector to interact with (and currentFrameIndex is not set also because of a reactive component being disabled because too small, which leaded to several bugs)

Fix #378 

## Description

The tracklet now have a fixed size, and the track have a variable size depending on number of views.