### PR TITLE
allows segmentation for vqa and EL workspaces

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/EntityLinkingViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/EntityLinkingViewer.svelte
@@ -8,6 +8,7 @@ License: CECILL-C
   // Imports
   import { Image as ImageJS } from "image-js";
   import { Loader2Icon } from "lucide-svelte";
+  import * as ort from "onnxruntime-web";
 
   import { Canvas2D } from "@pixano/canvas2d";
   import { DatasetItem, Image, Message, type ImagesPerView, type SaveItem } from "@pixano/core";
@@ -27,6 +28,7 @@ License: CECILL-C
     itemMasks,
     itemMetas,
     messages,
+    modelsUiStore,
     newShape,
     preAnnotationIsActive,
     saveData,
@@ -38,6 +40,7 @@ License: CECILL-C
   // Attributes
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
+  export let embeddings: Record<string, ort.Tensor> = {};
 
   // Images per view type
   let imagesPerView: ImagesPerView = {};
@@ -110,6 +113,7 @@ License: CECILL-C
   const updateImages = async (): Promise<void> => {
     if (selectedItem.views) {
       loaded = false;
+      modelsUiStore.update((store) => ({ ...store, yetToLoadEmbedding: true }));
       imagesPerView = await loadImages(selectedItem.views as Record<string, Image>);
       loaded = true;
     }
@@ -173,6 +177,7 @@ License: CECILL-C
       masks={$itemMasks}
       keypoints={$itemKeypoints}
       selectedKeypointTemplate={templates.find((t) => t.template_id === $selectedKeypointsTemplate)}
+      {embeddings}
       {filters}
       imageSmoothing={$imageSmoothing}
       bind:selectedTool={$selectedTool}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -9,14 +9,13 @@ License: CECILL-C
   import { Image as ImageJS } from "image-js";
   import { Loader2Icon } from "lucide-svelte";
   import * as ort from "onnxruntime-web";
+
   // Import stores and API functions
-  import { afterUpdate } from "svelte";
 
   import { Canvas2D } from "@pixano/canvas2d";
   import { DatasetItem, Image, type ImagesPerView } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
-  import { loadViewEmbeddings } from "../../lib/api/modelsApi";
   import { updateExistingObject } from "../../lib/api/objectsApi";
   import { templates } from "../../lib/settings/keyPointsTemplates";
   import {
@@ -38,44 +37,11 @@ License: CECILL-C
   // Attributes
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
+  export let embeddings: Record<string, ort.Tensor> = {};
 
   // Images per view type
   let imagesPerView: ImagesPerView = {};
   let loaded: boolean = false; // Loading status of images per view
-
-  let embeddings: Record<string, ort.Tensor> = {};
-
-  afterUpdate(() => {
-    if (
-      selectedItem &&
-      $modelsUiStore.yetToLoadEmbedding &&
-      $modelsUiStore.selectedModelName !== "" &&
-      $modelsUiStore.selectedTableName !== ""
-    ) {
-      modelsUiStore.update((store) => ({ ...store, yetToLoadEmbedding: false }));
-      loadViewEmbeddings(
-        selectedItem.item.id,
-        $modelsUiStore.selectedTableName,
-        selectedItem.ui.datasetId,
-      )
-        .then((results) => {
-          embeddings = results;
-          modelsUiStore.update((store) => ({
-            ...store,
-            currentModalOpen: "none",
-          }));
-        })
-        .catch((err) => {
-          modelsUiStore.update((store) => ({
-            ...store,
-            selectedTableName: "",
-            currentModalOpen: "noEmbeddings",
-          }));
-          console.error("cannot load Embeddings", err);
-          embeddings = {};
-        });
-    }
-  });
 
   /**
    * Normalize the pixel values of an image to a specified range.

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VqaViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VqaViewer.svelte
@@ -8,6 +8,7 @@ License: CECILL-C
   // Imports
   import { Image as ImageJS } from "image-js";
   import { Loader2Icon } from "lucide-svelte";
+  import * as ort from "onnxruntime-web";
 
   import { Canvas2D } from "@pixano/canvas2d";
   import { BaseSchema, DatasetItem, Image, LoadingModal, type ImagesPerView } from "@pixano/core";
@@ -36,6 +37,7 @@ License: CECILL-C
     itemMasks,
     itemMetas,
     messages,
+    modelsUiStore,
     newShape,
     preAnnotationIsActive,
     selectedKeypointsTemplate,
@@ -49,6 +51,7 @@ License: CECILL-C
   // Attributes
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
+  export let embeddings: Record<string, ort.Tensor> = {};
 
   // utility vars for resizing with slide bar
   let vqaAreaMaxWidth = 450; //default width
@@ -130,6 +133,7 @@ License: CECILL-C
   const updateImages = async (): Promise<void> => {
     if (selectedItem.views) {
       loaded = false;
+      modelsUiStore.update((store) => ({ ...store, yetToLoadEmbedding: true }));
       imagesPerView = await loadImages(selectedItem.views as Record<string, Image>);
       loaded = true;
     }
@@ -233,6 +237,7 @@ License: CECILL-C
         selectedKeypointTemplate={templates.find(
           (t) => t.template_id === $selectedKeypointsTemplate,
         )}
+        {embeddings}
         {filters}
         canvasSize={vqaAreaMaxWidth}
         imageSmoothing={$imageSmoothing}


### PR DESCRIPTION
## Issue

In VQA and Entity Linking workspaces, SAM segmentation was not possible, because the embedding loading was made inside ImageViewer.svelte (Image workspace)

## Description

Put embedding loading outside of Imge workspace, allow it for Image, VQA and Entity linking workspace
(what about Video workspace ? -- probably not as we want tracking with SAM2 here)