### PR TITLE
fix highlighted selected entity when sub entities

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -56,7 +56,7 @@ License: CECILL-C
     if (highlightedBoxes.length > 0) {
       const highlightedBoxesByEntityId = Object.groupBy(
         highlightedBoxes,
-        ({ data }) => data.entity_ref.id,
+        (ann) => getTopEntity(ann, $entities).id,
       );
       selectedEntitiesId = Object.keys(highlightedBoxesByEntityId);
       for (const [entityId, entityBoxes] of Object.entries(highlightedBoxesByEntityId)) {


### PR DESCRIPTION
## Issue

When a dataset has sub-entities, the highlighted thumbnail shown in right panel are incorrectly taken from each sub entities.

## Description

Use getTopEntity instead of just relying on parent entity (which is the sub entity if exist)