### PR TITLE
feat(front): Update object thumbnails in side panel

### DIFF
--- a/ui/components/canvas2d/src/components/Thumbnail.svelte
+++ b/ui/components/canvas2d/src/components/Thumbnail.svelte
@@ -14,28 +14,46 @@ License: CECILL-C
   export let imageUrl: string;
   export let maxHeight: number | undefined = undefined;
   export let maxWidth: number | undefined = undefined;
-  export let minWidth: number | undefined = undefined;
+  export let minSide: number | undefined = undefined;
 
   let [x, y, width, height] = coords;
-
+  const enlargeFactor = 0.2;
+  console.log("box", coords, imageDimension.width, imageDimension.height);
   let stage: Konva.Stage;
 
   const img = new Image();
   img.src = imageUrl;
 
-  let stageWidth = width * imageDimension.width;
-  let stageHeight = height * imageDimension.height;
+  let cropX = x * imageDimension.width - width * imageDimension.width * enlargeFactor;
+  if (cropX < 0) {
+    cropX = 0;
+  }
+  let cropY = y * imageDimension.height - height * imageDimension.height * enlargeFactor;
+  if (cropY < 0) {
+    cropY = 0;
+  }
+  let cropWidth = width * imageDimension.width * (1 + enlargeFactor * 2);
+  if (cropWidth > imageDimension.width) {
+    cropWidth = imageDimension.width;
+  }
+  let cropHeight = height * imageDimension.height * (1 + enlargeFactor * 2);
+  if (cropHeight > imageDimension.height) {
+    cropHeight = imageDimension.height;
+  }
+
+  let stageWidth = cropWidth;
+  let stageHeight = cropHeight;
 
   $: {
+    if (minSide && Math.max(stageWidth, stageHeight) < minSide) {
+      const ratio = Math.max(stageWidth, stageHeight) / minSide;
+      stageWidth /= ratio;
+      stageHeight /= ratio;
+    }
     if (maxHeight && stageHeight > maxHeight) {
       const ratio = stageHeight / maxHeight;
       stageWidth /= ratio;
       stageHeight /= ratio;
-    }
-    if (maxHeight && stageHeight < maxHeight) {
-      const ratio = maxHeight / stageHeight;
-      stageWidth *= ratio;
-      stageHeight *= ratio;
     }
     if (maxWidth && stageWidth > maxWidth) {
       const ratio = stageWidth / maxWidth;
@@ -43,39 +61,6 @@ License: CECILL-C
       stageHeight /= ratio;
     }
   }
-
-  $: {
-    if (minWidth && Math.max(stageWidth, stageHeight) < minWidth) {
-      const ratio = Math.max(stageWidth, stageHeight) / minWidth;
-      stageWidth /= ratio;
-      stageHeight /= ratio;
-    }
-  }
-
-  const defineCrop = () => {
-    let cropX = x * imageDimension.width - (width * imageDimension.width) / 2;
-    if (cropX < 0) {
-      cropX = 0;
-    }
-    let cropY = y * imageDimension.height - (height * imageDimension.height) / 2;
-    if (cropY < 0) {
-      cropY = 0;
-    }
-    let cropWidth = width * imageDimension.width * 2;
-    if (cropWidth > imageDimension.width) {
-      cropWidth = imageDimension.width;
-    }
-    let cropHeight = height * imageDimension.height * 2;
-    if (cropHeight > imageDimension.height) {
-      cropHeight = imageDimension.height;
-    }
-    return {
-      x: cropX,
-      y: cropY,
-      width: cropWidth,
-      height: cropHeight,
-    };
-  };
 </script>
 
 <div class="w-full h-fit flex justify-center">
@@ -97,7 +82,7 @@ License: CECILL-C
           height: stageHeight,
           image: img,
           id: "thumbnail-image",
-          crop: { ...defineCrop() },
+          crop: { x: cropX, y: cropY, height: cropHeight, width: cropWidth },
         }}
       />
     </Layer>

--- a/ui/components/canvas2d/src/components/Thumbnail.svelte
+++ b/ui/components/canvas2d/src/components/Thumbnail.svelte
@@ -18,7 +18,6 @@ License: CECILL-C
 
   let [x, y, width, height] = coords;
   const enlargeFactor = 0.2;
-  console.log("box", coords, imageDimension.width, imageDimension.height);
   let stage: Konva.Stage;
 
   const img = new Image();

