### PR TITLE
feat: Add larger color palette

### DIFF
--- a/ui/components/core/src/utils.ts
+++ b/ui/components/core/src/utils.ts
@@ -6,11 +6,44 @@ License: CECILL-C
 
 // Imports
 import { scaleOrdinal } from "d3";
-import { schemeSet3 } from "d3-scale-chromatic";
 
 // Exports
 export function ordinalColorScale(range: Iterable<string>) {
-  return scaleOrdinal(schemeSet3).domain(range);
+  const palette = [
+    "#ffc0cb",
+    "#7fffd4",
+    "#7b68ee",
+    "#ff1493",
+    "#b0e0e6",
+    "#eee8aa",
+    "#fa8072",
+    "#1e90ff",
+    "#ff00ff",
+    "#da70d6",
+    "#adff2f",
+    "#0000ff",
+    "#00bfff",
+    "#dc143c",
+    "#00fa9a",
+    "#9400d3",
+    "#00ff00",
+    "#ffff00",
+    "#ffa500",
+    "#ff0000",
+    "#b03060",
+    "#800080",
+    "#32cd32",
+    "#20b2aa",
+    "#d2691e",
+    "#000080",
+    "#3cb371",
+    "#008000",
+    "#483d8b",
+    "#808000",
+    "#7f0000",
+    "#2f4f4f",
+  ];
+  return scaleOrdinal(palette).domain(range);
 }
 
 export function isValidURL(urlString: string) {


### PR DESCRIPTION
Replace the existing schemeSet3 color palette (12 colors) with a new custom color palette (32 colors)

## Description

Created a larger color palette using https://mokole.com/palette.html to have more visually distinct colors.