### PR TITLE
feat(front): Re-enable dashboard page

### DIFF
--- a/ui/apps/pixano/src/components/dashboard/Dashboard.svelte
+++ b/ui/apps/pixano/src/components/dashboard/Dashboard.svelte
@@ -41,7 +41,7 @@ License: CECILL-C
         </span>
         <span class="w-1/4 ml-8 text-5xl font-bold text-right">
           {selectedDataset.num_items}
-          <span class="text-xl"> item{selectedDataset.num_items > 1 ? "s" : ""}s</span>
+          <span class="text-xl"> item{selectedDataset.num_items > 1 ? "s" : ""}</span>
         </span>
       </div>
 

--- a/ui/apps/pixano/src/components/dashboard/Dashboard.svelte
+++ b/ui/apps/pixano/src/components/dashboard/Dashboard.svelte
@@ -17,61 +17,58 @@ License: CECILL-C
   let selectedTab: (typeof dashboardTabs)[number] = dashboardTabs[0];
 </script>
 
-{#if selectedDataset.page}
-  <div class="h-full flex flex-row bg-slate-50 p-20 gap-4 text-slate-800 font-Montserrat">
-    <div class="bg-white min-h-[70%] shadow-md flex flex-col w-[30%]">
-      {#each dashboardTabs as tab}
-        <button
-          on:click={() => (selectedTab = tab)}
-          class={cn("p-4 text-left first-letter:capitalize hover:bg-slate-100", {
-            "bg-slate-200 text-primary hover:bg-slate-200": tab === selectedTab,
-          })}>{tab}</button
-        >
-      {/each}
-    </div>
-    <div class="w-full flex flex-col z-10 p-8">
-      {#if selectedTab === "source feature"}
-        <!-- Overview -->
-        <div class="w-full flex flex-row justify-between">
-          <div>
-            <span class="text-5xl font-bold">
-              {selectedDataset.name}
-            </span>
-            <span class="text-xl text-slate-500">
-              #{selectedDataset.id}
-            </span>
-          </div>
-          <div>
-            <span class="text-5xl font-bold">
-              {selectedDataset.num_items}
-            </span>
-            <span class="ml-2 text-xl"> items </span>
-          </div>
-        </div>
-        <!-- Description -->
-        <div class="mt-8">
-          <p class="text-lg text-justify">
-            {selectedDataset.description}
-          </p>
-        </div>
-      {:else if selectedTab === "derived source feature"}
-        <!-- Stats -->
-        <span class="text-5xl font-bold"> Statistics </span>
-
-        {#if selectedDataset.stats != null && selectedDataset.stats.length != 0}
-          <div class="mt-6 h-full overflow-y-auto flex flex-wrap justify-between gap-6">
-            <!-- If charts are ready to be displayed, display them -->
-            {#each selectedDataset.stats as chart}
-              <div class="w-[47%] min-h-80">
-                <Histogram hist={chart} />
-              </div>
-            {/each}
-          </div>
-        {:else}
-          <!-- Else show a message -->
-          <p class="mt-80 text-slate-500 italic text-center">No statistics found.</p>
-        {/if}
-      {/if}
-    </div>
+<div class="h-full flex flex-row bg-slate-50 p-20 gap-4 text-slate-800 font-Montserrat">
+  <div class="bg-white min-h-[70%] shadow-md flex flex-col w-1/6 min-w-32">
+    {#each dashboardTabs as tab}
+      <button
+        on:click={() => (selectedTab = tab)}
+        class={cn("p-4 text-left first-letter:capitalize hover:bg-slate-100", {
+          "bg-slate-200 text-primary hover:bg-slate-200": tab === selectedTab,
+        })}>{tab}</button
+      >
+    {/each}
   </div>
-{/if}
+  <div class="w-3/4 flex flex-col z-10 p-8">
+    {#if selectedTab === "source feature"}
+      <!-- Overview -->
+      <div class="w-full flex justify-between">
+        <span class="text-5xl font-bold truncate" title={selectedDataset.name}>
+          {selectedDataset.name}
+          <br />
+          <span class="text-xl text-slate-500">
+            #{selectedDataset.id}
+          </span>
+        </span>
+        <span class="w-1/4 ml-8 text-5xl font-bold text-right">
+          {selectedDataset.num_items}
+          <span class="text-xl"> item{selectedDataset.num_items > 1 ? "s" : ""}s</span>
+        </span>
+      </div>
+
+      <!-- Description -->
+      <div class="mt-8">
+        <p class="text-lg text-justify">
+          {selectedDataset.description}
+        </p>
+      </div>
+    {:else if selectedTab === "derived source feature"}
+      <!-- Stats -->
+      {#if selectedDataset.stats != null && selectedDataset.stats.length != 0}
+        <span class="text-5xl font-bold"> Statistics </span>
+        <div class="mt-6 h-full overflow-y-auto flex flex-wrap justify-between gap-6">
+          <!-- If charts are ready to be displayed, display them -->
+          {#each selectedDataset.stats as chart}
+            <div class="w-[47%] min-h-80">
+              <Histogram hist={chart} />
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <!-- Else show a message -->
+        <p class="mt-80 text-slate-500 italic text-center">No statistics found.</p>
+      {/if}
+    {:else}
+      <!-- Else show a message -->
+      <p class="mt-80 text-slate-500 italic text-center">No statistics found.</p>{/if}
+  </div>
+</div>

--- a/ui/apps/pixano/src/routes/[dataset]/dashboard/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dashboard/+page.svelte
@@ -6,27 +6,22 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { page } from "$app/stores";
-
-  import type { DatasetInfo } from "@pixano/core";
-  //import { api } from "@pixano/core/src";
+  import { currentDatasetStore } from "$lib/stores/datasetStores";
+  import type { DatasetInfo } from "@pixano/core/src";
+  import { onDestroy } from "svelte";
   import Dashboard from "../../../components/dashboard/Dashboard.svelte";
-
-  import { datasetsStore } from "../../../lib/stores/datasetStores";
-  //import { afterUpdate } from "svelte";
 
   let selectedDataset: DatasetInfo;
 
-  $: {
-    let currentDatasetName: string;
-    page.subscribe((value) => (currentDatasetName = value.params.dataset));
-    datasetsStore.subscribe((value) => {
-      const foundDataset = value?.find((dataset) => dataset.name === currentDatasetName);
-      if (foundDataset) {
-        selectedDataset = foundDataset;
-      }
-    });
-  }
+  $: getDatasetInfo = currentDatasetStore.subscribe(
+    (datasetInfo) => (selectedDataset = datasetInfo),
+  );
+
+  onDestroy(() => {
+    getDatasetInfo();
+  });
+
+  //import { afterUpdate } from "svelte";
 
   // get stats if not already loaded, and allow stats on page refresh
 
@@ -45,7 +40,7 @@ License: CECILL-C
   // });
 </script>
 
-{#if selectedDataset?.page}
+{#if selectedDataset}
   <div class="pt-20 h-1 min-h-screen">
     <Dashboard {selectedDataset} />
   </div>


### PR DESCRIPTION
## Description

- Use same logic as dataset page to load the DatasetInfo by subscribing to the currentDatasetStore.
- Add a minimum width for the left-side tab selection.
- On the main tab, fix the width for the dataset name and the number of items in case of long names.
- On the other tabs, display "No statistics found" while waiting for a new connection with the backend after the refactor.

![image](https://github.com/user-attachments/assets/41378ca1-3da7-4ec7-a0bc-6ae7501f1146)
