### PR TITLE
feat(back): Add back estimated dataset size

### DIFF
--- a/pixano/datasets/dataset_info.py
+++ b/pixano/datasets/dataset_info.py
@@ -13,6 +13,7 @@ from typing import Literal, overload
 from pydantic import BaseModel, field_validator
 
 from pixano.features import Image
+from pixano.utils.python import estimate_folder_size
 
 
 class DatasetInfo(BaseModel):
@@ -22,7 +23,7 @@ class DatasetInfo(BaseModel):
         id: Dataset ID. Must be unique.
         name: Dataset name.
         description: Dataset description.
-        estimated_size: Dataset estimated size.
+        size: Dataset estimated size.
         preview: Path to a preview thumbnail.
     """
 
@@ -96,6 +97,7 @@ class DatasetInfo(BaseModel):
         # Browse directory
         for json_fp in sorted(directory.glob("*/info.json")):
             info: DatasetInfo = DatasetInfo.from_json(json_fp)
+            info.size = estimate_folder_size(json_fp.parent)
             try:
                 info.preview = Image.open_url(
                     str(json_fp.parent / "previews/dataset_preview.jpg"),
@@ -134,6 +136,7 @@ class DatasetInfo(BaseModel):
         for json_fp in directory.glob("*/info.json"):
             info = DatasetInfo.from_json(json_fp)
             if info.id == id:
+                info.size = estimate_folder_size(json_fp.parent)
                 try:
                     info.preview = Image.open_url(
                         str(json_fp.parent / "previews/dataset_preview.jpg"),

--- a/tests/app/routers/test_datasets.py
+++ b/tests/app/routers/test_datasets.py
@@ -30,6 +30,11 @@ def test_get_datasets_info(
     response = client.get("/datasets/info")
     assert response.status_code == 200
     json_response = response.json()
+
+    # Disable dataset size estimation
+    for json_info in json_response:
+        json_info["size"] = "Unknown"
+
     assert len(json_response) == len(infos)
     for info in infos:
         assert info.model_dump() in json_response
@@ -51,8 +56,13 @@ def test_get_dataset_info(
 
     info_model_dataset_image_bboxes_keypoint.id = "dataset_image_bboxes_keypoint"
     response = client.get("/datasets/info/dataset_image_bboxes_keypoint")
+
+    # Disable dataset size estimation
+    json_response = response.json()
+    json_response["size"] = "Unknown"
+
     assert response.status_code == 200
-    assert response.json() == info_model_dataset_image_bboxes_keypoint.model_dump()
+    assert json_response == info_model_dataset_image_bboxes_keypoint.model_dump()
 
 
 def test_get_dataset(

--- a/tests/datasets/test_dataset_info.py
+++ b/tests/datasets/test_dataset_info.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from pixano.datasets.dataset_info import DatasetInfo
+from pixano.utils.python import estimate_folder_size
 
 
 class TestDatasetInfo:
@@ -67,7 +68,6 @@ class TestDatasetInfo:
                 id=f"id_{i}",
                 name=f"pascal_{i}",
                 description=f"PASCAL VOC 2007_{i}",
-                size="8GB",
                 preview="/preview",
             )
             info.to_json(info_dir / "info.json")
@@ -80,7 +80,7 @@ class TestDatasetInfo:
                 id=f"id_{i}",
                 name=f"pascal_{i}",
                 description=f"PASCAL VOC 2007_{i}",
-                size="8GB",
+                size=estimate_folder_size(temp_dir / f"info_{i}"),
                 preview=info.preview,  # TODO: remove hard coded value
             )
 
@@ -92,7 +92,7 @@ class TestDatasetInfo:
                 id=f"id_{i}",
                 name=f"pascal_{i}",
                 description=f"PASCAL VOC 2007_{i}",
-                size="8GB",
+                size=estimate_folder_size(temp_dir / f"info_{i}"),
                 preview=info.preview,  # TODO: remove hard coded value
             )
             assert path == temp_dir / f"info_{i}"
@@ -120,7 +120,7 @@ class TestDatasetInfo:
             id="id",
             name="pascal",
             description="PASCAL VOC 2007",
-            size="8GB",
+            size=estimate_folder_size(info_dir),
             preview=loaded_info.preview,  # TODO: remove hard coded value
         )
 
@@ -130,7 +130,7 @@ class TestDatasetInfo:
             id="id",
             name="pascal",
             description="PASCAL VOC 2007",
-            size="8GB",
+            size=estimate_folder_size(info_dir),
             preview=loaded_info.preview,  # TODO: remove hard coded value
         )
         assert path == temp_dir / "info"

--- a/tests/utils/test_python.py
+++ b/tests/utils/test_python.py
@@ -4,9 +4,9 @@
 # License: CECILL-C
 # =====================================
 
-import pytest
+from pathlib import Path
 
-from pixano.utils.python import get_super_type_from_dict, natural_key, unique_list
+from pixano.utils.python import estimate_folder_size, get_super_type_from_dict, natural_key, unique_list
 
 
 def test_natural_key():
@@ -17,9 +17,13 @@ def test_natural_key():
     assert output == ["", 231, "yolo", 1, ""]
 
 
-@pytest.mark.skip("Not implemented")
-def test_estimate_folder_size():
-    pass
+def test_estimate_folder_size(tmp_path: Path):
+    for i in range(4):
+        tmp_subfolder = tmp_path / f"folder_{i}"
+        tmp_subfolder.mkdir()
+        with open(tmp_subfolder / "file", "wb") as f:
+            f.truncate(8192 * i)
+    assert estimate_folder_size(tmp_path) == "48 KB"
 
 
 def test_get_super_type_from_dict():

--- a/tests/utils/test_python.py
+++ b/tests/utils/test_python.py
@@ -6,7 +6,16 @@
 
 from pathlib import Path
 
-from pixano.utils.python import estimate_folder_size, get_super_type_from_dict, natural_key, unique_list
+import pytest
+
+from pixano.utils.python import (
+    estimate_folder_size,
+    fn_sort_dict,
+    get_super_type_from_dict,
+    natural_key,
+    to_sql_list,
+    unique_list,
+)
 
 
 def test_natural_key():
@@ -49,6 +58,31 @@ def test_get_super_type_from_dict():
     assert get_super_type_from_dict(TypeC, dict_types) == TypeB
     assert get_super_type_from_dict(TypeD, dict_types) == TypeD
     assert get_super_type_from_dict(int, dict_types) is None
+
+
+def test_to_sql_list():
+    assert to_sql_list("id1") == "('id1')"
+    assert to_sql_list(["id1"]) == "('id1')"
+    assert to_sql_list(["id1", "id2"]) == "('id1', 'id2')"
+
+    with pytest.raises(ValueError, match="IDs must not be empty."):
+        to_sql_list([])
+
+    with pytest.raises(ValueError, match="IDs must be strings."):
+        to_sql_list([0, 8])
+
+
+def test_fn_sort_dict():
+    dict_to_sort = {"a": 1, "b": "v", "c": False, "d": None, "e": 6}
+    sorted_dict = fn_sort_dict(dict_to_sort, ["e", "d", "c", "b", "a"], [False, True, True, True, True])
+    assert sorted_dict == (6, None, 0, "\x89", -1)
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot sort by <class 'list'> in descending order. "
+        "Please use open an issue if you need this feature.",
+    ):
+        fn_sort_dict({"a": [0, 1]}, ["a"], [True])
 
 
 def test_unique_list():


### PR DESCRIPTION
## Description

Estimated dataset size was no longer calculated when loading datasets. Add it back.
Note: this estimated size no longer takes into account the media folder that can be stored outside the dataset.
