### PR TITLE
add entity, bbox, ... tables to default vqa schema

### DIFF
--- a/pixano/datasets/workspaces/dataset_items.py
+++ b/pixano/datasets/workspaces/dataset_items.py
@@ -26,12 +26,10 @@ class DefaultVQADatasetItem(DatasetItem):
     image: Image
     conversations: list[Conversation]
     messages: list[Message]
-
-    # TODO will be added soon... (but need some rework to allow both Conversation and Entity)
-    # bboxes: list[BBox]
-    # masks: list[CompressedRLE]
-    # keypoints: list[KeyPoints]
-    # objects: list[Entity]
+    objects: list[Entity]
+    bboxes: list[BBox]
+    masks: list[CompressedRLE]
+    keypoints: list[KeyPoints]
 
 
 class DefaultVideoDatasetItem(DatasetItem):

--- a/tests/datasets/builders/test_folders.py
+++ b/tests/datasets/builders/test_folders.py
@@ -68,8 +68,7 @@ class TestFolderBaseBuilder:
         assert vqa_folder_builder.target_dir.is_dir()
         assert vqa_folder_builder.view_name == "image"
         assert vqa_folder_builder.view_schema == Image
-        assert vqa_folder_builder.entity_name == "conversations"
-        assert vqa_folder_builder.entity_schema == Conversation
+        assert list(vqa_folder_builder.entities_schema.keys()) == ["conversations", "objects"]
         assert vqa_folder_builder.url_prefix == Path(".")
 
     def test_url_prefix_init(self, dataset_item_bboxes_metadata):


### PR DESCRIPTION
## Issue

Default VQA schema used by VqaFolderBuilder lacks tables Entity, BBox; Mask, Keypoints

## Description

Add them