### PR TITLE
SaveItem update: check with id and ALSO table_info

### DIFF
--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/addOrUpdateSaveItem.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/addOrUpdateSaveItem.ts
@@ -7,9 +7,17 @@ License: CECILL-C
 import type { SaveItem } from "@pixano/core";
 
 export const addOrUpdateSaveItem = (objects: SaveItem[], newObj: SaveItem) => {
-  const existing_sames = objects.filter((item) => newObj.object.id === item.object.id);
+  const existing_sames = objects.filter(
+    (item) =>
+      newObj.object.id === item.object.id &&
+      Object.keys(newObj.object.table_info).every(
+        (key) =>
+          newObj.object.table_info[key as keyof typeof newObj.object.table_info] ===
+          item.object.table_info[key as keyof typeof item.object.table_info],
+      ),
+  );
   //remove other refs to this same object (as the last state is the correct one)
-  objects = objects.filter((item) => newObj.object.id !== item.object.id);
+  objects = objects.filter((item) => !existing_sames.includes(item));
 
   if (
     newObj.change_type === "delete" &&


### PR DESCRIPTION
## Issue

If we have non unique id (though in different table) the process of filtering SaveItem (already modified) would bug because of "too large (in whole dataset, not just within tables)" unique id assumption.

Fixes #437 

## Description

check also for table_info when filtering saveItem by ids