--- a/ui/components/core/src/lib/types/dataset/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/dataset/datasetTypes.ts
@@ -225,6 +225,7 @@ export interface DisplayControl {
 
 export interface ObjectThumbnail {
   uri: string;
+  view: string;
   baseImageDimensions: {
     width: number;
     height: number;

--- a/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
@@ -153,7 +153,7 @@ License: CECILL-C
 </script>
 
 {#if entitiesCombo.length > 0}
-  <span>Select attached Entity</span>
+  <span>Select parent entity</span>
   <select
     class="py-1 px-2 border rounded focus:outline-none
 bg-slate-100 border-slate-300 focus:border-main"
@@ -176,8 +176,8 @@ bg-slate-100 border-slate-300 focus:border-main"
           ? initialValues[feature.sch.name][feature.name]?.value === 1
           : false}
       />
-      <span
-        >{feature.label}
+      <span class="capitalize">
+        {feature.label}
         {#if feature.required}
           <span>*</span>
         {/if}
@@ -193,8 +193,8 @@ bg-slate-100 border-slate-300 focus:border-main"
   {/if}
   {#if ["int", "float", "str"].includes(feature.type)}
     <div>
-      <span
-        >{feature.label}
+      <span class="capitalize">
+        {feature.label}
         {#if feature.required}
           <span>*</span>
         {/if}

--- a/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
@@ -27,7 +27,7 @@ License: CECILL-C
 {#each features as feature}
   <div class="grid gap-4 grid-cols-[150px_auto] mt-2 pr-4">
     {#if isEditing || feature.value !== undefined}
-      <p class="font-medium first-letter:uppercase flex items-center">
+      <p class="font-medium capitalize flex items-center">
         {feature.label.replace("_", " ")}
       </p>
     {/if}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/DisplayCheckbox.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/DisplayCheckbox.svelte
@@ -21,7 +21,7 @@ License: CECILL-C
 
 {#if !isAnnotationEmpty}
   <div class="flex gap-2 mt-2 items-center">
-    <p class="font-light first-letter:uppercase">{annotationName}</p>
+    <p class="font-light">{annotationName}</p>
     <Checkbox
       handleClick={() =>
         handleSetAnnotationDisplayControl("hidden", annotationIsVisible, base_schema)}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -282,7 +282,7 @@ License: CECILL-C
       (ann) => ann.is_type(BaseSchema.BBox) && ann.data.view_ref.name == viewName,
     );
     const thumb_box: Annotation | undefined = boxes
-      ? boxes[Math.round(boxes.length / 2)]
+      ? boxes[Math.floor(boxes.length / 2)]
       : undefined;
     const thumbnail: ObjectThumbnail | null = thumb_box
       ? defineObjectThumbnail($itemMetas, $views, thumb_box)
@@ -419,7 +419,9 @@ License: CECILL-C
                 maxWidth={200}
                 maxHeight={200}
               />
-              <span class="text-center italic">{thumbnail.view}</span>
+              {#if thumbnails.length > 1}
+                <span class="text-center italic">{thumbnail.view}</span>
+              {/if}
             {/each}
             <TextSpansContent annotations={entity.ui.childs} />
           </div>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -277,17 +277,19 @@ License: CECILL-C
   };
 
   const thumbnails: ObjectThumbnail[] = [];
-  for (const viewName of Object.keys($views)) {
-    const boxes: Annotation[] | undefined = entity.ui.childs?.filter(
-      (ann) => ann.is_type(BaseSchema.BBox) && ann.data.view_ref.name == viewName,
+  for (const view of Object.keys($views)) {
+    const highlightedBoxesByView = entity.ui.childs?.filter(
+      (ann) => ann.is_type(BaseSchema.BBox) && ann.data.view_ref.name == view,
     );
-    const thumb_box: Annotation | undefined = boxes
-      ? boxes[Math.floor(boxes.length / 2)]
-      : undefined;
-    const thumbnail: ObjectThumbnail | null = thumb_box
-      ? defineObjectThumbnail($itemMetas, $views, thumb_box)
-      : null;
-    if (thumbnail) thumbnails.push(thumbnail);
+    if (highlightedBoxesByView) {
+      const selectedBox = highlightedBoxesByView[Math.floor(highlightedBoxesByView.length / 2)];
+      if (selectedBox) {
+        const selectedThumbnail = defineObjectThumbnail($itemMetas, $views, selectedBox);
+        if (selectedThumbnail) {
+          thumbnails.push(selectedThumbnail);
+        }
+      }
+    }
   }
 </script>
 

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -368,20 +368,20 @@ License: CECILL-C
         >
           <div class="flex flex-col gap-2">
             <div>
-              <p class="font-medium first-letter:uppercase">display</p>
+              <p class="font-medium">Display</p>
               <div class="flex gap-4">
                 <DisplayCheckbox
                   isAnnotationEmpty={!entity.ui.childs?.some((ann) => ann.is_type(BaseSchema.BBox))}
                   {handleSetAnnotationDisplayControl}
                   annotationIsVisible={boxIsVisible}
-                  annotationName="Box"
+                  annotationName="Bounding box"
                   base_schema={BaseSchema.BBox}
                 />
                 <DisplayCheckbox
                   isAnnotationEmpty={!entity.ui.childs?.some((ann) => ann.is_type(BaseSchema.Mask))}
                   {handleSetAnnotationDisplayControl}
                   annotationIsVisible={maskIsVisible}
-                  annotationName="Mask"
+                  annotationName="Segmentation mask"
                   base_schema={BaseSchema.Mask}
                 />
                 <DisplayCheckbox

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -419,7 +419,7 @@ License: CECILL-C
                 maxWidth={200}
                 maxHeight={200}
               />
-              {#if thumbnails.length > 1}
+              {#if Object.keys($views).length > 1}
                 <span class="text-center italic">{thumbnail.view}</span>
               {/if}
             {/each}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -276,12 +276,19 @@ License: CECILL-C
     !isEditing && selectedTool.set(panTool);
   };
 
-  const thumb_box: Annotation | undefined = entity.ui.childs?.find((ann) =>
-    ann.is_type(BaseSchema.BBox),
-  );
-  const thumbnail: ObjectThumbnail | null = thumb_box
-    ? defineObjectThumbnail($itemMetas, $views, thumb_box)
-    : null;
+  const thumbnails: ObjectThumbnail[] = [];
+  for (const viewName of Object.keys($views)) {
+    const boxes: Annotation[] | undefined = entity.ui.childs?.filter(
+      (ann) => ann.is_type(BaseSchema.BBox) && ann.data.view_ref.name == viewName,
+    );
+    const thumb_box: Annotation | undefined = boxes
+      ? boxes[Math.round(boxes.length / 2)]
+      : undefined;
+    const thumbnail: ObjectThumbnail | null = thumb_box
+      ? defineObjectThumbnail($itemMetas, $views, thumb_box)
+      : null;
+    if (thumbnail) thumbnails.push(thumbnail);
+  }
 </script>
 
 {#if entity.table_info.name !== "conversations"}
@@ -403,15 +410,17 @@ License: CECILL-C
               {isEditing}
               {saveInputChange}
             />
-            {#if thumbnail}
+            {#each thumbnails as thumbnail}
               <Thumbnail
                 imageDimension={thumbnail.baseImageDimensions}
                 coords={thumbnail.coords}
                 imageUrl={`/${thumbnail.uri}`}
-                minWidth={150}
-                maxWidth={300}
+                minSide={150}
+                maxWidth={200}
+                maxHeight={200}
               />
-            {/if}
+              <span class="text-center italic">{thumbnail.view}</span>
+            {/each}
             <TextSpansContent annotations={entity.ui.childs} />
           </div>
         </div>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -59,7 +59,7 @@ License: CECILL-C
       (ann) => ann.ui.highlighted === "self" && ann.is_type(BaseSchema.BBox),
     );
     const highlightedObject: Annotation | undefined = highlightedBoxes
-      ? highlightedBoxes[Math.round(highlightedBoxes.length / 2)]
+      ? highlightedBoxes[Math.floor(highlightedBoxes.length / 2)]
       : undefined;
 
     if (highlightedObject) {

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -26,7 +26,7 @@ License: CECILL-C
   import ObjectsModelSection from "./ObjectsModelSection.svelte";
 
   let allTopEntities: Entity[];
-  let selectedEntity: String;
+  let selectedEntity: string;
   let thumbnail: ObjectThumbnail | null = null;
 
   //Note: Previously Entities where grouped by source

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -85,7 +85,8 @@ License: CECILL-C
       })}
     >
       {#if thumbnail}
-        <span class="flex justify-center"> Selected object: {selectedEntity}</span>
+        <span class="flex justify-center font-medium text-slate-800"> Selected object </span>
+        <span class="flex justify-center text-slate-800">{selectedEntity}</span>
         {#key thumbnail.coords[0]}
           <Thumbnail
             imageDimension={thumbnail.baseImageDimensions}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -7,13 +7,9 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { Thumbnail } from "@pixano/canvas2d";
-  import { BaseSchema, Annotation, cn, Entity, Source, type ObjectThumbnail } from "@pixano/core";
+  import { BaseSchema, Entity, Source, type ObjectThumbnail } from "@pixano/core";
 
-  import {
-    createObjectCardId,
-    defineObjectThumbnail,
-    getTopEntity,
-  } from "../../lib/api/objectsApi";
+  import { defineObjectThumbnail, getTopEntity } from "../../lib/api/objectsApi";
   import {
     annotations,
     entities,
@@ -24,10 +20,11 @@ License: CECILL-C
   import PreAnnotation from "../PreAnnotation/PreAnnotation.svelte";
   import ObjectCard from "./ObjectCard.svelte";
   import ObjectsModelSection from "./ObjectsModelSection.svelte";
+  import { afterUpdate } from "svelte";
 
   let allTopEntities: Entity[];
-  let selectedEntity: string;
-  let thumbnail: ObjectThumbnail | null = null;
+  let selectedEntities: string[];
+  const thumbnails: Record<string, ObjectThumbnail | null> = {};
 
   //Note: Previously Entities where grouped by source
   //Now they're all displayed regardless of source
@@ -50,53 +47,64 @@ License: CECILL-C
       allTopEntitiesSet.add(getTopEntity(ann, $entities));
     });
     allTopEntities = Array.from(allTopEntitiesSet);
-    //console.log("ObjectInspector refresh fired", $annotations, $entities, allTopEntities);
+    selectedEntities = [];
 
-    //scroll and set thumbnail to highlighted object if any
-    // const highlightedObject = $annotations.find((ann) => ann.ui.highlighted === "self");
-
-    const highlightedBoxes: Annotation[] | undefined = $annotations.filter(
+    const highlightedBoxes = $annotations.filter(
       (ann) => ann.ui.highlighted === "self" && ann.is_type(BaseSchema.BBox),
     );
-    const highlightedObject: Annotation | undefined = highlightedBoxes
-      ? highlightedBoxes[Math.floor(highlightedBoxes.length / 2)]
-      : undefined;
 
-    if (highlightedObject) {
-      selectedEntity = highlightedObject.data.entity_ref.id;
-      thumbnail = defineObjectThumbnail($itemMetas, $views, highlightedObject);
-      const element = document.querySelector(`#${createObjectCardId(highlightedObject)}`);
-      if (element) {
-        element.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (highlightedBoxes.length > 0) {
+      const highlightedBoxesByEntity = Object.groupBy(
+        highlightedBoxes,
+        ({ data }) => data.entity_ref.id,
+      );
+      selectedEntities = Object.keys(highlightedBoxesByEntity);
+      for (const [entity, entityBoxes] of Object.entries(highlightedBoxesByEntity)) {
+        if (entityBoxes) {
+          const selectedBox = entityBoxes[Math.floor(entityBoxes.length / 2)];
+          if (selectedBox) {
+            const selectedThumbnail = defineObjectThumbnail($itemMetas, $views, selectedBox);
+            if (selectedThumbnail) {
+              thumbnails[entity] = selectedThumbnail;
+            }
+          }
+        }
       }
-    } else {
-      thumbnail = null;
+    }
+    const element = document.querySelector("#preAnnotationThumbnail");
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   };
+
+  afterUpdate(() => {
+    handleAnnotationSortedByModel();
+  });
 </script>
 
 <div class="p-2 h-[calc(100vh-200px)] w-full">
   <PreAnnotation />
   {#if !$preAnnotationIsActive}
-    <div
-      class={cn({
-        block: !thumbnail,
-        "grid-rows-[150px_80%]": thumbnail,
-      })}
-    >
-      {#if thumbnail}
-        <span class="flex justify-center font-medium text-slate-800"> Selected object </span>
-        <span class="flex justify-center text-slate-800">{selectedEntity}</span>
-        {#key thumbnail.coords[0]}
-          <Thumbnail
-            imageDimension={thumbnail.baseImageDimensions}
-            coords={thumbnail.coords}
-            imageUrl={`/${thumbnail.uri}`}
-            minSide={150}
-            maxHeight={200}
-            maxWidth={200}
-          />
-        {/key}
+    <div id="preAnnotationThumbnail">
+      {#if selectedEntities.length > 0}
+        <span class="flex justify-center font-medium text-slate-800">
+          Selected object{selectedEntities.length > 1 ? "s" : ""}
+        </span>
+        {#each selectedEntities as selectedEntity}
+          <span class="flex justify-center text-slate-800">{selectedEntity}</span>
+          {#if thumbnails[selectedEntity]}
+            {#key thumbnails[selectedEntity].coords[0]}
+              <Thumbnail
+                imageDimension={thumbnails[selectedEntity].baseImageDimensions}
+                coords={thumbnails[selectedEntity].coords}
+                imageUrl={`/${thumbnails[selectedEntity].uri}`}
+                minSide={150}
+                maxHeight={200}
+                maxWidth={200}
+              />
+            {/key}
+          {/if}
+        {/each}
       {/if}
       <ObjectsModelSection source={globalSource} numberOfItem={allTopEntities.length}>
         {#each allTopEntities as entity}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -7,7 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { Thumbnail } from "@pixano/canvas2d";
-  import { BaseSchema, cn, Entity, Source, type ObjectThumbnail } from "@pixano/core";
+  import { BaseSchema, Annotation, cn, Entity, Source, type ObjectThumbnail } from "@pixano/core";
 
   import {
     createObjectCardId,
@@ -26,6 +26,7 @@ License: CECILL-C
   import ObjectsModelSection from "./ObjectsModelSection.svelte";
 
   let allTopEntities: Entity[];
+  let selectedEntity: String;
   let thumbnail: ObjectThumbnail | null = null;
 
   //Note: Previously Entities where grouped by source
@@ -52,8 +53,17 @@ License: CECILL-C
     //console.log("ObjectInspector refresh fired", $annotations, $entities, allTopEntities);
 
     //scroll and set thumbnail to highlighted object if any
-    const highlightedObject = $annotations.find((ann) => ann.ui.highlighted === "self");
+    // const highlightedObject = $annotations.find((ann) => ann.ui.highlighted === "self");
+
+    const highlightedBoxes: Annotation[] | undefined = $annotations.filter(
+      (ann) => ann.ui.highlighted === "self" && ann.is_type(BaseSchema.BBox),
+    );
+    const highlightedObject: Annotation | undefined = highlightedBoxes
+      ? highlightedBoxes[Math.round(highlightedBoxes.length / 2)]
+      : undefined;
+
     if (highlightedObject) {
+      selectedEntity = highlightedObject.data.entity_ref.id;
       thumbnail = defineObjectThumbnail($itemMetas, $views, highlightedObject);
       const element = document.querySelector(`#${createObjectCardId(highlightedObject)}`);
       if (element) {
@@ -65,7 +75,7 @@ License: CECILL-C
   };
 </script>
 
-<div class="p-2 h-[calc(100vh-200px)]">
+<div class="p-2 h-[calc(100vh-200px)] w-full">
   <PreAnnotation />
   {#if !$preAnnotationIsActive}
     <div
@@ -75,13 +85,15 @@ License: CECILL-C
       })}
     >
       {#if thumbnail}
+        <span class="flex justify-center"> Selected object: {selectedEntity}</span>
         {#key thumbnail.coords[0]}
           <Thumbnail
             imageDimension={thumbnail.baseImageDimensions}
             coords={thumbnail.coords}
             imageUrl={`/${thumbnail.uri}`}
-            maxHeight={150}
-            maxWidth={300}
+            minSide={150}
+            maxHeight={200}
+            maxWidth={200}
           />
         {/key}
       {/if}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
@@ -119,19 +119,19 @@ License: CECILL-C
     <h3 class="uppercase font-medium h-10 flex items-center">{meta.id}</h3>
     <div class="mx-4 mb-4">
       <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
-        <p class="font-medium first-letter:uppercase">File name</p>
+        <p class="font-medium">File name</p>
         <p class="truncate" title={meta.fileName}>{meta.fileName}</p>
       </div>
       <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
-        <p class="font-medium first-letter:uppercase">Width</p>
+        <p class="font-medium">Width</p>
         <p>{meta.width}</p>
       </div>
       <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
-        <p class="font-medium first-letter:uppercase">Height</p>
+        <p class="font-medium">Height</p>
         <p>{meta.height}</p>
       </div>
       <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
-        <p class="font-medium first-letter:uppercase">Format</p>
+        <p class="font-medium">Format</p>
         <p>{meta.format}</p>
       </div>
     </div>

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineObjectThumbnail.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineObjectThumbnail.ts
@@ -44,5 +44,6 @@ export const defineObjectThumbnail = (metas: ItemsMeta, views: MView, object: An
     },
     coords,
     uri: view?.data.url,
+    view: view_name,
   };
 };


### PR DESCRIPTION
## Description

-  Select better bounding boxes for object thumbnails
    -  Take the bounding box of the middle of the track for each view, which will better show the object than the first bounding box (often smaller or partial view).
- Add object thumbnails for each view for multi-camera tracks
- Fix thumbnails dimension and aspect ratio calculations
- Change minimum and maximum dimensions of object thumbnails

Tested on multi-view video datasets and single-view image datasets 