### PR TITLE
show/hide track

### DIFF
--- a/ui/components/core/src/lib/types/dataset/entities/Entity.ts
+++ b/ui/components/core/src/lib/types/dataset/entities/Entity.ts
@@ -7,8 +7,8 @@ License: CECILL-C
 import { z } from "zod";
 import { createTypedEntity } from "../../../utils/entities";
 import type { Annotation } from "../annotations";
-import { BaseData, type BaseDataFields, referenceSchema } from "../datasetTypes";
 import { BaseSchema } from "../BaseSchema";
+import { BaseData, type BaseDataFields, referenceSchema } from "../datasetTypes";
 
 export const entitySchema = z
   .object({
@@ -20,11 +20,13 @@ export const entitySchema = z
 
 export type EntityType = z.infer<typeof entitySchema>; //export if needed
 
+export type EntityUIFields = {
+  childs?: Annotation[];
+};
+
 export class Entity extends BaseData<EntityType> {
   //UI fields
-  ui: {
-    childs?: Annotation[];
-  } = { childs: [] };
+  ui: EntityUIFields = { childs: [] };
 
   constructor(obj: BaseDataFields<EntityType>) {
     entitySchema.parse(obj.data);
@@ -53,7 +55,6 @@ export class Entity extends BaseData<EntityType> {
       console.error("ERROR: do not use 'is_*' on uninitialized object");
       return false;
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     return this.table_info.base_schema === type;
   }
 

--- a/ui/components/core/src/lib/types/dataset/entities/Track.ts
+++ b/ui/components/core/src/lib/types/dataset/entities/Track.ts
@@ -6,7 +6,7 @@ License: CECILL-C
 
 import { z } from "zod";
 import type { BaseDataFields } from "../datasetTypes";
-import { Entity, type EntityType } from "./Entity";
+import { Entity, type EntityType, type EntityUIFields } from "./Entity";
 
 const trackSchema = z
   .object({
@@ -17,6 +17,10 @@ const trackSchema = z
 export type TrackType = z.infer<typeof trackSchema>; //export if needed
 
 export class Track extends Entity {
+  ui: EntityUIFields & {
+    hidden?: boolean;
+  } = { hidden: false };
+
   constructor(obj: BaseDataFields<TrackType>) {
     trackSchema.parse(obj.data);
     super(obj as unknown as BaseDataFields<EntityType>);

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { ChevronRight, Eye, EyeOff, Pencil, Trash2 } from "lucide-svelte";
+  import { ChevronRight, Eye, EyeOff, ListPlus, ListX, Pencil, Trash2 } from "lucide-svelte";
   import { derived } from "svelte/store";
 
   import { TextSpansContent, Thumbnail } from "@pixano/canvas2d";
@@ -14,6 +14,7 @@ License: CECILL-C
     Annotation,
     Entity,
     Item,
+    Track,
     type DisplayControl,
     type ObjectThumbnail,
     type SaveItem,
@@ -47,7 +48,6 @@ License: CECILL-C
   import DisplayCheckbox from "./DisplayCheckbox.svelte";
 
   export let entity: Entity;
-
   let open: boolean = false;
   let showIcons: boolean = false;
   let isHighlighted: boolean = false;
@@ -57,6 +57,8 @@ License: CECILL-C
   let maskIsVisible: boolean = true;
   let keypointsIsVisible: boolean = true;
   let textSpansIsVisible: boolean = true;
+
+  let hiddenTrack = entity.is_track ? (entity as Track).ui.hidden : false;
 
   $: displayName =
     (entity.data.name
@@ -260,6 +262,15 @@ License: CECILL-C
     );
   };
 
+  const onTrackVisClick = () => {
+    if (entity.is_track) {
+      (entity as Track).ui.hidden = !(entity as Track).ui.hidden;
+      hiddenTrack = (entity as Track).ui.hidden;
+      //svelte hack to refresh
+      entities.set($entities);
+    }
+  };
+
   const onEditIconClick = () => {
     handleSetAnnotationDisplayControl("editing", !isEditing);
     !isEditing && selectedTool.set(panTool);
@@ -309,11 +320,24 @@ License: CECILL-C
       <div
         class={cn(
           "flex-shrink-0 flex items-center justify-end",
-          showIcons || isEditing ? "basis-[120px]" : "basis-[40px]",
+          showIcons || isEditing
+            ? entity.is_track
+              ? "basis-[160px]"
+              : "basis-[120px]"
+            : "basis-[40px]",
         )}
         style="min-width: 40px;"
       >
         {#if showIcons || isEditing}
+          {#if entity.is_track}
+            <IconButton
+              tooltipContent={hiddenTrack ? "Show track" : "Hide track"}
+              on:click={onTrackVisClick}
+              >{#if hiddenTrack}<ListPlus class="h-4" />{:else}<ListX
+                  class="h-4"
+                />{/if}</IconButton
+            >
+          {/if}
           <IconButton tooltipContent="Edit object" selected={isEditing} on:click={onEditIconClick}
             ><Pencil class="h-4" /></IconButton
           >

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -324,25 +324,25 @@ License: CECILL-C
             ? entity.is_track
               ? "basis-[160px]"
               : "basis-[120px]"
-            : "basis-[40px]",
+            : entity.is_track && hiddenTrack
+              ? "basis-[80px]"
+              : "basis-[40px]",
         )}
         style="min-width: 40px;"
       >
         {#if showIcons || isEditing}
-          {#if entity.is_track}
-            <IconButton
-              tooltipContent={hiddenTrack ? "Show track" : "Hide track"}
-              on:click={onTrackVisClick}
-              >{#if hiddenTrack}<ListPlus class="h-4" />{:else}<ListX
-                  class="h-4"
-                />{/if}</IconButton
-            >
-          {/if}
           <IconButton tooltipContent="Edit object" selected={isEditing} on:click={onEditIconClick}
             ><Pencil class="h-4" /></IconButton
           >
           <IconButton tooltipContent="Delete object" on:click={deleteObject}
             ><Trash2 class="h-4" /></IconButton
+          >
+        {/if}
+        {#if entity.is_track && (showIcons || isEditing || hiddenTrack)}
+          <IconButton
+            tooltipContent={hiddenTrack ? "Show track" : "Hide track"}
+            on:click={onTrackVisClick}
+            >{#if hiddenTrack}<ListPlus class="h-4" />{:else}<ListX class="h-4" />{/if}</IconButton
           >
         {/if}
         <IconButton

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -65,17 +65,19 @@ License: CECILL-C
     </div>
     <div class="flex flex-col grow z-10">
       {#each tracks as track (track.ui.childs)}
-        <VideoPlayerRow>
-          <ObjectTrack
-            slot="timeTrack"
-            {track}
-            views={$views}
-            {onTimeTrackClick}
-            {bboxes}
-            {keypoints}
-            {resetTool}
-          />
-        </VideoPlayerRow>
+        {#if !track.ui.hidden}
+          <VideoPlayerRow>
+            <ObjectTrack
+              slot="timeTrack"
+              {track}
+              views={$views}
+              {onTimeTrackClick}
+              {bboxes}
+              {keypoints}
+              {resetTool}
+            />
+          </VideoPlayerRow>
+        {/if}
       {/each}
     </div>
     <div class="px-2 sticky bottom-0 left-0 z-20 bg-white shadow flex justify-between">


### PR DESCRIPTION
## Issue

new feature:
![image](https://github.com/user-attachments/assets/d4f08400-5a2b-45dc-b0dc-8b3fc7f9e64a)

allow to hide/show tracks in VideoInspector

## Description

add button in ObjectInspector to show/hide tracks

Note: UI/design wise, unlike the classic "show/hide" icon (eye), the icon is visible only when selected or on hover, so it's possible to be somehow confused about which one is visible/invisible ...
Also, there is not much diffirence with currently choosen icons between visible and hidden.