### PR TITLE
bugfix unknown image type

### DIFF
--- a/pixano/features/utils/image.py
+++ b/pixano/features/utils/image.py
@@ -270,7 +270,8 @@ def image_to_base64(image: Image.Image, format: str | None = None) -> str:
 
     buffered = io.BytesIO()
     out_format = format or image.format
-
+    if out_format.upper() == "UNKNOWN":
+        out_format = "JPEG"
     image.save(buffered, format=out_format)
 
     encoded = base64.b64encode(buffered.getvalue()).decode("utf-8")

--- a/tests/features/utils/test_image.py
+++ b/tests/features/utils/test_image.py
@@ -107,6 +107,10 @@ def test_image_to_base64():
     assert isinstance(base64_image, str)
     assert base64_image.startswith("data:image/jpeg;base64,")
 
+    image.format = "Unknown"
+    base64_image = image_to_base64(image)
+    assert isinstance(base64_image, str)
+
 
 def test_base64_to_image():
     image = Image.open_url("sample_data/image_jpg.jpg", ASSETS_DIRECTORY, "image")

--- a/tests/features/utils/test_image.py
+++ b/tests/features/utils/test_image.py
@@ -110,6 +110,7 @@ def test_image_to_base64():
     image.format = "Unknown"
     base64_image = image_to_base64(image)
     assert isinstance(base64_image, str)
+    assert base64_image.startswith("data:image/jpeg;base64,")
 
 
 def test_base64_to_image():


### PR DESCRIPTION
## Issue

image_to_base64 will crash with a "Unknown" image format.
It happens sometimes (I had it with one dataset. Images are .jpg but for it seems PIL doesn't correctly identify the format, although he can read it)

## Description

If format is "Unknown", use "JPEG" instead. As it is an internal save before base64 encoding, for thumbnail, this has no impact.