### PR TITLE
feat(front): Improve object highlighting

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -27,6 +27,7 @@ License: CECILL-C
     defineObjectThumbnail,
     getTopEntity,
     toggleObjectDisplayControl,
+    highlightObject,
   } from "../../lib/api/objectsApi";
   import {
     annotations,
@@ -37,7 +38,7 @@ License: CECILL-C
     selectedTool,
     views,
   } from "../../lib/stores/datasetItemWorkspaceStores";
-  import { currentFrameIndex } from "../../lib/stores/videoViewerStores";
+  import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
   import type { Feature } from "../../lib/types/datasetItemWorkspaceTypes";
 
   import { addOrUpdateSaveItem } from "../../lib/api/objectsApi";
@@ -69,7 +70,11 @@ License: CECILL-C
 
   $: color = $colorScale[1](entity.id);
 
-  $: if (isEditing) open = true;
+  $: if (isEditing) {
+    open = true;
+  } else {
+    open = false;
+  }
 
   const features = derived(
     [currentFrameIndex, entities, annotations],
@@ -250,16 +255,7 @@ License: CECILL-C
   };
 
   const onColoredDotClick = () => {
-    annotations.update((objects) =>
-      objects.map((ann) => {
-        ann.ui.highlighted = isHighlighted
-          ? "all"
-          : getTopEntity(ann, $entities).id === entity.id
-            ? "self"
-            : "none";
-        return ann;
-      }),
-    );
+    highlightObject(entity, $entities, isHighlighted, $lastFrameIndex);
   };
 
   const onTrackVisClick = () => {
@@ -272,6 +268,7 @@ License: CECILL-C
   };
 
   const onEditIconClick = () => {
+    highlightObject(entity, $entities, isHighlighted, $lastFrameIndex);
     handleSetAnnotationDisplayControl("editing", !isEditing);
     !isEditing && selectedTool.set(panTool);
   };

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -24,7 +24,6 @@ License: CECILL-C
 
   import { createFeature } from "../../lib/api/featuresApi";
   import {
-    createObjectCardId,
     defineObjectThumbnail,
     getTopEntity,
     toggleObjectDisplayControl,
@@ -302,7 +301,7 @@ License: CECILL-C
   <article
     on:mouseenter={() => (showIcons = true)}
     on:mouseleave={() => (showIcons = open)}
-    id={createObjectCardId(entity)}
+    id={`card-object-${entity.id}`}
   >
     <div
       class={cn(

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -71,10 +71,6 @@ License: CECILL-C
         }
       }
     }
