### PR TITLE
feat(front): Add icons for timeline zoom slider

### DIFF
--- a/ui/components/core/src/components/ui/slider/SliderRoot.svelte
+++ b/ui/components/core/src/components/ui/slider/SliderRoot.svelte
@@ -8,6 +8,7 @@ License: CECILL-C
   // Imports
   import { Slider as SliderPrimitive } from "bits-ui";
   import { cn } from "../../../lib/utils/styleUtils";
+  import { ZoomOut, ZoomIn } from "lucide-svelte";
 
   type $$Props = SliderPrimitive.Props;
 
@@ -16,15 +17,26 @@ License: CECILL-C
   export { className as class };
 </script>
 
-<SliderPrimitive.Root
-  bind:value
-  class={cn("relative flex w-full touch-none select-none items-center", className)}
+<div
+  class={cn("relative flex justify-between items-center gap-4 p-4 w-full", className)}
   {...$$restProps}
 >
-  <span class="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-    <SliderPrimitive.Range class="absolute h-full bg-primary" />
-  </span>
-  <SliderPrimitive.Thumb
-    class="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-  />
-</SliderPrimitive.Root>
+  <div title="Zoom out" class="text-primary">
+    <ZoomOut />
+  </div>
+  <SliderPrimitive.Root
+    bind:value
+    class={cn("relative flex w-full touch-none select-none items-center", className)}
+    {...$$restProps}
+  >
+    <span class="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range class="absolute h-full bg-primary" />
+    </span>
+    <SliderPrimitive.Thumb
+      class="block h-4 w-4 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+    />
+  </SliderPrimitive.Root>
+  <div title="Zoom in" class="text-primary">
+    <ZoomIn />
+  </div>
+</div>

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -83,7 +83,7 @@ License: CECILL-C
     <div class="px-2 sticky bottom-0 left-0 z-20 bg-white shadow flex justify-between">
       <VideoControls {updateView} {resetTool} />
       <SliderRoot
-        class="max-w-[200px]"
+        class="max-w-[250px]"
         bind:value={$videoControls.zoomLevel}
         min={100}
         max={Math.max($lastFrameIndex * 3, 200)}


### PR DESCRIPTION
## Description

Just a small UI improvement to add zoom in and zoom out icons on each side of the zoom slider for the video timeline, based on a suggestion that its purpose might not be obvious for all beginner users.