### PR TITLE
add a "cancel" button to SelectModal

### DIFF
--- a/ui/components/core/src/components/modals/SelectModal.svelte
+++ b/ui/components/core/src/components/modals/SelectModal.svelte
@@ -51,7 +51,7 @@ License: CECILL-C
 
       <button
         type="button"
-        disabled={!selected || selected === ""}
+        disabled={!selected}
         class="rounded border border-transparent text-slate-50 mt-3 mx-1 py-1 px-3
         bg-primary transition-colors hover:bg-primary-foreground disabled:bg-primary-light"
         on:click={handleConfirm}

--- a/ui/components/core/src/components/modals/SelectModal.svelte
+++ b/ui/components/core/src/components/modals/SelectModal.svelte
@@ -19,6 +19,10 @@ License: CECILL-C
   function handleConfirm() {
     dispatch("confirm");
   }
+
+  function handleCancel() {
+    dispatch("cancel");
+  }
 </script>
 
 <div class="fixed inset-0 z-50 overflow-y-auto">
@@ -47,11 +51,20 @@ License: CECILL-C
 
       <button
         type="button"
+        disabled={!selected || selected === ""}
         class="rounded border border-transparent text-slate-50 mt-3 mx-1 py-1 px-3
-        bg-primary transition-colors hover:bg-primary-foreground"
+        bg-primary transition-colors hover:bg-primary-foreground disabled:bg-primary-light"
         on:click={handleConfirm}
       >
         Ok
+      </button>
+      <button
+        type="button"
+        class="rounded border border-transparent text-slate-50 mt-3 mx-1 py-1 px-3
+        bg-primary transition-colors hover:bg-primary-foreground"
+        on:click={handleCancel}
+      >
+        Cancel
       </button>
     </div>
   </div>

--- a/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
@@ -13,6 +13,7 @@ License: CECILL-C
   import { SAM } from "@pixano/models";
 
   import { datasetSchema } from "../../../../apps/pixano/src/lib/stores/datasetStores";
+  import { panTool } from "../lib/settings/selectionTools";
   import {
     interactiveSegmenterModel,
     modelsUiStore,
@@ -61,6 +62,16 @@ License: CECILL-C
     modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectEmbeddingsTable" }));
   }
 
+  const closeModal = () => {
+    modelsUiStore.set({
+      currentModalOpen: "none",
+      selectedModelName: "",
+      selectedTableName: "",
+      yetToLoadEmbedding: true,
+    });
+    selectedTool.set(panTool);
+  };
+
   $: {
     if ($selectedTool?.isSmart && models.length > 1 && !selectedModelName) {
       modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
@@ -78,6 +89,7 @@ License: CECILL-C
     ifNoChoices={""}
     bind:selected={selectedModelName}
     on:confirm={loadModel}
+    on:cancel={closeModal}
   />
 {/if}
 {#if currentModalOpen === "loading"}
@@ -90,6 +102,7 @@ License: CECILL-C
     ifNoChoices={""}
     bind:selected={selectedTableName}
     on:confirm={getViewEmbeddings}
+    on:cancel={closeModal}
   />
 {/if}
 {#if currentModalOpen === "noModel"}

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -42,7 +42,7 @@ License: CECILL-C
   export let isVideo: boolean = false;
 
   let previousSelectedTool: SelectionTool | null = null;
-  let showSmartTools: boolean = false;
+  $: showSmartTools = $selectedTool && $selectedTool.isSmart;
 
   const cleanFusion = () => {
     //deselect everything = unhighlight all
@@ -70,7 +70,6 @@ License: CECILL-C
       selectTool(addSmartPointTool);
       modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
     } else selectTool(panTool);
-    showSmartTools = !showSmartTools;
   };
 
   interactiveSegmenterModel.subscribe((segmenter) => {


### PR DESCRIPTION
## Issue

In SelectModal (used when we select a segmentation model and embeddings), when no choice is available, or if we want to abort, only a "OK" button. In some case it cause an infinite loading wheel (though nothing is loading)

## Description

- Add a Cancel button
- disable OK button is nothing is selected