### PR TITLE
track association

### DIFF
--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -146,6 +146,7 @@ License: CECILL-C
 
     const no_delete_data = data.filter((d) => d.change_type !== "delete");
 
+    //TODO: gather items too (like deletes)
     for (const savedItem of no_delete_data) {
       let no_table = false;
       let route = savedItem.object.table_info.group;

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -548,9 +548,6 @@ License: CECILL-C
       case ToolType.Classification:
         displayClassificationTool(selectedTool);
         break;
-      case ToolType.Fusion:
-        displayFusionTool();
-        break;
 
       default:
         // Reset or disable any specific behavior
@@ -659,17 +656,6 @@ License: CECILL-C
       // deactivate drag on input points
       toggleInputPointDrag(false);
     }
-  }
-
-  function displayFusionTool() {
-    //deselect all (NOTE: quite strange way to deselect, should need rework)
-    newShape = {
-      status: "editing",
-      viewRef: {}, // TODO: is it OK ?
-      type: "none",
-      shapeId: null,
-      highlighted: "all",
-    };
   }
 
   // ********** CLASSIFICATION TOOL ********** //

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -549,7 +549,7 @@ License: CECILL-C
         displayClassificationTool(selectedTool);
         break;
       case ToolType.Fusion:
-        displayFusionTool(selectedTool);
+        displayFusionTool();
         break;
 
       default:
