### PR TITLE
feat(front): Small SceneInspector enhancements

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
@@ -26,13 +26,15 @@ License: CECILL-C
   import { addOrUpdateSaveItem } from "../../lib/api/objectsApi";
   import type { Feature, ItemsMeta } from "../../lib/types/datasetItemWorkspaceTypes";
   import { datasetSchema } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
+  import { currentFrameIndex } from "../../lib/stores/videoViewerStores";
 
   type ViewMeta = {
-    fileName: string | undefined;
+    url: string | undefined;
     width: number;
     height: number;
     format: string;
     id: string;
+    view: string;
   };
 
   // Component state variables
@@ -42,21 +44,22 @@ License: CECILL-C
   let combineChannels: boolean = false;
   let viewMeta: ViewMeta[] = [];
 
-  views.subscribe((views) => {
+  $: views.subscribe((views) => {
     viewMeta = Object.values(views || {}).map((view: View | View[]) => {
       let image: Image | SequenceFrame;
       if (Array.isArray(view)) {
         isVideo = true;
-        image = view[0] as SequenceFrame;
+        image = view[$currentFrameIndex] as SequenceFrame;
       } else {
         image = view as Image;
       }
       return {
-        fileName: image.data.url.split("/").at(-1),
+        url: image.data.url,
         width: image.data.width,
         height: image.data.height,
         format: image.data.format,
         id: image.id,
+        view: image.table_info.name,
       };
     });
     features = createFeature($itemMetas.item, $datasetSchema);
@@ -114,22 +117,25 @@ License: CECILL-C
 
 <!-- Item Meta Information Section -->
 <div class="p-4 pb-8 border-b-2 border-b-slate-500 text-slate-800">
+  <h3 class="uppercase font-medium h-10 flex items-center">Views</h3>
   {#each viewMeta as meta}
-    <h3 class="uppercase font-medium h-10 flex items-center">{meta.id}</h3>
-    <div class="mx-4 mb-4">
-      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
-        <p class="font-medium">File name</p>
-        <p class="truncate" title={meta.fileName}>{meta.fileName}</p>
+    <h2 class="font-medium h-10 flex items-center truncate" title="{meta.id} ({meta.view})">
+      {meta.id} ({meta.view})
+    </h2>
+    <div class="mx-4">
+      <div class="grid gap-4 grid-cols-[150px_auto]">
+        <p class="font-medium">URL</p>
+        <p class="truncate" title={meta.url}>{meta.url}</p>
       </div>
-      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+      <div class="grid gap-4 grid-cols-[150px_auto]">
         <p class="font-medium">Width</p>
         <p>{meta.width}</p>
       </div>
-      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+      <div class="grid gap-4 grid-cols-[150px_auto]">
         <p class="font-medium">Height</p>
         <p>{meta.height}</p>
       </div>
-      <div class="grid gap-4 grid-cols-[150px_auto] mt-2">
+      <div class="grid gap-4 grid-cols-[150px_auto]">
         <p class="font-medium">Format</p>
         <p>{meta.format}</p>
       </div>


### PR DESCRIPTION
## Description

- Replace `fileName` with complete URL to help find the file in the media file, or check where it is supposed to be
- Add view name (e.g. "image" or "cam1") next to the Image / SequenceFrame ID
- For videos, update information on `currentFrameIndex` change
- Reduce vertical margins to see more views at once

### Single-view image dataset

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/e050dfc8-34c8-4392-b73b-f6bb9f6f0a35) | ![image](https://github.com/user-attachments/assets/e9224171-bc7e-4ccb-ba35-346f9e873b83) |

### Multi-view video dataset

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/72985329-5e64-4c48-adc8-eb9e47c50184) | ![image](https://github.com/user-attachments/assets/049d3cb8-0cfc-4b1c-aeff-8c6d9d46d16a) |
