### PR TITLE
change embeddings load

### DIFF
--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -31,10 +31,7 @@ License: CECILL-C
   let currentDatasetId: string;
   let currentDatasetItemsIds: string[];
 
-  async function handleGetModels() {
-    //TMP for lint
-    await new Promise((resolve) => setTimeout(resolve, 1));
-    modelsStore.set([]);
+  function handleGetModels() {
     api
       .getModels()
       .then((models) => modelsStore.set(models))
@@ -53,8 +50,6 @@ License: CECILL-C
 
   onMount(async () => {
     handleGetModels()
-      .then(() => console.log(`Found ${$modelsStore.length} model(s):`, $modelsStore))
-      .catch((err) => console.error("ERROR: Can't get model", err));
     await handleGetDatasets();
   });
 

--- a/ui/components/core/src/api.ts
+++ b/ui/components/core/src/api.ts
@@ -196,6 +196,7 @@ export async function getViewEmbeddings(
     const response = await fetch(`/embeddings/${datasetId}/${tableName}/?item_ids=${itemId}`);
     if (response.ok) {
       viewEmbeddings = (await response.json()) as Array<ViewEmbedding>;
+      console.log("api.getViewEmbeddings - Embeddings loaded.")
     } else {
       viewEmbeddings = [];
       console.log(

--- a/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
@@ -9,7 +9,7 @@ License: CECILL-C
   import { derived } from "svelte/store";
   import { SelectModal, WarningModal, LoadingModal, DatasetInfo } from "@pixano/core";
   import { SAM } from "@pixano/models";
-  import { loadViewEmbeddings as loadViewEmbeddingsAPI } from "../lib/api/modelsApi";
+  import { loadViewEmbeddings } from "../lib/api/modelsApi";
   import {
     interactiveSegmenterModel,
     modelsUiStore,
@@ -26,7 +26,7 @@ License: CECILL-C
 
   let currentModalOpen: ModelSelection["currentModalOpen"] = "none";
   let selectedModelName: ModelSelection["selectedModelName"] = models ? models[0] : "";
-  let selectedTableName: string;
+  let selectedTableName: ModelSelection["selectedTableName"];
   let sortedTablesChoices = derived(datasetSchema, ($datasetSchema) => {
     const withSam = $datasetSchema.groups.embeddings.filter((t) => t.includes("sam"));
     const withoutSam = $datasetSchema.groups.embeddings.filter((t) => !t.includes("sam"));
@@ -37,10 +37,12 @@ License: CECILL-C
     currentModalOpen = store.currentModalOpen;
     selectedModelName =
       store.selectedModelName !== "" ? store.selectedModelName : selectedModelName;
+    selectedTableName =
+      store.selectedTableName !== "" ? store.selectedTableName : selectedTableName;
   });
 
-  const loadViewEmbeddings = () => {
-    modelsUiStore.update((store) => ({ ...store, currentModalOpen: "none" }));
+  const getViewEmbeddings = () => {
+    modelsUiStore.update((store) => ({ ...store, selectedTableName, currentModalOpen: "none" }));
     if (
       !selectedItemId ||
       !selectedTableName ||
@@ -49,7 +51,7 @@ License: CECILL-C
     ) {
       return;
     }
-    loadViewEmbeddingsAPI(selectedItemId, selectedTableName, currentDatasetId)
+    loadViewEmbeddings(selectedItemId, selectedTableName, currentDatasetId)
       .then((results) => {
         embeddings = results;
       })
@@ -65,7 +67,7 @@ License: CECILL-C
     modelsUiStore.update((store) => ({
       ...store,
       currentModalOpen: "loading",
-      selectedModelName: selectedModelName,
+      selectedModelName,
     }));
     await sam.init("/app_models/" + selectedModelName + ".onnx");
     interactiveSegmenterModel.set(sam);
@@ -100,7 +102,7 @@ License: CECILL-C
     choices={$sortedTablesChoices}
     ifNoChoices={""}
     bind:selected={selectedTableName}
-    on:confirm={loadViewEmbeddings}
+    on:confirm={getViewEmbeddings}
   />
 {/if}
 {#if currentModalOpen === "noModel"}

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -38,6 +38,7 @@ export const preAnnotationIsActive = writable<boolean>(false);
 export const modelsUiStore = writable<ModelSelection>({
   currentModalOpen: "none",
   selectedModelName: "",
+  selectedTableName: "",
 });
 export const filters = writable<Filters>({
   brightness: 0,

--- a/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
@@ -70,6 +70,7 @@ export type ModelSelection = {
     | "loading"
     | "none";
   selectedModelName: string;
+  selectedTableName: string;
 };
 
 export type ItemsMeta = {


### PR DESCRIPTION
## Issue

When changing dataset item, new embeddings is not loaded (previously loaded kept) until we open/close interactive segmentation tool.

Fixes #382 

## Description

Once a model + embedding has been loaded, model + embedding table is kept. New embedding are loaded on dataset item change
