### PR TITLE
Feat/text view class

### DIFF
--- a/ui/components/core/src/lib/types/dataset/BaseSchema.ts
+++ b/ui/components/core/src/lib/types/dataset/BaseSchema.ts
@@ -16,6 +16,7 @@ export enum BaseSchema {
   Entity = "Entity",
   Image = "Image",
   SequenceFrame = "SequenceFrame",
+  TextView = "TextView",
   Feature = "Feature",
   Classification = "Classification",
   Conversation = "Conversation",

--- a/ui/components/core/src/lib/types/dataset/views/SequenceFrame.ts
+++ b/ui/components/core/src/lib/types/dataset/views/SequenceFrame.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { BaseSchema } from "../BaseSchema";
 import type { BaseDataFields } from "../datasetTypes";
 import { Image, type ImageType } from "./Image";
-import { type ViewType } from "./View";
+import { View, type ViewType } from "./View";
 
 export const sequenceFrameSchema = z
   .object({
@@ -35,3 +35,14 @@ export class SequenceFrame extends Image {
     return super.nonFeaturesFields().concat(["timestamp", "frame_index"]);
   }
 }
+
+export const isSequenceFrameArray = (view: View | View[]): view is SequenceFrame[] =>
+  Array.isArray(view) && view.every((v) => v.table_info.base_schema === BaseSchema.SequenceFrame);
+
+// Defined here to avoid circular dependency
+export const isMediaView = (view: View | View[]): view is Image | SequenceFrame[] => {
+  if (Array.isArray(view)) {
+    return view.every((v) => v.table_info.base_schema === BaseSchema.SequenceFrame);
+  }
+  return view.table_info.base_schema === BaseSchema.Image;
+};

--- a/ui/components/core/src/lib/types/dataset/views/TextView.ts
+++ b/ui/components/core/src/lib/types/dataset/views/TextView.ts
@@ -1,0 +1,34 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { z } from "zod";
+
+import { BaseSchema } from "../BaseSchema";
+import type { BaseDataFields } from "../datasetTypes";
+import { View, type ViewType } from "./View";
+
+export const textSchema = z.object({
+  content: z.string(),
+});
+
+export type TextViewType = z.infer<typeof textSchema>; //export if needed
+
+export class TextView extends View {
+  declare data: TextViewType & ViewType;
+
+  constructor(obj: BaseDataFields<TextViewType>) {
+    textSchema.parse(obj.data);
+    super(obj as unknown as BaseDataFields<ViewType>);
+    this.data = obj.data as TextViewType & ViewType;
+  }
+
+  static nonFeaturesFields(): string[] {
+    return super.nonFeaturesFields().concat(["content"]);
+  }
+}
+
+export const isTextView = (view: View | View[]): view is TextView =>
+  Array.isArray(view) === false && view.table_info.base_schema === BaseSchema.TextView;

--- a/ui/components/core/src/lib/types/dataset/views/index.ts
+++ b/ui/components/core/src/lib/types/dataset/views/index.ts
@@ -6,5 +6,6 @@ License: CECILL-C
 
 export * from "./Image";
 export * from "./SequenceFrame";
+export * from "./TextView";
 export * from "./View";
 export * from "./ViewEmbedding";

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -14,6 +14,7 @@ License: CECILL-C
     BaseSchema,
     DatasetItem,
     Entity,
+    isSequenceFrameArray,
     Mask,
     Tracklet,
     WorkspaceType,
@@ -34,6 +35,7 @@ License: CECILL-C
     canSave,
     entities,
     itemMetas,
+    mediaViews,
     newShape,
     saveData,
     views,
@@ -60,7 +62,7 @@ License: CECILL-C
     if (selectedItem.ui.type === WorkspaceType.VIDEO) {
       //add frame_index to annotation
       if (ann.table_info.base_schema !== BaseSchema.Tracklet) {
-        const seqframe = ($views[ann.data.view_ref.name] as SequenceFrame[]).find(
+        const seqframe = ($mediaViews[ann.data.view_ref.name] as SequenceFrame[]).find(
           (sf) => sf.id === ann.data.view_ref.id,
         );
         if (seqframe?.data.frame_index != undefined) ann.ui.frame_index = seqframe.data.frame_index;
@@ -74,8 +76,8 @@ License: CECILL-C
 
     if (selectedItem.ui.type === WorkspaceType.VIDEO) {
       for (const view in selectedItem.views) {
-        if (Array.isArray(selectedItem.views[view])) {
-          const video = selectedItem.views[view] as SequenceFrame[];
+        if (isSequenceFrameArray(selectedItem.views[view])) {
+          const video = selectedItem.views[view];
           const vspeed = Math.round(
             (video[video.length - 1].data.timestamp - video[0].data.timestamp) / video.length,
           );

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -51,13 +51,13 @@ License: CECILL-C
     itemBboxes,
     itemKeypoints,
     itemMasks,
+    mediaViews,
     merges,
     newShape,
     saveData,
     selectedKeypointsTemplate,
     selectedTool,
     tracklets,
-    views,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     currentFrameIndex,
@@ -97,7 +97,7 @@ License: CECILL-C
         if (box) current_bboxes_and_interpolated.push(box);
         else if (bbox_childs.length > 1) {
           const sample_bbox = bbox_childs[0];
-          const view_id = ($views[sample_bbox.data.view_ref.name] as SequenceFrame[])[
+          const view_id = ($mediaViews[sample_bbox.data.view_ref.name] as SequenceFrame[])[
             $currentFrameIndex
           ].id;
           const interpolated_box = boxLinearInterpolation(bbox_childs, $currentFrameIndex, view_id);
@@ -128,8 +128,9 @@ License: CECILL-C
         if (kpt) current_kpts_and_interpolated.push(kpt);
         else if (kpt_childs.length > 1) {
           const sample_kpt = kpt_childs[0];
-          const view_id = ($views[sample_kpt.viewRef!.name] as SequenceFrame[])[$currentFrameIndex]
-            .id;
+          const view_id = ($mediaViews[sample_kpt.viewRef!.name] as SequenceFrame[])[
+            $currentFrameIndex
+          ].id;
           const interpolated_kpt = keypointsLinearInterpolation(
             kpt_childs,
             $currentFrameIndex,

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -39,9 +39,9 @@ License: CECILL-C
     colorScale,
     entities,
     itemMetas,
+    mediaViews,
     saveData,
     selectedTool,
-    views,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex } from "../../lib/stores/videoViewerStores";
   import type { Feature } from "../../lib/types/datasetItemWorkspaceTypes";
@@ -280,14 +280,14 @@ License: CECILL-C
   let thumbnails: ObjectThumbnail[] = [];
   const setThumbnails = () => {
     thumbnails = [];
-    for (const view of Object.keys($views)) {
+    for (const view of Object.keys($mediaViews)) {
       const highlightedBoxesByView = entity.ui.childs?.filter(
         (ann) => ann.is_type(BaseSchema.BBox) && ann.data.view_ref.name == view,
       );
       if (highlightedBoxesByView) {
         const selectedBox = highlightedBoxesByView[Math.floor(highlightedBoxesByView.length / 2)];
         if (selectedBox) {
-          const selectedThumbnail = defineObjectThumbnail($itemMetas, $views, selectedBox);
+          const selectedThumbnail = defineObjectThumbnail($itemMetas, $mediaViews, selectedBox);
           if (selectedThumbnail) {
             thumbnails.push(selectedThumbnail);
           }
@@ -430,7 +430,7 @@ License: CECILL-C
               maxWidth={200}
               maxHeight={200}
             />
-            {#if Object.keys($views).length > 1}
+            {#if Object.keys($mediaViews).length > 1}
               <span class="text-center italic">{thumbnail.view}</span>
             {/if}
           {/each}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsInspector.svelte
@@ -16,8 +16,8 @@ License: CECILL-C
     annotations,
     entities,
     itemMetas,
+    mediaViews,
     preAnnotationIsActive,
-    views,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import PreAnnotation from "../PreAnnotation/PreAnnotation.svelte";
   import ObjectCard from "./ObjectCard.svelte";
@@ -65,7 +65,7 @@ License: CECILL-C
         if (entityBoxes) {
           const selectedBox = entityBoxes[Math.floor(entityBoxes.length / 2)];
           if (selectedBox) {
-            const selectedThumbnail = defineObjectThumbnail($itemMetas, $views, selectedBox);
+            const selectedThumbnail = defineObjectThumbnail($itemMetas, $mediaViews, selectedBox);
             if (selectedThumbnail) {
               thumbnails[entityId] = selectedThumbnail;
             }

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/SceneInspector.svelte
@@ -22,8 +22,8 @@ License: CECILL-C
     filters,
     imageSmoothing,
     itemMetas,
+    mediaViews,
     saveData,
-    views,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex } from "../../lib/stores/videoViewerStores";
   import type { Feature, ItemsMeta } from "../../lib/types/datasetItemWorkspaceTypes";
@@ -45,7 +45,7 @@ License: CECILL-C
   let combineChannels: boolean = false;
   let viewMeta: ViewMeta[] = [];
 
-  $: views.subscribe((views) => {
+  $: mediaViews.subscribe((views) => {
     viewMeta = Object.values(views || {}).map((view: View | View[]) => {
       let image: Image | SequenceFrame;
       if (Array.isArray(view)) {

--- a/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -267,7 +267,7 @@ License: CECILL-C
       if (Array.isArray(seqs)) {
         while (!endView) {
           endFrameIndex = endFrameIndex - 1;
-          endView = (seqs as SequenceFrame[]).find(
+          endView = seqs.find(
             (view) =>
               view.data.frame_index === endFrameIndex &&
               view.table_info.name === ($newShape as SaveShape).viewRef.name,

--- a/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/SaveShape/SaveShapeForm.svelte
@@ -34,9 +34,9 @@ License: CECILL-C
     annotations,
     entities,
     itemMetas,
+    mediaViews,
     newShape,
     saveData,
-    views,
   } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex } from "../../lib/stores/videoViewerStores";
   import type {
@@ -263,7 +263,7 @@ License: CECILL-C
 
     if (isVideo) {
       endFrameIndex = $currentFrameIndex + NEWTRACKLET_LENGTH + 1; //+1 for the first while loop
-      const seqs = $views[$newShape.viewRef.name];
+      const seqs = $mediaViews[$newShape.viewRef.name];
       if (Array.isArray(seqs)) {
         while (!endView) {
           endFrameIndex = endFrameIndex - 1;

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -12,7 +12,7 @@ License: CECILL-C
   import { BBox, SliderRoot, Track, type KeypointsTemplate } from "@pixano/core";
 
   import { panTool } from "../../lib/settings/selectionTools";
-  import { entities, selectedTool, views } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { entities, mediaViews, selectedTool } from "../../lib/stores/datasetItemWorkspaceStores";
   import {
     currentFrameIndex,
     lastFrameIndex,
@@ -64,7 +64,7 @@ License: CECILL-C
             <ObjectTrack
               slot="timeTrack"
               {track}
-              views={$views}
+              views={$mediaViews}
               {onTimeTrackClick}
               {bboxes}
               {keypoints}

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
@@ -35,4 +35,3 @@ export * from "./scrollIntoView";
 export * from "./sortAndFilterObjectsToAnnotate";
 export * from "./toggleObjectDisplayControl";
 export * from "./updateExistingObject";
-

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
@@ -4,11 +4,11 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { Annotation, Entity, View } from "@pixano/core";
+import type { Annotation, Entity, Image, SequenceFrame } from "@pixano/core";
 
 import { PRE_ANNOTATION } from "../../constants";
 
-export type MView = Record<string, View | View[]>;
+export type MView = Record<string, Image | SequenceFrame[]>;
 
 export const getObjectEntity = (ann: Annotation, entities: Entity[]): Entity | undefined => {
   return entities.find((entity) => entity.id === ann.data.entity_ref.id);
@@ -35,3 +35,4 @@ export * from "./scrollIntoView";
 export * from "./sortAndFilterObjectsToAnnotate";
 export * from "./toggleObjectDisplayControl";
 export * from "./updateExistingObject";
+

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/mapObjectToBBox.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/mapObjectToBBox.ts
@@ -4,7 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { BaseSchema, WorkspaceType, type BBox, type Image, type SequenceFrame } from "@pixano/core";
+import { BaseSchema, WorkspaceType, type BBox } from "@pixano/core";
 
 import type { MView } from ".";
 import {
@@ -32,7 +32,7 @@ export const mapObjectToBBox = (bbox: BBox, views: MView): BBox | undefined => {
   }
   if (bbox.data.is_normalized) {
     const view = views[bbox.data.view_ref.name];
-    const image = Array.isArray(view) ? (view[0] as SequenceFrame) : (view as Image);
+    const image = Array.isArray(view) ? view[0] : view;
     const imageHeight = image.data.height || 1;
     const imageWidth = image.data.width || 1;
     //TODO: manage correctly format -- here we will change user format if save

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/mapObjectToKeypoints.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/mapObjectToKeypoints.ts
@@ -4,13 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import {
-  WorkspaceType,
-  type Image,
-  type Keypoints,
-  type KeypointsTemplate,
-  type SequenceFrame,
-} from "@pixano/core";
+import { WorkspaceType, type Keypoints, type KeypointsTemplate } from "@pixano/core";
 
 import type { MView } from ".";
 import { templates } from "../../settings/keyPointsTemplates";
@@ -29,7 +23,7 @@ export const mapObjectToKeypoints = (
   if (!template) return;
 
   const view = views[keypoints.data.view_ref.name];
-  const image = Array.isArray(view) ? (view[0] as SequenceFrame) : (view as Image);
+  const image = Array.isArray(view) ? view[0] : view;
   const imageHeight = image.data.height || 1;
   const imageWidth = image.data.width || 1;
   const vertices = [];


### PR DESCRIPTION
## Description

- Create TextView class and add the corresponding BaseSchema
- Add two derived stores of _views_ :
  - _mediaViews_: stores the Image and SequenceFrame arrays
  - _textViews_: stores the TextViews

Use mediaViews wherever views was used before. Leave the loadData method of datasetItemWorkspace as is.

## To implement in future PR

- Clean TextSpan removing annotationRef field
- Refactor EntityLinking workspace with the updated/new types
