### PR TITLE
feat(front): Small homepage enhancements

### DIFF
--- a/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
@@ -29,18 +29,20 @@ License: CECILL-C
 >
   <!-- Dataset Infos -->
   <div class="w-full h-1/4 pt-4 px-4 flex flex-col justify-center relative">
-    <div>
-      <h3
-        class="text-lg font-semibold truncate text-primary"
-        title="{dataset.name}&#10;&#13;{dataset.description}"
-      >
-        {dataset.name}
-      </h3>
-    </div>
+    <h3
+      class="text-lg w-5/6 font-semibold truncate text-primary"
+      title="{dataset.name}&#10;&#13;{dataset.description}"
+    >
+      {dataset.name}
+    </h3>
 
     <p class="text-sm text-slate-500 font-medium">
-      {dataset.num_items} items {dataset.size && dataset.size != "N/A" ? " - " + dataset.size : ""}
+      {dataset.num_items} item{dataset.num_items > 1 ? "s" : ""}
+      {dataset.size && dataset.size != "Unknown" && dataset.size != "N/A"
+        ? " - " + dataset.size
+        : ""}
     </p>
+
     <svg
       xmlns="http://www.w3.org/2000/svg"
       height="48"

--- a/ui/apps/pixano/src/components/layout/MainHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/MainHeader.svelte
@@ -36,13 +36,17 @@ License: CECILL-C
     {#if datasets}
       <div class="my-4 mr-8 p-4 pr-8 border rounded-lg border-primary-foreground">
         <span class="mr-2 text-4xl font-medium"> {datasets?.length} </span>
-        <span class="text-xl font-medium"> datasets </span>
+        <span class="text-xl font-medium">
+          dataset{datasets?.length > 1 ? "s" : ""}
+        </span>
       </div>
       <div class="my-4 mr-8 p-4 pr-8 border rounded-lg border-primary-foreground">
         <span class="mr-2 text-4xl font-medium">
           {datasets.reduce((sum, dataset) => sum + dataset.num_items, 0)}
         </span>
-        <span class="text-xl font-medium"> items </span>
+        <span class="text-xl font-medium">
+          item{datasets.reduce((sum, dataset) => sum + dataset.num_items, 0) > 1 ? "s" : ""}
+        </span>
       </div>
       <div class="grow self-end flex flex-row justify-end items-end">
         <div class="flex items-center space-x-2">


### PR DESCRIPTION
## Description

- MainHeader
  - Add plural for datasets and items on homepage only if needed
- DatasetPreviewCard
  - Reduce width of title to leave space for the "Open" arrow
  - Add plural for number of items only if needed
  - Hide dataset size if "Unknown"

### Before

![image](https://github.com/user-attachments/assets/abdf1da0-dd38-48bb-b35b-0f44c30dbccc)

### After

![image](https://github.com/user-attachments/assets/ed9f445b-9c95-4869-8967-9c2cd7cea72c)