@@ -588,7 +588,7 @@ License: CECILL-C
   // ********** KEY_POINT TOOL ********** //
 
   function dragInputKeyPointRectMove(viewRef: Reference) {
-    if (selectedTool?.type === "KEY_POINT" && newShape.status !== "saving") {
+    if (selectedTool?.type === ToolType.Keypoint && newShape.status !== "saving") {
       const viewLayer: Konva.Layer = stage.findOne(`#${viewRef.name}`);
 
       const pos = viewLayer.getRelativePointerPosition();
@@ -661,7 +661,7 @@ License: CECILL-C
     }
   }
 
-  function displayFusionTool(tool: SelectionTool) {
+  function displayFusionTool() {
     //deselect all (NOTE: quite strange way to deselect, should need rework)
     newShape = {
       status: "editing",

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { SaveShapeType, WarningModal, type ImagesPerView } from "@pixano/core";
+  import { Annotation, SaveShapeType, WarningModal, type ImagesPerView } from "@pixano/core";
   import Konva from "konva";
   import { nanoid } from "nanoid";
   import * as ort from "onnxruntime-web";
@@ -44,6 +44,7 @@ License: CECILL-C
     POINT_SELECTION,
   } from "./lib/constants";
   import { equalizeHistogram } from "./lib/utils/equalizeHistogram";
+  import { ToolType } from "./tools";
 
   // Exports
   export let selectedItemId: string;
@@ -59,6 +60,9 @@ License: CECILL-C
   export let colorScale: (value: string) => string;
   export let isVideo: boolean = false;
   export let imageSmoothing: boolean = true;
+  export let merge: (ann: Annotation) => void = () => {
+    return;
+  };
 
   // Image settings
   export let filters: Writable<Filters> = writable<Filters>();
@@ -523,26 +527,29 @@ License: CECILL-C
     // Update the behavior of the canvas stage based on the selected tool
     // You can add more cases for different tools as needed
     switch (selectedTool.type) {
-      case "POINT_SELECTION":
+      case ToolType.PointSelection:
         displayInputPointTool(selectedTool);
         break;
-      case "RECTANGLE":
+      case ToolType.Rectangle:
         displayInputRectTool(selectedTool);
         // Enable box creation or change cursor style
         break;
-      case "KEY_POINT":
+      case ToolType.Keypoint:
         // Enable key point creation or change cursor style
         break;
-      case "DELETE":
+      case ToolType.Delete:
         clearAnnotationAndInputs();
         displayInputDeleteTool(selectedTool);
         break;
-      case "PAN":
+      case ToolType.Pan:
         displayPanTool(selectedTool);
         // Enable box creation or change cursor style
         break;
-      case "CLASSIFICATION":
+      case ToolType.Classification:
         displayClassificationTool(selectedTool);
+        break;
+      case ToolType.Fusion:
+        displayFusionTool(selectedTool);
         break;
 
       default:
@@ -609,7 +616,7 @@ License: CECILL-C
   }
 
   function dragKeyPointInputRectEnd(viewRef: Reference) {
-    if (selectedTool?.type == "KEY_POINT") {
+    if (selectedTool?.type == ToolType.Keypoint) {
       const viewLayer: Konva.Layer = stage.findOne(`#${viewRef.name}`);
       const rect: Konva.Rect = stage.findOne("#move-keyPoints-group");
       if (rect && newShape.status === "creating" && newShape.type === SaveShapeType.keypoints) {
@@ -652,6 +659,17 @@ License: CECILL-C
       // deactivate drag on input points
       toggleInputPointDrag(false);
     }
+  }
+
+  function displayFusionTool(tool: SelectionTool) {
+    //deselect all (NOTE: quite strange way to deselect, should need rework)
+    newShape = {
+      status: "editing",
+      viewRef: {}, // TODO: is it OK ?
+      type: "none",
+      shapeId: null,
+      highlighted: "all",
+    };
   }
 
   // ********** CLASSIFICATION TOOL ********** //
@@ -882,7 +900,7 @@ License: CECILL-C
   }
 
   function dragInputRectMove(viewRef: Reference) {
-    if (selectedTool?.type === "RECTANGLE") {
+    if (selectedTool?.type === ToolType.Rectangle) {
       const viewLayer: Konva.Layer = stage.findOne(`#${viewRef.name}`);
 
       const pos = viewLayer.getRelativePointerPosition();
@@ -903,7 +921,7 @@ License: CECILL-C
   }
 
   async function dragInputRectEnd(viewRef: Reference) {
-    if (selectedTool?.type == "RECTANGLE") {
+    if (selectedTool?.type === ToolType.Rectangle) {
       const viewLayer: Konva.Layer = stage.findOne(`#${viewRef.name}`);
       const rect: Konva.Rect = stage.findOne("#drag-rect");
       if (rect) {
@@ -986,11 +1004,11 @@ License: CECILL-C
     const position = stage.getRelativePointerPosition();
 
     // Update tools states
-    if (selectedTool?.type === "POINT_SELECTION") {
+    if (selectedTool?.type === ToolType.PointSelection) {
       updateInputPointStage(position);
     }
 
-    if (selectedTool?.type === "RECTANGLE") {
+    if (selectedTool?.type === ToolType.Rectangle) {
       updateInputRectState(position);
     }
   }
@@ -1017,7 +1035,7 @@ License: CECILL-C
     const viewLayer: Konva.Layer = stage.findOne(`#${viewRef.name}`);
     viewLayer.draggable(false);
     viewLayer.off("dragend dragmove");
-    if (selectedTool?.type === "POLYGON") {
+    if (selectedTool?.type === ToolType.Polygon) {
       drawPolygonPoints(viewRef);
     }
 
@@ -1054,11 +1072,11 @@ License: CECILL-C
     }
     // Perform tool action if any active tool
     // For convenience: bypass tool on mouse middle-button click
-    if (selectedTool?.type == "PAN" || event.button == 1) {
+    if (selectedTool?.type === ToolType.Pan || event.button === 1) {
       viewLayer.draggable(true);
       viewLayer.on("dragmove", handleMouseMoveStage);
       viewLayer.on("dragend", () => handleDragEndOnView(viewRef.name));
-    } else if (selectedTool?.type == "POINT_SELECTION") {
+    } else if (selectedTool?.type === ToolType.PointSelection) {
       const clickOnViewPos = viewLayer.getRelativePointerPosition();
 
       //add Konva Point
@@ -1090,10 +1108,10 @@ License: CECILL-C
       inputGroup.add(input_point);
       highlightInputPoint(input_point, viewRef.name);
       await updateCurrentMask(viewRef);
-    } else if (selectedTool?.type == "RECTANGLE") {
+    } else if (selectedTool?.type == ToolType.Rectangle) {
       viewLayer.on("pointermove", () => dragInputRectMove(viewRef));
       viewLayer.on("pointerup", () => void dragInputRectEnd(viewRef));
-    } else if (selectedTool?.type === "KEY_POINT") {
+    } else if (selectedTool?.type === ToolType.Keypoint) {
       viewLayer.on("pointermove", () => dragInputKeyPointRectMove(viewRef));
       viewLayer.on("pointerup", () => void dragKeyPointInputRectEnd(viewRef));
     }
@@ -1242,6 +1260,7 @@ License: CECILL-C
                     {stage}
                     bind:newShape
                     {selectedTool}
+                    {merge}
                   />
                 {/if}
               {/each}

--- a/ui/components/canvas2d/src/components/PolygonGroup.svelte
+++ b/ui/components/canvas2d/src/components/PolygonGroup.svelte
@@ -24,6 +24,7 @@ License: CECILL-C
     sceneFunc,
   } from "../api/maskApi";
   import type { PolygonGroupPoint, PolygonShape } from "../lib/types/canvas2dTypes";
+  import { ToolType } from "../tools";
   import PolygonPoints from "./PolygonPoints.svelte";
 
   // Exports
@@ -130,7 +131,7 @@ License: CECILL-C
     draggable: canEdit,
     visible: !mask.ui.displayControl?.hidden,
     opacity: mask.ui.opacity,
-    listening: selectedTool.type === "PAN",
+    listening: selectedTool.type === ToolType.Pan,
   }}
 >
   {#if canEdit}

--- a/ui/components/canvas2d/src/components/Rectangle.svelte
+++ b/ui/components/canvas2d/src/components/Rectangle.svelte
@@ -9,7 +9,13 @@ License: CECILL-C
   import { onDestroy, tick } from "svelte";
   import Konva from "konva";
   import { Rect, Group } from "svelte-konva";
-  import { SaveShapeType, type BBox, type SelectionTool, type Shape } from "@pixano/core";
+  import {
+    Annotation,
+    SaveShapeType,
+    type BBox,
+    type SelectionTool,
+    type Shape,
+  } from "@pixano/core";
 
   import { BBOX_STROKEWIDTH } from "../lib/constants";
   import {
@@ -19,6 +25,7 @@ License: CECILL-C
     toggleIsEditingBBox,
   } from "../api/rectangleApi";
   import LabelTag from "./LabelTag.svelte";
+  import { ToolType } from "../tools";
 
   export let stage: Konva.Stage;
   export let bbox: BBox;
@@ -26,6 +33,7 @@ License: CECILL-C
   export let zoomFactor: number;
   export let newShape: Shape;
   export let selectedTool: SelectionTool;
+  export let merge: (ann: Annotation) => void;
 
   const updateDimensions = (rect: Konva.Rect) => {
     const coords = getNewRectangleDimensions(rect, stage, bbox.data.view_ref);
@@ -79,6 +87,9 @@ License: CECILL-C
         type: "none",
       };
     }
+    //Note: design-wise, should be better to handle this on a upper level,
+    //but in case of interpolated we can't find top_entity with annotation id only
+    merge(bbox);
   };
 
   onDestroy(() => {
@@ -116,7 +127,9 @@ License: CECILL-C
 <Group
   on:dblclick={onDoubleClick}
   on:click={onClick}
-  config={{ listening: selectedTool?.type === "PAN" }}
+  config={{
+    listening: selectedTool?.type === ToolType.Pan || selectedTool?.type === ToolType.Fusion,
+  }}
 >
   <Rect
     config={{

--- a/ui/components/canvas2d/src/tools.ts
+++ b/ui/components/canvas2d/src/tools.ts
@@ -13,8 +13,11 @@ import type { InteractiveImageSegmenter } from "@pixano/models";
 export enum ToolType {
   PointSelection = "POINT_SELECTION",
   Rectangle = "RECTANGLE",
+  Polygon = "POLYGON",
+  Keypoint = "KEY_POINT",
   Delete = "DELETE",
   Pan = "PAN",
+  Fusion = "FUSION",
   Classification = "CLASSIFICATION",
 }
 
@@ -122,11 +125,11 @@ export function createClassifTool(): ClassificationTool {
 }
 
 export type {
-  Tool,
-  PointSelectionTool,
-  PointSelectionModeTool,
-  RectangleTool,
+  ClassificationTool,
   DeleteTool,
   PanTool,
-  ClassificationTool,
+  PointSelectionModeTool,
+  PointSelectionTool,
+  RectangleTool,
+  Tool,
 };

--- a/ui/components/core/src/lib/types/toolsTypes.ts
+++ b/ui/components/core/src/lib/types/toolsTypes.ts
@@ -5,16 +5,8 @@ License: CECILL-C
 -------------------------------------*/
 
 // Imports
+import { ToolType } from "../../../../canvas2d/src/tools";
 import type { InteractiveImageSegmenter } from "./modelsTypes";
-
-export type ToolType =
-  | "POINT_SELECTION"
-  | "RECTANGLE"
-  | "DELETE"
-  | "PAN"
-  | "CLASSIFICATION"
-  | "KEY_POINT"
-  | "POLYGON";
 
 // Exports
 type BaseTool<T extends ToolType> = {
@@ -26,10 +18,16 @@ type BaseTool<T extends ToolType> = {
 };
 
 export type AllTool = BaseTool<
-  "RECTANGLE" | "PAN" | "DELETE" | "CLASSIFICATION" | "POLYGON" | "KEY_POINT"
+  | ToolType.Rectangle
+  | ToolType.Pan
+  | ToolType.Delete
+  | ToolType.Classification
+  | ToolType.Polygon
+  | ToolType.Keypoint
+  | ToolType.Fusion
 >;
 
-export type LabeledPointTool = BaseTool<"POINT_SELECTION"> & {
+export type LabeledPointTool = BaseTool<ToolType.PointSelection> & {
   label: number;
 };
 

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -196,7 +196,7 @@ License: CECILL-C
       <Loader2Icon class="animate-spin" />
     </div>
   {/if}
-  <Toolbar />
+  <Toolbar isVideo={selectedItem.ui.type === "video"} />
   <DatasetItemViewer {selectedItem} {isLoading} {headerHeight} />
   <Inspector on:click={onSave} {isLoading} />
   <LoadModelModal {models} />

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -35,7 +35,6 @@ License: CECILL-C
     saveData,
     views,
   } from "./lib/stores/datasetItemWorkspaceStores";
-  import "./index.css";
   export let featureValues: FeaturesValues;
   export let selectedItem: DatasetItem;
   export let models: string[] = [];

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   // Imports
   import { Loader2Icon } from "lucide-svelte";
 
-  import type { DatasetItem } from "@pixano/core";
+  import type { Annotation, DatasetItem } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
   import ThreeDimensionsViewer from "./3DViewer.svelte";
@@ -28,7 +28,7 @@ License: CECILL-C
       <Loader2Icon class="animate-spin text-white" />
     </div>
   {:else if selectedItem.ui.type === "video"}
-    <VideoViewer {selectedItem} bind:currentAnn />
+    <VideoViewer {selectedItem} bind:currentAnn/>
   {:else if selectedItem.ui.type === "vqa"}
     <TextImageViewer {selectedItem} bind:currentAnn />
   {:else if selectedItem.ui.type === "image" || !selectedItem.ui.type}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   // Imports
   import { Loader2Icon } from "lucide-svelte";
 
-  import type { Annotation, DatasetItem } from "@pixano/core";
+  import type { DatasetItem } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
   import ThreeDimensionsViewer from "./3DViewer.svelte";
@@ -28,7 +28,7 @@ License: CECILL-C
       <Loader2Icon class="animate-spin text-white" />
     </div>
   {:else if selectedItem.ui.type === "video"}
-    <VideoViewer {selectedItem} bind:currentAnn/>
+    <VideoViewer {selectedItem} bind:currentAnn />
   {:else if selectedItem.ui.type === "vqa"}
     <TextImageViewer {selectedItem} bind:currentAnn />
   {:else if selectedItem.ui.type === "image" || !selectedItem.ui.type}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -57,7 +57,6 @@ License: CECILL-C
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
   import VideoInspector from "../VideoPlayer/VideoInspector.svelte";
-  import { string } from "zod";
 
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/InspectorInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/InspectorInspector.svelte
@@ -21,7 +21,6 @@ License: CECILL-C
   canSave.subscribe((value) => {
     isButtonEnabled = value;
   });
-
 </script>
 
 <div class="h-full max-h-screen shadow-sm border-l border-slate-200 bg-slate-100 font-Montserrat">

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/InspectorInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/InspectorInspector.svelte
@@ -6,7 +6,6 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import type { Shape } from "@pixano/core";
   import { cn, Tabs, Skeleton } from "@pixano/core/src";
 
   import SceneInspector from "./SceneInspector.svelte";
@@ -16,7 +15,6 @@ License: CECILL-C
 
   export let isLoading: boolean;
 
-  let shape: Shape;
   let currentTab: "scene" | "objects" = "objects";
   let isButtonEnabled = false;
 
@@ -24,13 +22,10 @@ License: CECILL-C
     isButtonEnabled = value;
   });
 
-  newShape.subscribe((value) => {
-    shape = value;
-  });
 </script>
 
 <div class="h-full max-h-screen shadow-sm border-l border-slate-200 bg-slate-100 font-Montserrat">
-  {#if shape?.status === "saving"}
+  {#if $newShape?.status === "saving"}
     <SaveShapeForm bind:currentTab />
   {:else}
     <Tabs.Root bind:value={currentTab} class="h-full">

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -31,7 +31,7 @@ License: CECILL-C
   //Note: Previously Entities where grouped by source
   //Now they're all displayed regardless of source
   //so we fake a global source for ObjectsModelSection (may be rewritten later)
-  const now = new Date(Date.now()).toISOString();
+  const now = new Date(Date.now()).toISOString().replace(/Z$/, "+00:00");
   const globalSource = new Source({
     id: "pixano_source",
     created_at: now,

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -41,6 +41,8 @@ License: CECILL-C
   import FusionTool from "./Toolbar/FusionTool.svelte";
   import { ToolType } from "@pixano/canvas2d/src/tools";
 
+  export let isVideo: boolean = false;
+
   let previousSelectedTool: SelectionTool | null = null;
   let showSmartTools: boolean = false;
 
@@ -118,7 +120,9 @@ License: CECILL-C
       <Share2 />
     </IconButton>
     <KeyPointsSelection {selectTool} />
-    <FusionTool {cleanFusion} />
+    {#if isVideo}
+      <FusionTool {cleanFusion} />
+    {/if}
   </div>
   <div
     class={cn("flex items-center flex-col gap-4 mt-4", {

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -117,7 +117,7 @@ License: CECILL-C
     >
       <Share2 />
     </IconButton>
-    <KeyPointsSelection />
+    <KeyPointsSelection {selectTool} />
     <FusionTool {cleanFusion} />
   </div>
   <div

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -36,6 +36,8 @@ License: CECILL-C
   import { onMount } from "svelte";
 
   import KeyPointsSelection from "./Toolbar/KeyPointsSelectionTool.svelte";
+  import FusionTool from "./Toolbar/FusionTool.svelte";
+  import { ToolType } from "@pixano/canvas2d/src/tools";
 
   let previousSelectedTool: SelectionTool | null = null;
   let showSmartTools: boolean = false;
@@ -77,25 +79,26 @@ License: CECILL-C
     <IconButton
       tooltipContent={panTool.name}
       on:click={() => selectTool(panTool)}
-      selected={$selectedTool?.type === "PAN"}
+      selected={$selectedTool?.type === ToolType.Pan}
     >
       <MousePointer />
     </IconButton>
     <IconButton
       tooltipContent={rectangleTool.name}
       on:click={() => selectTool(rectangleTool)}
-      selected={$selectedTool?.type === "RECTANGLE" && !$selectedTool.isSmart}
+      selected={$selectedTool?.type === ToolType.Rectangle && !$selectedTool.isSmart}
     >
       <Square />
     </IconButton>
     <IconButton
       tooltipContent={polygonTool.name}
       on:click={() => selectTool(polygonTool)}
-      selected={$selectedTool?.type === "POLYGON"}
+      selected={$selectedTool?.type === ToolType.Polygon}
     >
       <Share2 />
     </IconButton>
     <KeyPointsSelection />
+    <FusionTool />
   </div>
   <div
     class={cn("flex items-center flex-col gap-4 mt-4", {
@@ -110,7 +113,7 @@ License: CECILL-C
       <IconButton
         tooltipContent={addSmartPointTool.name}
         on:click={() => selectTool(addSmartPointTool)}
-        selected={$selectedTool?.type === "POINT_SELECTION" && !!$selectedTool.label}
+        selected={$selectedTool?.type === ToolType.PointSelection && !!$selectedTool.label}
       >
         <PlusCircleIcon />
         <MagicIcon />
@@ -118,7 +121,7 @@ License: CECILL-C
       <IconButton
         tooltipContent={removeSmartPointTool.name}
         on:click={() => selectTool(removeSmartPointTool)}
-        selected={$selectedTool?.type === "POINT_SELECTION" && !$selectedTool.label}
+        selected={$selectedTool?.type === ToolType.PointSelection && !$selectedTool.label}
       >
         <MinusCircleIcon />
         <MagicIcon />
@@ -126,7 +129,7 @@ License: CECILL-C
       <IconButton
         tooltipContent={smartRectangleTool.name}
         on:click={() => selectTool(smartRectangleTool)}
-        selected={$selectedTool?.type === "RECTANGLE" && $selectedTool.isSmart}
+        selected={$selectedTool?.type === ToolType.Rectangle && $selectedTool.isSmart}
       >
         <Square />
         <MagicIcon />

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -28,8 +28,10 @@ License: CECILL-C
     polygonTool,
   } from "../lib/settings/selectionTools";
   import {
+    annotations,
     interactiveSegmenterModel,
     newShape,
+    merges,
     modelsUiStore,
     selectedTool,
   } from "../lib/stores/datasetItemWorkspaceStores";
@@ -42,8 +44,26 @@ License: CECILL-C
   let previousSelectedTool: SelectionTool | null = null;
   let showSmartTools: boolean = false;
 
+  const cleanFusion = () => {
+    //deselect everything = unhighlight all
+    annotations.update((anns) =>
+      anns.map((ann) => {
+        ann.ui.highlighted = "all";
+        return ann;
+      }),
+    );
+    merges.set({ to_fuse: [], forbids: [] });
+    selectedTool.set(panTool);
+  };
+
   const selectTool = (tool: SelectionTool) => {
-    if (tool !== $selectedTool) selectedTool.set(tool);
+    if (tool !== $selectedTool) {
+      if (previousSelectedTool?.type === ToolType.Fusion) {
+        //abort fusion
+        cleanFusion();
+      }
+      selectedTool.set(tool);
+    }
   };
 
   const handleSmartToolClick = () => {
@@ -98,7 +118,7 @@ License: CECILL-C
       <Share2 />
     </IconButton>
     <KeyPointsSelection />
-    <FusionTool />
+    <FusionTool {cleanFusion} />
   </div>
   <div
     class={cn("flex items-center flex-col gap-4 mt-4", {

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar/FusionTool.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar/FusionTool.svelte
@@ -11,7 +11,7 @@ License: CECILL-C
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import { Annotation, cn, IconButton, type SaveItem } from "@pixano/core/src";
   import { addOrUpdateSaveItem } from "../../lib/api/objectsApi";
-  import { fusionTool, panTool } from "../../lib/settings/selectionTools";
+  import { fusionTool } from "../../lib/settings/selectionTools";
   import {
     annotations,
     entities,
@@ -19,15 +19,23 @@ License: CECILL-C
     saveData,
     selectedTool,
   } from "../../lib/stores/datasetItemWorkspaceStores";
+  export let cleanFusion: () => void;
 
   const onFusionClick = () => {
     merges.set({ to_fuse: [], forbids: [] }); //should not be needed, but for safety...
     selectedTool.set(fusionTool);
-    console.log("Fusion mode ON");
-    //TODO deselect everything -- done in Canvas2D, but may be better if possible to do it here...
+    //deselect everything = unhighlight all
+    annotations.update((anns) =>
+      anns.map((ann) => {
+        ann.ui.highlighted = "all";
+        ann.ui.displayControl = { ...ann.ui.displayControl, editing: false };
+        return ann;
+      }),
+    );
   };
 
-  //merges.subscribe((assoc) => console.log("fusion list:", assoc));
+  //TMP dev
+  merges.subscribe((assoc) => console.log("fusion list:", assoc));
 
   const onValidate = () => {
     let reassoc_anns: Annotation[] = [];
@@ -83,15 +91,11 @@ License: CECILL-C
         saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
       });
     }
-
-    merges.set({ to_fuse: [], forbids: [] });
-    selectedTool.set(panTool);
+    cleanFusion();
   };
 
   const onAbort = () => {
-    console.log("Fusion abort");
-    merges.set({ to_fuse: [], forbids: [] });
-    selectedTool.set(panTool);
+    cleanFusion();
   };
 </script>
 

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar/FusionTool.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar/FusionTool.svelte
@@ -1,0 +1,118 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  // Imports
+  import { Check, ReplaceAll, X } from "lucide-svelte";
+
+  import { ToolType } from "@pixano/canvas2d/src/tools";
+  import { Annotation, cn, IconButton, type SaveItem } from "@pixano/core/src";
+  import { addOrUpdateSaveItem } from "../../lib/api/objectsApi";
+  import { fusionTool, panTool } from "../../lib/settings/selectionTools";
+  import {
+    annotations,
+    entities,
+    merges,
+    saveData,
+    selectedTool,
+  } from "../../lib/stores/datasetItemWorkspaceStores";
+
+  const onFusionClick = () => {
+    merges.set({ to_fuse: [], forbids: [] }); //should not be needed, but for safety...
+    selectedTool.set(fusionTool);
+    console.log("Fusion mode ON");
+    //TODO deselect everything -- done in Canvas2D, but may be better if possible to do it here...
+  };
+
+  //merges.subscribe((assoc) => console.log("fusion list:", assoc));
+
+  const onValidate = () => {
+    let reassoc_anns: Annotation[] = [];
+    console.log("Fusion validate (WIP = no constraint on impossible fusion yet!)");
+    if ($merges.to_fuse.length > 1) {
+      const [reference, ...to_fuse] = $merges.to_fuse;
+      to_fuse.forEach((entity) => {
+        if (entity.ui.childs) reassoc_anns = [...reassoc_anns, ...entity.ui.childs];
+      });
+      //change merged annotations entity reference
+      annotations.update((anns) =>
+        anns.map((ann) => {
+          if (reassoc_anns.includes(ann)) {
+            if (
+              ann.ui.top_entities &&
+              ann.ui.top_entities.length > 0 &&
+              ann.data.entity_ref.id !== ann.ui.top_entities[0].id
+            ) {
+              //TODO: if sub entities !
+              console.warn("ARGH, it's a sub entity !", ann);
+            }
+            ann.data.entity_ref = { id: reference.id, name: reference.table_info.name };
+            ann.ui.top_entities = [reference];
+            const save_item: SaveItem = {
+              change_type: "update",
+              object: ann,
+            };
+            saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+          }
+          return ann;
+        }),
+      );
+      //update entities
+      entities.update((ents) => {
+        const remaining_ents = ents.filter((ent) => !to_fuse.includes(ent));
+        if (remaining_ents.length > 0) {
+          remaining_ents.map((ent) => {
+            if (ent.id === reference.id) {
+              //update reference childs (note: no save needed as 'ui' field is front only)
+              ent.ui.childs = ent.ui.childs ? [...ent.ui.childs, ...reassoc_anns] : reassoc_anns;
+            }
+            return ent;
+          });
+        }
+        return remaining_ents;
+      });
+      // save deletion of fused entities
+      to_fuse.forEach((ent_to_del) => {
+        const save_item: SaveItem = {
+          change_type: "delete",
+          object: ent_to_del,
+        };
+        saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_item));
+      });
+    }
+
+    merges.set({ to_fuse: [], forbids: [] });
+    selectedTool.set(panTool);
+  };
+
+  const onAbort = () => {
+    console.log("Fusion abort");
+    merges.set({ to_fuse: [], forbids: [] });
+    selectedTool.set(panTool);
+  };
+</script>
+
+<div
+  class={cn("flex items-center flex-col gap-4 mt-4", {
+    "bg-slate-200 rounded-sm": $selectedTool?.type === ToolType.Fusion,
+  })}
+>
+  <IconButton
+    tooltipContent={fusionTool.name}
+    on:click={onFusionClick}
+    selected={$selectedTool?.type === ToolType.Fusion}
+  >
+    <ReplaceAll />
+  </IconButton>
+  {#if $selectedTool?.type === ToolType.Fusion}
+    <IconButton tooltipContent={"Validate association"} on:click={onValidate} selected={false}>
+      <Check />
+    </IconButton>
+    <IconButton tooltipContent={"Abort association"} on:click={onAbort} selected={false}>
+      <X />
+    </IconButton>
+  {/if}
+</div>

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar/FusionTool.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar/FusionTool.svelte
@@ -34,12 +34,8 @@ License: CECILL-C
     );
   };
 
-  //TMP dev
-  merges.subscribe((assoc) => console.log("fusion list:", assoc));
-
   const onValidate = () => {
     let reassoc_anns: Annotation[] = [];
-    console.log("Fusion validate (WIP = no constraint on impossible fusion yet!)");
     if ($merges.to_fuse.length > 1) {
       const [reference, ...to_fuse] = $merges.to_fuse;
       to_fuse.forEach((entity) => {
@@ -54,8 +50,9 @@ License: CECILL-C
               ann.ui.top_entities.length > 0 &&
               ann.data.entity_ref.id !== ann.ui.top_entities[0].id
             ) {
-              //TODO: if sub entities !
-              console.warn("ARGH, it's a sub entity !", ann);
+              //TODO: if sub entities ! (then we should change top_entities[1] to reference)
+              console.error("ERROR: Sub entities currently not managed for fusion.", ann);
+              return ann;
             }
             ann.data.entity_ref = { id: reference.id, name: reference.table_info.name };
             ann.ui.top_entities = [reference];

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar/KeyPointsSelectionTool.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar/KeyPointsSelectionTool.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   // Imports
   import { TangentIcon } from "lucide-svelte";
 
-  import { cn, IconButton, type Vertex } from "@pixano/core/src";
+  import { cn, IconButton, type SelectionTool, type Vertex } from "@pixano/core/src";
 
   import { keyPointTool } from "../../lib/settings/selectionTools";
   import {
@@ -19,6 +19,8 @@ License: CECILL-C
 
   import { templates } from "../../lib/settings/keyPointsTemplates";
   import { ToolType } from "@pixano/canvas2d/src/tools";
+
+  export let selectTool: (tool: SelectionTool) => void;
 
   const defineDotColor = (vertex: Vertex, selected: boolean) => {
     if (vertex.features?.color) return vertex.features.color;
@@ -44,7 +46,7 @@ License: CECILL-C
     "bg-slate-200 rounded-sm": $selectedTool?.type === ToolType.Keypoint,
   })}
 >
-  <IconButton tooltipContent={keyPointTool.name} on:click={() => selectedTool.set(keyPointTool)}>
+  <IconButton tooltipContent={keyPointTool.name} on:click={() => selectTool(keyPointTool)}>
     <TangentIcon />
   </IconButton>
   {#if $selectedTool?.type === ToolType.Keypoint}

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar/KeyPointsSelectionTool.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar/KeyPointsSelectionTool.svelte
@@ -18,6 +18,7 @@ License: CECILL-C
   } from "../../lib/stores/datasetItemWorkspaceStores";
 
   import { templates } from "../../lib/settings/keyPointsTemplates";
+  import { ToolType } from "@pixano/canvas2d/src/tools";
 
   const defineDotColor = (vertex: Vertex, selected: boolean) => {
     if (vertex.features?.color) return vertex.features.color;
@@ -30,7 +31,7 @@ License: CECILL-C
   };
 
   selectedTool.subscribe((tool) => {
-    if (tool?.type !== "KEY_POINT") {
+    if (tool?.type !== ToolType.Keypoint) {
       selectedKeypointsTemplate.set(null);
     } else {
       selectedKeypointsTemplate.set(templates[0].template_id);
@@ -40,13 +41,13 @@ License: CECILL-C
 
 <div
   class={cn("flex items-center flex-col gap-4 mt-4", {
-    "bg-slate-200 rounded-sm": $selectedTool?.type === "KEY_POINT",
+    "bg-slate-200 rounded-sm": $selectedTool?.type === ToolType.Keypoint,
   })}
 >
   <IconButton tooltipContent={keyPointTool.name} on:click={() => selectedTool.set(keyPointTool)}>
     <TangentIcon />
   </IconButton>
-  {#if $selectedTool?.type === "KEY_POINT"}
+  {#if $selectedTool?.type === ToolType.Keypoint}
     {#each templates as template}
       <IconButton
         tooltipContent={template.template_id}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -26,13 +26,7 @@ License: CECILL-C
   import { sourcesStore } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import { addOrUpdateSaveItem, getPixanoSource, getTopEntity } from "../../lib/api/objectsApi";
   import { sortByFrameIndex, splitTrackletInTwo } from "../../lib/api/videoApi";
-  import { panTool } from "../../lib/settings/selectionTools";
-  import {
-    annotations,
-    entities,
-    saveData,
-    selectedTool,
-  } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { annotations, entities, saveData } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     currentFrameIndex,
     lastFrameIndex,
@@ -47,6 +41,7 @@ License: CECILL-C
   export let onTimeTrackClick: (imageIndex: number) => void;
   export let bboxes: BBox[];
   export let keypoints: KeypointsTemplate[];
+  export let resetTool: () => void;
 
   let rightClickFrameIndex: number;
   let objectTimeTrack: HTMLElement;
@@ -79,7 +74,7 @@ License: CECILL-C
       );
     }
     moveCursorToPosition(event.clientX);
-    selectedTool.set(panTool);
+    resetTool();
   };
 
   const onEditKeyItemClick = (frameIndex: TrackletItem["frame_index"]) => {
@@ -346,6 +341,7 @@ License: CECILL-C
         onDeleteTrackletClick={() => onDeleteTrackletClick(tracklet)}
         {findNeighborItems}
         {moveCursorToPosition}
+        {resetTool}
       />
     {/each}
   </div>

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -26,7 +26,12 @@ License: CECILL-C
   import { sourcesStore } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import { addOrUpdateSaveItem, getPixanoSource, getTopEntity } from "../../lib/api/objectsApi";
   import { sortByFrameIndex, splitTrackletInTwo } from "../../lib/api/videoApi";
-  import { annotations, entities, saveData } from "../../lib/stores/datasetItemWorkspaceStores";
+  import {
+    annotations,
+    entities,
+    colorScale,
+    saveData,
+  } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     currentFrameIndex,
     lastFrameIndex,
@@ -48,6 +53,7 @@ License: CECILL-C
   let tracklets: Tracklet[];
 
   $: totalWidth = ($lastFrameIndex / ($lastFrameIndex + 1)) * 100;
+  $: color = $colorScale[1](track.id);
 
   $: if (track) {
     tracklets = $annotations.filter(
@@ -310,7 +316,7 @@ License: CECILL-C
   <div
     class="flex gap-5 relative my-auto z-20"
     id={`video-object-${track.id}`}
-    style={`width: ${$videoControls.zoomLevel[0]}%; height: ${Object.keys(views).length * 20}px;`}
+    style={`width: ${$videoControls.zoomLevel[0]}%; height: ${Object.keys(views).length * 20}px; background: ${color}1a;`}
     bind:this={objectTimeTrack}
     role="complementary"
   >
@@ -318,6 +324,7 @@ License: CECILL-C
       class="w-[1px] bg-primary h-full absolute top-0 z-30 pointer-events-none"
       style={`left: ${($currentFrameIndex / ($lastFrameIndex + 1)) * 100}%`}
     />
+    <span class="sticky left-0 m-1">{track.data.name} ({track.id})</span>
     <ContextMenu.Root>
       <ContextMenu.Trigger class="h-full w-full absolute left-0" style={`width: ${totalWidth}%`}>
         <p on:contextmenu|preventDefault={(e) => onContextMenu(e)} class="h-full w-full" />

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -321,7 +321,7 @@ License: CECILL-C
   <div
     class="flex gap-5 relative my-auto z-20"
     id={`video-object-${track.id}`}
-    style={`width: ${$videoControls.zoomLevel[0]}%; height: ${Object.keys(views).length * 20}px; background: ${color}1a;`}
+    style={`width: ${$videoControls.zoomLevel[0]}%; height: ${Object.keys(views).length * 10}px; background: ${color}1a;`}
     bind:this={objectTimeTrack}
     role="complementary"
   >

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -313,7 +313,9 @@ License: CECILL-C
 </script>
 
 {#if track && tracklets}
-  <span style={`background: ${color}1a;`}>{track.data.name} ({track.id})</span>
+  <span class="sticky left-5 m-1" style={`background: ${color}1a;`}
+    >{track.data.name} ({track.id})</span
+  >
   <div
     class="flex gap-5 relative my-auto z-20"
     id={`video-object-${track.id}`}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -313,6 +313,7 @@ License: CECILL-C
 </script>
 
 {#if track && tracklets}
+  <span style={`background: ${color}1a;`}>{track.data.name} ({track.id})</span>
   <div
     class="flex gap-5 relative my-auto z-20"
     id={`video-object-${track.id}`}
@@ -324,7 +325,6 @@ License: CECILL-C
       class="w-[1px] bg-primary h-full absolute top-0 z-30 pointer-events-none"
       style={`left: ${($currentFrameIndex / ($lastFrameIndex + 1)) * 100}%`}
     />
-    <span class="sticky left-0 m-1">{track.data.name} ({track.id})</span>
     <ContextMenu.Root>
       <ContextMenu.Trigger class="h-full w-full absolute left-0" style={`width: ${totalWidth}%`}>
         <p on:contextmenu|preventDefault={(e) => onContextMenu(e)} class="h-full w-full" />

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -313,9 +313,11 @@ License: CECILL-C
 </script>
 
 {#if track && tracklets}
-  <span class="sticky left-5 m-1" style={`background: ${color}1a;`}
-    >{track.data.name} ({track.id})</span
-  >
+  <div style={`width: ${$videoControls.zoomLevel[0]}%;`}>
+    <span class="sticky left-5 m-1" style={`background: ${color}1a;`}
+      >{track.data.name} ({track.id})</span
+    >
+  </div>
   <div
     class="flex gap-5 relative my-auto z-20"
     id={`video-object-${track.id}`}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -161,6 +161,7 @@ License: CECILL-C
     <ContextMenu.Item inset on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
   </ContextMenu.Content>
 </ContextMenu.Root>
+<!--
 {#each tracklet_annotations_frame_indexes as itemFrameIndex}
   <TrackletKeyItem
     {itemFrameIndex}
@@ -177,3 +178,4 @@ License: CECILL-C
     {resetTool}
   />
 {/each}
+-->

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -41,6 +41,7 @@ License: CECILL-C
   export let onDeleteTrackletClick: () => void;
   export let findNeighborItems: (tracklet: Tracklet, frameIndex: number) => [number, number];
   export let moveCursorToPosition: (clientX: number) => void;
+  export let resetTool: () => void;
 
   const getLeft = (tracklet: Tracklet) =>
     (tracklet.data.start_timestep / ($lastFrameIndex + 1)) * 100;
@@ -140,7 +141,7 @@ License: CECILL-C
 
   const onClick = (clientX: number) => {
     moveCursorToPosition(clientX);
-    selectedTool.set(panTool);
+    resetTool();
   };
 </script>
 
@@ -180,5 +181,6 @@ License: CECILL-C
     {trackId}
     {canContinueDragging}
     {updateTrackletWidth}
+    {resetTool}
   />
 {/each}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -35,6 +35,7 @@ License: CECILL-C
   export let findNeighborItems: (tracklet: Tracklet, frameIndex: number) => [number, number];
   export let moveCursorToPosition: (clientX: number) => void;
   export let resetTool: () => void;
+  const showKeyframes: boolean = false; //later this flag could be controled somewhere
 
   const getLeft = (tracklet: Tracklet) =>
     (tracklet.data.start_timestep / ($lastFrameIndex + 1)) * 100;
@@ -161,21 +162,21 @@ License: CECILL-C
     <ContextMenu.Item inset on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
   </ContextMenu.Content>
 </ContextMenu.Root>
-<!--
-{#each tracklet_annotations_frame_indexes as itemFrameIndex}
-  <TrackletKeyItem
-    {itemFrameIndex}
-    {tracklet}
-    {color}
-    {height}
-    {top}
-    {oneFrameInPixel}
-    {onEditKeyItemClick}
-    {onClick}
-    {trackId}
-    {canContinueDragging}
-    {updateTrackletWidth}
-    {resetTool}
-  />
-{/each}
--->
+{#if showKeyframes}
+  {#each tracklet_annotations_frame_indexes as itemFrameIndex}
+    <TrackletKeyItem
+      {itemFrameIndex}
+      {tracklet}
+      {color}
+      {height}
+      {top}
+      {oneFrameInPixel}
+      {onEditKeyItemClick}
+      {onClick}
+      {trackId}
+      {canContinueDragging}
+      {updateTrackletWidth}
+      {resetTool}
+    />
+  {/each}
+{/if}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -18,16 +18,9 @@ License: CECILL-C
   } from "@pixano/core";
   import { sourcesStore } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import { addOrUpdateSaveItem, getPixanoSource } from "../../lib/api/objectsApi";
-  import {
-    annotations,
-    colorScale,
-    saveData,
-    selectedTool,
-  } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { annotations, colorScale, saveData } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
   import TrackletKeyItem from "./TrackletKeyItem.svelte";
-
-  import { panTool } from "../../lib/settings/selectionTools";
 
   type MView = Record<string, View | View[]>;
 

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
@@ -13,10 +13,9 @@ License: CECILL-C
     videoControls,
   } from "../../lib/stores/videoViewerStores";
   import { onMount } from "svelte";
-  import { selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
-  import { panTool } from "../../lib/settings/selectionTools";
 
   export let updateView: (imageIndex: number) => void;
+  export let resetTool: () => void;
 
   let cursorElement: HTMLButtonElement;
   let timeTrackElement: HTMLElement;
@@ -25,12 +24,6 @@ License: CECILL-C
   const videoTotalLengthInMs = imageFilesLength * $videoControls.videoSpeed;
   let timeScaleInMs = [...Array(Math.floor(videoTotalLengthInMs / 100)).keys()];
   let timeTrackDensity = 1;
-
-  const changeSelectedTool = () => {
-    if ($selectedTool.name !== panTool.name) {
-      selectedTool.set(panTool);
-    }
-  };
 
   const dragMe = (node: HTMLButtonElement) => {
     let moving = false;
@@ -44,7 +37,7 @@ License: CECILL-C
       if (moving) {
         currentFrameIndex.set(getImageIndexFromMouseMove(event, node, imageFilesLength));
         updateView($currentFrameIndex);
-        changeSelectedTool();
+        resetTool();
       }
     });
 
@@ -78,7 +71,7 @@ License: CECILL-C
       Math.round((event.offsetX / targetElement.offsetWidth) * imageFilesLength),
     );
     updateView($currentFrameIndex);
-    changeSelectedTool();
+    resetTool();
   };
 
   const shouldDisplayTime = (ms: number, density: number) => {

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -10,11 +10,7 @@ License: CECILL-C
   import { BaseSchema, ContextMenu, Tracklet, cn } from "@pixano/core";
   import { sourcesStore } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import { addOrUpdateSaveItem, getPixanoSource } from "../../lib/api/objectsApi";
-  import {
-    annotations,
-    entities,
-    saveData,
-  } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { annotations, entities, saveData } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
 
   export let trackId: string;

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -10,12 +10,10 @@ License: CECILL-C
   import { BaseSchema, ContextMenu, Tracklet, cn } from "@pixano/core";
   import { sourcesStore } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import { addOrUpdateSaveItem, getPixanoSource } from "../../lib/api/objectsApi";
-  import { panTool } from "../../lib/settings/selectionTools";
   import {
     annotations,
     entities,
     saveData,
-    selectedTool,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
 
@@ -37,6 +35,7 @@ License: CECILL-C
     newIndex: TrackletItem["frame_index"],
     draggedIndex: TrackletItem["frame_index"],
   ) => boolean;
+  export let resetTool: () => void;
 
   let isItemBeingEdited = false;
 
@@ -132,7 +131,7 @@ License: CECILL-C
       startPosition = event.clientX;
       startFrameIndex = itemFrameIndex;
       startOneFrameInPixel = oneFrameInPixel;
-      selectedTool.set(panTool);
+      resetTool();
       const dragController = new AbortController();
 
       window.addEventListener(

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
@@ -14,10 +14,9 @@ License: CECILL-C
     currentFrameIndex,
     videoControls,
   } from "../../lib/stores/videoViewerStores";
-  import { selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
-  import { panTool } from "../../lib/settings/selectionTools";
 
   export let updateView: (frameIndex: number) => void;
+  export let resetTool: () => void;
 
   let currentTime: string;
 
@@ -38,7 +37,7 @@ License: CECILL-C
   $: currentTime = getCurrentImageTime($currentFrameIndex, $videoControls.videoSpeed);
 
   const onPlayStepClick = () => {
-    selectedTool.set(panTool);
+    resetTool();
     if ($videoControls.intervalId) {
       clearInterval($videoControls.intervalId);
       videoControls.update((old) => ({ ...old, intervalId: 0 }));
@@ -51,7 +50,7 @@ License: CECILL-C
   };
 
   const onPlayStepBackClick = () => {
-    selectedTool.set(panTool);
+    resetTool();
     if ($videoControls.intervalId) {
       clearInterval($videoControls.intervalId);
       videoControls.update((old) => ({ ...old, intervalId: 0 }));
@@ -67,7 +66,7 @@ License: CECILL-C
   };
 
   const onPlayClick = () => {
-    selectedTool.set(panTool);
+    resetTool();
     if ($videoControls.intervalId) {
       clearInterval($videoControls.intervalId);
       videoControls.update((old) => ({ ...old, intervalId: 0 }));

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -20,6 +20,9 @@ License: CECILL-C
   } from "../../lib/stores/videoViewerStores";
   import { SliderRoot, Track, BBox, type KeypointsTemplate } from "@pixano/core";
   import { onMount } from "svelte";
+  import { selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { panTool } from "../../lib/settings/selectionTools";
+  import { ToolType } from "@pixano/canvas2d/src/tools";
 
   export let updateView: (frameIndex: number) => void;
   export let tracks: Track[];
@@ -29,6 +32,12 @@ License: CECILL-C
   onMount(() => {
     videoControls.update((old) => ({ ...old, isLoaded: true }));
   });
+
+  const resetTool = () => {
+    if (![ToolType.Pan, ToolType.Fusion].includes($selectedTool.type)) {
+      selectedTool.set(panTool);
+    }
+  };
 
   const onTimeTrackClick = (index: number) => {
     if ($currentFrameIndex !== index) {
@@ -51,7 +60,7 @@ License: CECILL-C
   <div class="h-full bg-white overflow-x-auto relative flex flex-col">
     <div class="sticky top-0 bg-white z-20">
       <VideoPlayerRow class="bg-white ">
-        <TimeTrack slot="timeTrack" {updateView} />
+        <TimeTrack slot="timeTrack" {updateView} {resetTool}/>
       </VideoPlayerRow>
     </div>
     <div class="flex flex-col grow z-10">
@@ -64,12 +73,13 @@ License: CECILL-C
             {onTimeTrackClick}
             {bboxes}
             {keypoints}
+            {resetTool}
           />
         </VideoPlayerRow>
       {/each}
     </div>
     <div class="px-2 sticky bottom-0 left-0 z-20 bg-white shadow flex justify-between">
-      <VideoControls {updateView} />
+      <VideoControls {updateView} {resetTool}/>
       <SliderRoot
         class="max-w-[200px]"
         bind:value={$videoControls.zoomLevel}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -60,7 +60,7 @@ License: CECILL-C
   <div class="h-full bg-white overflow-x-auto relative flex flex-col">
     <div class="sticky top-0 bg-white z-20">
       <VideoPlayerRow class="bg-white ">
-        <TimeTrack slot="timeTrack" {updateView} {resetTool}/>
+        <TimeTrack slot="timeTrack" {updateView} {resetTool} />
       </VideoPlayerRow>
     </div>
     <div class="flex flex-col grow z-10">
@@ -79,7 +79,7 @@ License: CECILL-C
       {/each}
     </div>
     <div class="px-2 sticky bottom-0 left-0 z-20 bg-white shadow flex justify-between">
-      <VideoControls {updateView} {resetTool}/>
+      <VideoControls {updateView} {resetTool} />
       <SliderRoot
         class="max-w-[200px]"
         bind:value={$videoControls.zoomLevel}

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineCreatedEntity.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineCreatedEntity.ts
@@ -25,7 +25,7 @@ export const defineCreatedEntity = (
   alternateViewRef: { id: string; name: string } | undefined = undefined,
 ): Entity | Track => {
   const table = entitySchema.name;
-  const now = new Date(Date.now()).toISOString();
+  const now = new Date(Date.now()).toISOString().replace(/Z$/, "+00:00");
   const entity = {
     id: nanoid(10),
     created_at: now,

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineCreatedObject.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineCreatedObject.ts
@@ -35,7 +35,7 @@ export const defineCreatedObject = (
   isVideo: boolean,
   currentFrameIndex: number,
 ): Annotation | undefined => {
-  const now = new Date(Date.now()).toISOString();
+  const now = new Date(Date.now()).toISOString().replace(/Z$/, "+00:00");
   const baseAnn = {
     id: nanoid(10),
     created_at: now,

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/getPixanoSource.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/getPixanoSource.ts
@@ -15,7 +15,7 @@ export const getPixanoSource = (srcStore: Writable<Source[]>): Source => {
   const sources = get<Source[]>(srcStore);
   let pixanoSource = sources.find((src) => src.data.name === "Pixano" && src.data.kind === "other");
   if (!pixanoSource) {
-    const now = new Date(Date.now()).toISOString();
+    const now = new Date(Date.now()).toISOString().replace(/Z$/, "+00:00");
     pixanoSource = new Source({
       id: "pixano_source",
       created_at: now,

--- a/ui/components/datasetItemWorkspace/src/lib/settings/selectionTools.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/settings/selectionTools.ts
@@ -4,38 +4,46 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import { ToolType } from "@pixano/canvas2d/src/tools";
 import type { SelectionTool } from "@pixano/core";
 
 export const panTool: SelectionTool = {
   name: "Move image",
-  type: "PAN",
+  type: ToolType.Pan,
   cursor: "move",
 };
 
 export const rectangleTool: SelectionTool = {
   name: "Create a bounding box",
-  type: "RECTANGLE",
+  type: ToolType.Rectangle,
   cursor: "crosshair",
   isSmart: false,
 };
 
 export const polygonTool: SelectionTool = {
   name: "Create a polygon",
-  type: "POLYGON",
+  type: ToolType.Polygon,
   cursor: "crosshair",
   isSmart: false,
 };
 
 export const keyPointTool: SelectionTool = {
   name: "Create key points",
-  type: "KEY_POINT",
+  type: ToolType.Keypoint,
   cursor: "crosshair",
+  isSmart: false,
+};
+
+export const fusionTool: SelectionTool = {
+  name: "Associate objects",
+  type: ToolType.Fusion,
+  cursor: "default",
   isSmart: false,
 };
 
 export const removeSmartPointTool: SelectionTool = {
   name: "Negative point selection",
-  type: "POINT_SELECTION",
+  type: ToolType.PointSelection,
   cursor: "crosshair",
   label: 0,
   isSmart: true,
@@ -43,7 +51,7 @@ export const removeSmartPointTool: SelectionTool = {
 
 export const addSmartPointTool: SelectionTool = {
   name: "Positive point selection",
-  type: "POINT_SELECTION",
+  type: ToolType.PointSelection,
   cursor: "crosshair",
   label: 1,
   isSmart: true,
@@ -51,7 +59,7 @@ export const addSmartPointTool: SelectionTool = {
 
 export const smartRectangleTool: SelectionTool = {
   name: "Rectangle selection",
-  type: "RECTANGLE",
+  type: ToolType.Rectangle,
   cursor: "crosshair",
   isSmart: true,
 };

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -27,7 +27,12 @@ import {
 import { derived, writable } from "svelte/store";
 
 import { mapObjectToBBox, mapObjectToKeypoints, mapObjectToMasks } from "../api/objectsApi";
-import type { Filters, ItemsMeta, ModelSelection } from "../types/datasetItemWorkspaceTypes";
+import type {
+  Filters,
+  ItemsMeta,
+  Merges,
+  ModelSelection,
+} from "../types/datasetItemWorkspaceTypes";
 
 // Exports
 export const newShape = writable<Shape>();
@@ -35,6 +40,7 @@ export const selectedTool = writable<SelectionTool>();
 export const annotations = writable<Annotation[]>([]);
 export const entities = writable<Entity[]>([]);
 export const views = writable<Record<string, View | View[]>>({});
+export const merges = writable<Merges>({ to_fuse: [], forbids: [] });
 export const interactiveSegmenterModel = writable<InteractiveImageSegmenter>();
 export const itemMetas = writable<ItemsMeta>();
 export const preAnnotationIsActive = writable<boolean>(false);

--- a/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/types/datasetItemWorkspaceTypes.ts
@@ -4,10 +4,10 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { z } from "zod";
 import * as ort from "onnxruntime-web";
+import { z } from "zod";
 
-import { Item, Entity, Annotation, type FeaturesValues, type FeatureValues } from "@pixano/core";
+import { Annotation, Entity, Item, type FeaturesValues, type FeatureValues } from "@pixano/core";
 
 import type {
   createObjectInputsSchema,
@@ -92,4 +92,10 @@ export type Filters = {
   greenRange: number[];
   blueRange: number[];
   u16BitRange: number[];
+};
+
+export type Merges = {
+  //reference: Entity,
+  to_fuse: Entity[];
+  forbids: Entity[];
 };


### PR DESCRIPTION
## Issue

For video, we want to be able to merge tracks (Re ID)

Fixes #379 
Also should fixes #389 

## Description

New feature: 
![image](https://github.com/user-attachments/assets/a7663667-3917-4445-b77d-40b337775267)

use the "Associate" button to enter *Association* mode.

click on bbox in views to add their whole track to the association list. Click on an already selected bbox to remove it from list.

The first one clicked is the reference (all will be merged in this one). -- first in the list at validation time, it could have changed if first has been deselected

Click "Validate" button to merge. (it doesn't save, you have to save as usual to push changes to back).
Click "Abort" button to cancel current association.

- [x] highlight (reference + tracks added in merge list)
- [x] unhighlight tracks that cannot merge (because of conflict, eg. a bbox in same view as any already in merge list, etc...)
- [x] do not allow theses forbiden tracks to be added

+ some minor code refactoring on ToolType (use Enum ToolType instead of plain string)
+ fix for trailing Z in dates (see #389)
+ add track label "name (id)" in video inspector

Note: only BBox are "clickable" for association, (but all what belongs to the tracks is merged)
It could be ehanced if needed