### PR TITLE
feat(front): Keep fusion tool selected

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -55,7 +55,6 @@ License: CECILL-C
       }),
     );
     merges.set({ to_fuse: [], forbids: [] });
-    selectedTool.set(panTool);
   };
 
   const selectTool = (tool: SelectionTool) => {


### PR DESCRIPTION
## Description

After either validating or aborting the current fusion, keep the fusion tool selected so the user can keep annotating without having to select the tool again.
