### PR TITLE
feat(front): Small dataset page enhancements

### DIFF
--- a/ui/components/table/src/Table.svelte
+++ b/ui/components/table/src/Table.svelte
@@ -42,7 +42,7 @@ License: CECILL-C
     // Add field to column list
     itemColumns.push(
       table.column({
-        header: col.name,
+        header: col.name.replace("_", " "),
         // giving the exact type is troublesome here, for this one we will allow 'any' assignement
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         cell: TableCell[col.type],

--- a/ui/components/table/src/TableCell.ts
+++ b/ui/components/table/src/TableCell.ts
@@ -11,6 +11,7 @@ import VideoCell from "./TableCells/VideoCell.svelte";
 import NumberCell from "./TableCells/NumberCell.svelte";
 import BooleanCell from "./TableCells/BooleanCell.svelte";
 import TextCell from "./TableCells/TextCell.svelte";
+import DateTimeCell from "./TableCells/DateTimeCell.svelte";
 import { createRender } from "svelte-headless-table";
 import type { DatasetStat } from "@pixano/core";
 
@@ -29,6 +30,7 @@ export const TableCell = {
   float: createRenderFunction(NumberCell),
   bool: createRenderFunction(BooleanCell),
   str: createRenderFunction(TextCell),
+  datetime: createRenderFunction(DateTimeCell),
   video: createRenderFunction(VideoCell),
   histogram: createRenderFunction(HistogramCell),
 };

--- a/ui/components/table/src/TableCells/DateTimeCell.svelte
+++ b/ui/components/table/src/TableCells/DateTimeCell.svelte
@@ -1,0 +1,16 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  // Exports
+  export let value: string;
+
+  const date = new Date(value);
+</script>
+
+<div class="min-w-24 px-2">
+  {date.toLocaleString("fr-FR")}
+</div>


### PR DESCRIPTION
## Description

- Table
  - Change names like "created_at" and "updated_at" to "created at" and "updated at" for more readable columns
- TableCell
  - Add DateTimeCell to display datetime values like created_at and updated_at in a more human readable format

### Before
![image](https://github.com/user-attachments/assets/9e86c56f-6a2b-420b-b018-af91856774cc)
### After
![image](https://github.com/user-attachments/assets/07c8fa69-4853-4bb4-9e84-a00be417663d)