### PR TITLE
fix fake source metadata type

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -36,7 +36,7 @@ License: CECILL-C
     created_at: now,
     updated_at: now,
     table_info: { name: "source", group: "source", base_schema: BaseSchema.Source },
-    data: { name: "All", kind: "Global", metadata: "{}" },
+    data: { name: "All", kind: "Global", metadata: {} },
   });
 
   $: $annotations, $entities, handleAnnotationSortedByModel();


### PR DESCRIPTION
## Issue

A source used to group entities in Object Inspector had wrong "metadata" type

Fixed
