### PR TITLE
feat(front): Better TimeTrack scaling

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
@@ -75,11 +75,25 @@ License: CECILL-C
   };
 
   const shouldDisplayTime = (ms: number, density: number) => {
-    if (ms % 10 !== 0) return false;
-    if (50 < density && ms % 50 === 0) return true;
-    if (25 < density && density < 50 && ms % 20 === 0) return true;
-    if (density < 25) return true;
-    return false;
+    if (density > 2000) {
+      return ms % 1200 === 0;
+    } else if (density > 1000) {
+      return ms % 600 === 0;
+    } else if (density > 500) {
+      return ms % 300 === 0;
+    } else if (density > 400) {
+      return ms % 200 === 0;
+    } else if (density > 250) {
+      return ms % 150 === 0;
+    } else if (density > 100) {
+      return ms % 100 === 0;
+    } else if (density > 50) {
+      return ms % 50 === 0;
+    } else if (density > 25) {
+      return ms % 20 === 0;
+    } else {
+      return ms % 10 === 0;
+    }
   };
 
   $: {
@@ -89,10 +103,23 @@ License: CECILL-C
   }
 
   const shouldDisplayMarker = (ms: number, density: number) => {
-    if (density > 200) return false;
-    if (density > 25 && ms % 10 === 0) return true;
-    if (density < 25) return true;
-    return false;
+    if (density > 2000) {
+      return ms % 600 === 0;
+    } else if (density > 1000) {
+      return ms % 300 === 0;
+    } else if (density > 500) {
+      return ms % 150 === 0;
+    } else if (density > 400) {
+      return ms % 100 === 0;
+    } else if (density > 250) {
+      return ms % 50 === 0;
+    } else if (density > 20) {
+      return ms % 10 === 0;
+    } else if (density > 10) {
+      return ms % 5 === 0;
+    } else {
+      return true;
+    }
   };
 </script>
 
@@ -129,9 +156,15 @@ License: CECILL-C
       />
       {#if ms > 0}
         <span
-          class="absolute -translate-x-1/2 text-slate-300 bottom-1/3 pointer-events-none font-light text-xs pb-1"
-          style={`left: ${((ms * 100) / videoTotalLengthInMs) * 100}%`}>{ms / 10}s</span
+          class="absolute -translate-x-1/2 text-slate-500 bottom-1/3 pointer-events-none font-light text-xs pb-1"
+          style={`left: ${((ms * 100) / videoTotalLengthInMs) * 100}%`}
         >
+          {#if videoTotalLengthInMs > 60000}
+            {Math.floor(ms / 600)}:{String(Math.floor(ms % 600) / 10).padStart(2, "0")}
+          {:else}
+            {Math.floor(ms % 600) / 10}s
+          {/if}
+        </span>
       {/if}
     {:else if shouldDisplayMarker(ms, timeTrackDensity)}
       <span

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
@@ -75,25 +75,14 @@ License: CECILL-C
   };
 
   const shouldDisplayTime = (ms: number, density: number) => {
-    if (density > 2000) {
-      return ms % 1200 === 0;
-    } else if (density > 1000) {
-      return ms % 600 === 0;
-    } else if (density > 500) {
-      return ms % 300 === 0;
-    } else if (density > 400) {
-      return ms % 200 === 0;
-    } else if (density > 250) {
-      return ms % 150 === 0;
-    } else if (density > 100) {
-      return ms % 100 === 0;
-    } else if (density > 50) {
-      return ms % 50 === 0;
-    } else if (density > 25) {
-      return ms % 20 === 0;
-    } else {
-      return ms % 10 === 0;
+    let densityThresholds = [2000, 1000, 500, 400, 250, 100, 50, 25];
+    let displayedTimes = [1200, 600, 300, 200, 150, 100, 50, 20];
+    for (let i = 0; i < densityThresholds.length; ++i) {
+      if (density > densityThresholds[i]) {
+        return ms % displayedTimes[i] === 0;
+      }
     }
+    return ms % 10 === 0;
   };
 
   $: {
@@ -103,23 +92,14 @@ License: CECILL-C
   }
 
   const shouldDisplayMarker = (ms: number, density: number) => {
-    if (density > 2000) {
-      return ms % 600 === 0;
-    } else if (density > 1000) {
-      return ms % 300 === 0;
-    } else if (density > 500) {
-      return ms % 150 === 0;
-    } else if (density > 400) {
-      return ms % 100 === 0;
-    } else if (density > 250) {
-      return ms % 50 === 0;
-    } else if (density > 20) {
-      return ms % 10 === 0;
-    } else if (density > 10) {
-      return ms % 5 === 0;
-    } else {
-      return true;
+    let densityThresholds = [2000, 1000, 500, 400, 250, 20, 10];
+    let displayedMarkers = [600, 300, 150, 100, 50, 10, 5];
+    for (let i = 0; i < densityThresholds.length; ++i) {
+      if (density > densityThresholds[i]) {
+        return ms % displayedMarkers[i] === 0;
+      }
     }
+    return true;
   };
 </script>
 


### PR DESCRIPTION
## Description

Better scaling of markers and time indicators for longer videos with more granular options based on timeline density

![image](https://github.com/user-attachments/assets/a997a142-1413-4b22-9527-72007e9fa721)
![image](https://github.com/user-attachments/assets/97f0ac14-3829-4687-bc3e-72d3067dd1ce)
![image](https://github.com/user-attachments/assets/96d07580-c5b4-4c80-ad90-0720d385c13c)
![image](https://github.com/user-attachments/assets/80279f27-5449-45f9-a9a3-fd39edf19cef)
![image](https://github.com/user-attachments/assets/f1778f20-d5a0-411a-bfa9-63dd998414e6)
![image](https://github.com/user-attachments/assets/e6dfcd0e-dbbb-4c92-b707-733aa835557b)

Note: time indicators in "`{mm}`:`{ss}`" format for videos longer than a minute, and in "`{ss}`s" for shorter videos 