### PR TITLE
feat(front): Disable focus and scrolling on spacebar shortcut

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TimeTrack.svelte
@@ -104,7 +104,7 @@ License: CECILL-C
 </script>
 
 <div
-  class="py-2 flex w-full h-16 justify-between relative cursor-pointer bg-white border-b border-slate-200"
+  class="py-2 flex w-full h-16 justify-between relative cursor-pointer bg-white border-b border-slate-200 focus:outline-none"
   style={`width: ${$videoControls.zoomLevel[0]}%`}
   role="slider"
   tabindex="0"

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
@@ -88,6 +88,7 @@ License: CECILL-C
     switch (event.key) {
       case " ":
         if (event.repeat) break;
+        event.preventDefault();
         onPlayClick();
         break;
       case "ArrowRight":


### PR DESCRIPTION
## Description

Small UI enhancement.

When using the spacebar shortcut for play/pause after a click on the TimeTrack (e.g. to move the video cursor), the TimeTrack gets a black outline from being in focus, and the VideoInspector scrolls down.

Disable this unwanted black outline and scrolling.

### Before

![image](https://github.com/user-attachments/assets/c788a861-f120-4f0a-bf00-e17abc0d1c95)

### After

![image](https://github.com/user-attachments/assets/f42520a8-5ab0-4e83-a795-9bf77fa278a8)
