### PR TITLE
dataset thumbnail: get absolute path

### DIFF
--- a/pixano/datasets/dataset_info.py
+++ b/pixano/datasets/dataset_info.py
@@ -111,7 +111,7 @@ class DatasetInfo(BaseModel):
             info: DatasetInfo = DatasetInfo.from_json(json_fp)
             try:
                 info.preview = Image.open_url(
-                    str(json_fp.parent / "previews/dataset_preview.jpg"),
+                    str(json_fp.parent.resolve() / "previews/dataset_preview.jpg"),
                     Path("/"),
                 )  # TODO choose correct preview name / path / extension
             except Exception:  # TODO: specify exception URL and Value

--- a/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
@@ -58,7 +58,7 @@ License: CECILL-C
   <div class="m-4 bg-slate-50">
     <img
       src={dataset.preview ? dataset.preview : pixanoLogo}
-      alt="{dataset.name} {dataset.preview ?? 'pixanoLogo'} thumbnail"
+      alt="{dataset.name} thumbnail"
       class="w-[350px] h-[176px] rounded-sm object-contain object-center"
     />
   </div>

--- a/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
@@ -57,8 +57,8 @@ License: CECILL-C
   <!-- Dataset Thumbnail -->
   <div class="m-4 bg-slate-50">
     <img
-      src={dataset.preview ?? pixanoLogo}
-      alt="{dataset.name} thumbnail"
+      src={dataset.preview ? dataset.preview : pixanoLogo}
+      alt="{dataset.name} {dataset.preview ?? 'pixanoLogo'} thumbnail"
       class="w-[350px] h-[176px] rounded-sm object-contain object-center"
     />
   </div>


### PR DESCRIPTION
## Issue

thumbnails displayed in datasets explorer page do not resolve relative path, and so doesn't display thumbnail if library dir is given as a relative path

## Description

resolve() path to absolute