-    const element = document.querySelector("#preAnnotationThumbnail");
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
   };
 
   afterUpdate(() => {
@@ -85,34 +81,32 @@ License: CECILL-C
 <div class="p-2 h-[calc(100vh-200px)] w-full">
   <PreAnnotation />
   {#if !$preAnnotationIsActive}
-    <div id="preAnnotationThumbnail">
-      {#if selectedEntitiesId.length > 0}
-        <span class="flex justify-center font-medium text-slate-800">
-          Selected object{selectedEntitiesId.length > 1 ? "s" : ""}
-        </span>
-        {#each selectedEntitiesId as selectedEntity}
-          <span class="flex justify-center text-slate-800">{selectedEntity}</span>
-          {#if thumbnails[selectedEntity]}
-            {#key thumbnails[selectedEntity].coords[0]}
-              <Thumbnail
-                imageDimension={thumbnails[selectedEntity].baseImageDimensions}
-                coords={thumbnails[selectedEntity].coords}
-                imageUrl={`/${thumbnails[selectedEntity].uri}`}
-                minSide={150}
-                maxHeight={200}
-                maxWidth={200}
-              />
-            {/key}
-          {/if}
+    {#if selectedEntitiesId.length > 0}
+      <span class="flex justify-center font-medium text-slate-800">
+        Selected object{selectedEntitiesId.length > 1 ? "s" : ""}
+      </span>
+      {#each selectedEntitiesId as selectedEntity}
+        <span class="flex justify-center text-slate-800">{selectedEntity}</span>
+        {#if thumbnails[selectedEntity]}
+          {#key thumbnails[selectedEntity].coords[0]}
+            <Thumbnail
+              imageDimension={thumbnails[selectedEntity].baseImageDimensions}
+              coords={thumbnails[selectedEntity].coords}
+              imageUrl={`/${thumbnails[selectedEntity].uri}`}
+              minSide={150}
+              maxHeight={200}
+              maxWidth={200}
+            />
+          {/key}
+        {/if}
+      {/each}
+    {/if}
+    <ObjectsModelSection source={globalSource} numberOfItem={allTopEntities.length}>
+      {#key allTopEntities.length}
+        {#each allTopEntities as entity}
+          <ObjectCard {entity} />
         {/each}
-      {/if}
-      <ObjectsModelSection source={globalSource} numberOfItem={allTopEntities.length}>
-        {#key allTopEntities.length}
-          {#each allTopEntities as entity}
-            <ObjectCard {entity} />
-          {/each}
-        {/key}
-      </ObjectsModelSection>
-    </div>
+      {/key}
+    </ObjectsModelSection>
   {/if}
 </div>

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -49,15 +49,6 @@ License: CECILL-C
       updateView($currentFrameIndex);
     }
   };
-
-  annotations.subscribe((value) => {
-    const highlightedObject = value.find((item) => item.ui.highlighted === "self");
-    if (!highlightedObject) return;
-    const element = document.querySelector(`#video-object-${highlightedObject.id}`);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "center" });
-    }
-  });
 </script>
 
 {#if $videoControls.isLoaded}

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/highlightObject.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/highlightObject.ts
@@ -1,0 +1,49 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { Entity, Tracklet, BaseSchema } from "@pixano/core";
+import { annotations } from "../../stores/datasetItemWorkspaceStores";
+import { currentFrameIndex } from "../../stores/videoViewerStores";
+import { getTopEntity } from "./getTopEntity";
+
+export const highlightObject = (
+  entity: Entity,
+  entities: Entity[],
+  isHighlighted: boolean,
+  lastFrameIndex: number,
+) => {
+  let highlightFrameIndex = lastFrameIndex + 1;
+  console.log(entity.id, isHighlighted);
+  annotations.update((objects) =>
+    objects.map((ann) => {
+      ann.ui.highlighted = isHighlighted
+        ? "all"
+        : getTopEntity(ann, entities).id === entity.id
+          ? "self"
+          : "none";
+      if (
+        getTopEntity(ann, entities).id === entity.id &&
+        ann.is_type(BaseSchema.Tracklet) &&
+        ann.ui.highlighted === "self" &&
+        (ann as Tracklet).data.start_timestep < highlightFrameIndex
+      ) {
+        highlightFrameIndex = (ann as Tracklet).data.start_timestep;
+      }
+      return ann;
+    }),
+  );
+  if (highlightFrameIndex != lastFrameIndex + 1) {
+    currentFrameIndex.set(highlightFrameIndex);
+    const cardElement = document.querySelector(`#card-object-${entity.id}`);
+    if (cardElement) {
+      cardElement.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    const trackElement = document.querySelector(`#video-object-${entity.id}`);
+    if (trackElement) {
+      trackElement.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }
+};

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
@@ -26,6 +26,7 @@ export * from "./sortAndFilterObjectsToAnnotate";
 export * from "./getPixanoSource";
 export * from "./getTable";
 export * from "./getTopEntity";
+export * from "./highlightObject";
 export * from "./mapObjectToBBox";
 export * from "./mapObjectToKeypoints";
 export * from "./mapObjectToMasks";

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
@@ -9,8 +9,6 @@ import { PRE_ANNOTATION } from "../../constants";
 
 export type MView = Record<string, View | View[]>;
 
-export const createObjectCardId = (object: Annotation | Entity): string => `object-${object.id}`;
-
 export const getObjectEntity = (ann: Annotation, entities: Entity[]): Entity | undefined => {
   return entities.find((entity) => entity.id === ann.data.entity_ref.id);
 };


### PR DESCRIPTION
## Description

Add highlightObject function in objectsApi that highlights and scrolls into view both the ObjectCard and the ObjectTrack.
Still works on image datasets that don't use the ObjectTrack.

Add buttons in ObjectTracks to trigger this highlighting.

![image](https://github.com/user-attachments/assets/c6732ab0-c3ec-4e5c-941d-07f27c59c936)
![image](https://github.com/user-attachments/assets/b7bc3646-f9b7-4f22-a38d-7ad740f40c4d)

## Known issues

When double clicking on a bounding box in the image/video to trigger the editing mode, the highlighting doesn't reset correctly when using on the colored buttons from the ObjectCards or ObjectTracks afterwards. The first click only triggers the scrolling, and the second one actually highlights them.

This looks like an issue with updating the value of `isHighlighted` in ObjectCard / ObjectTrack based on the `ui.highlighted` flags of annotations after the bounding box edition changed them.

@BertrandRenault I might need your help for this.