### PR TITLE
folder default item values & default conversation

### DIFF
--- a/pixano/datasets/builders/folders/base.py
+++ b/pixano/datasets/builders/folders/base.py
@@ -498,20 +498,6 @@ class FolderBaseBuilder(DatasetBuilder):
         custom_item_metadata: dict[str, Any] = {}
         custom_fields = list(set(self.item_schema.field_names()) - set(Item.field_names()))
         for field in custom_fields:
-            field_type = self.item_schema.model_json_schema()["properties"][field]["type"]
-            match field_type:
-                case "string":
-                    custom_item_metadata[field] = ""
-                case "boolean":
-                    custom_item_metadata[field] = False
-                case "integer":
-                    custom_item_metadata[field] = 0
-                case "number":
-                    custom_item_metadata[field] = 0.0
-                case "array":
-                    custom_item_metadata[field] = []
-                case "object":
-                    custom_item_metadata[field] = {}
-                case _:
-                    custom_item_metadata[field] = None
+            field_type = self.item_schema.__annotations__[field]
+            custom_item_metadata[field] = field_type()
         return custom_item_metadata

--- a/pixano/datasets/builders/folders/base.py
+++ b/pixano/datasets/builders/folders/base.py
@@ -24,6 +24,7 @@ from pixano.features import (
     Message,
     View,
     create_bbox,
+    create_conversation,
     is_annotation,
     is_bbox,
     is_conversation,
@@ -167,8 +168,9 @@ class FolderBaseBuilder(DatasetBuilder):
                     # only consider {split}/{item}.{ext} files
                     if not view_file.is_file() or view_file.suffix not in self.EXTENSIONS:
                         continue
-                    # create item
-                    item = self._create_item(split.name, **{})
+                    # create item with default values for custom fields
+                    custom_item_metadata = self._build_default_custom_metadata_item()
+                    item = self._create_item(split.name, **custom_item_metadata)
                     # create view
                     view_name_nojsonl, view_schema_nojsonl = list(self.views_schema.items())[0]  # only one view
                     view = self._create_view(item, view_file, view_schema_nojsonl)
@@ -176,6 +178,18 @@ class FolderBaseBuilder(DatasetBuilder):
                         self.item_schema_name: item,
                         view_name_nojsonl: view,
                     }
+                    # if schema contain a Conversation, add one
+                    for entity_name, entity_schema_nojsonl in self.entities_schema.items():
+                        if entity_schema_nojsonl is not None and is_conversation(entity_schema_nojsonl):
+                            default_view_ref = ViewRef(id=view.id, name=view_name_nojsonl)
+                            conversation = create_conversation(
+                                id=shortuuid.uuid(),
+                                kind="vqa",
+                                item_ref=ItemRef(id=item.id),
+                                view_ref=default_view_ref,
+                            )
+                            yield {"conversations": conversation}
+
                 continue
 
             for dataset_piece in dataset_pieces:
@@ -479,3 +493,25 @@ class FolderBaseBuilder(DatasetBuilder):
         if not metadata_file.exists():
             raise FileNotFoundError(f"Metadata file {metadata_file} not found")
         return pa_json.read_json(metadata_file).to_pylist()
+
+    def _build_default_custom_metadata_item(self) -> dict[str, Any]:
+        custom_item_metadata: dict[str, Any] = {}
+        custom_fields = list(set(self.item_schema.field_names()) - set(Item.field_names()))
+        for field in custom_fields:
+            field_type = self.item_schema.model_json_schema()["properties"][field]["type"]
+            match field_type:
+                case "string":
+                    custom_item_metadata[field] = ""
+                case "boolean":
+                    custom_item_metadata[field] = False
+                case "integer":
+                    custom_item_metadata[field] = 0
+                case "number":
+                    custom_item_metadata[field] = 0.0
+                case "array":
+                    custom_item_metadata[field] = []
+                case "object":
+                    custom_item_metadata[field] = {}
+                case _:
+                    custom_item_metadata[field] = None
+        return custom_item_metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,14 +34,14 @@ from tests.fixtures.datasets.builders.builder import (
 from tests.fixtures.datasets.builders.folder import (
     edge_case_folder,
     edge_case_folder_builder,
+    folder_no_jsonl,
     image_folder,
     image_folder_builder,
-    image_folder_builder_no_jsonl,
-    image_folder_no_jsonl,
     video_folder,
     video_folder_builder,
     vqa_folder,
     vqa_folder_builder,
+    vqa_folder_builder_no_jsonl,
 )
 from tests.fixtures.datasets.dataset import (
     dataset_image_bboxes_keypoint,

--- a/tests/fixtures/datasets/builders/folder.py
+++ b/tests/fixtures/datasets/builders/folder.py
@@ -106,7 +106,7 @@ def image_folder():
 
 
 @pytest.fixture
-def image_folder_no_jsonl():
+def folder_no_jsonl():
     source_dir = _create_folder(
         [SAMPLE_DATA_PATHS["image_jpg"], SAMPLE_DATA_PATHS["image_png"]], ["train", "val"], [10, 5], with_jsonl=False
     )
@@ -149,9 +149,9 @@ def image_folder_builder(image_folder, dataset_item_image_bboxes_keypoints):
 
 
 @pytest.fixture
-def image_folder_builder_no_jsonl(image_folder_no_jsonl):
-    return ImageFolderBuilder(
-        source_dir=image_folder_no_jsonl,
+def vqa_folder_builder_no_jsonl(folder_no_jsonl):
+    return VQAFolderBuilder(
+        source_dir=folder_no_jsonl,
         target_dir=tempfile.mkdtemp(),
         info=DatasetInfo(name="test", description="test"),
     )


### PR DESCRIPTION
## Issue

- If user add a custom metadata while using a FolderBuilder without metadata.jsonl, no default value is provided for custom metadata resulting in a pydantic validation error
Fixes #500 

- If schema contains a Conversation, without metadata.jsonl, no Conversation is created, which make impossible to add questin and so on on VQA workspace.

## Description

- Add a default value based on type of metadata

- Create a default Conversation when needed
