### PR TITLE
folder builder change params

### DIFF
--- a/docs/tutorials/create_your_first_library.md
+++ b/docs/tutorials/create_your_first_library.md
@@ -46,6 +46,7 @@ class HealthDatasetItem(DatasetItem):
 Notice that when multiple elements are attached to an item we use the `list` type.
 
 Another possibility is to use a predefined `DatasetItem` for image datasets:
+
 ```python
 class DefaultImageDatasetItem(DatasetItem):
     """Default Image DatasetItem Schema."""
@@ -56,9 +57,11 @@ class DefaultImageDatasetItem(DatasetItem):
     masks: list[CompressedRLE]
     keypoints: list[KeyPoints]
 ```
+
 This is the one used by `ImageFolderBuilder` if no schema is provided.
 
 We can override it to add or modify attributes, as shown in the following example, which is functionally equivalent:
+
 ```python
 class EntityWithCategory(Entity):
     category: str

--- a/docs/tutorials/segmentation_powered_by_sam.md
+++ b/docs/tutorials/segmentation_powered_by_sam.md
@@ -72,7 +72,7 @@ print(num_images)
 2. Create the SAM embeddings table.
 
 ```python
-from pixano.features import ViewEmbedding, NDArrayFloat
+from pixano.features import ViewEmbedding
 from pixano.datasets.dataset_schema import SchemaRelation
 from lancedb.pydantic import Vector
 

--- a/pixano/datasets/builders/folders/base.py
+++ b/pixano/datasets/builders/folders/base.py
@@ -220,8 +220,6 @@ class FolderBaseBuilder(DatasetBuilder):
 
                 # create view
                 views_data: list[tuple[str, View]] = []
-                all_entities_data: dict[str, list[Entity]] = defaultdict(list)
-                all_annotations_data: dict[str, list[Annotation]] = defaultdict(list)
                 for k, v in dataset_piece.items():
                     if k in self.views_schema:
                         view_name = k
@@ -245,12 +243,14 @@ class FolderBaseBuilder(DatasetBuilder):
                                     views_data.append((view_name, view))
                             else:
                                 view_file = self.source_dir / (
-                                    Path(v) if split.name in Path(v).parts else split / Path(v)
+                                    Path(v) if split.name == Path(v).parts[0] else split / Path(v)
                                 )
                                 if view_file.is_file() and view_file.suffix in self.EXTENSIONS:
                                     view = self._create_view(item, view_file, view_schema)
                                     views_data.append((view_name, view))
 
+                all_entities_data: dict[str, list[Entity]] = defaultdict(list)
+                all_annotations_data: dict[str, list[Annotation]] = defaultdict(list)
                 for k, v in dataset_piece.items():
                     if k in self.entities_schema and v is not None:
                         entity_name = k

--- a/pixano/datasets/builders/folders/base.py
+++ b/pixano/datasets/builders/folders/base.py
@@ -215,7 +215,7 @@ class FolderBaseBuilder(DatasetBuilder):
 
                 # create item
                 item = self._create_item(
-                    split.name, id=f"item_{i}" if self.use_image_name_as_id else None, **item_metadata
+                    split.name, id=f"item_{split.name}_{i}" if self.use_image_name_as_id else None, **item_metadata
                 )
 
                 # create view
@@ -284,7 +284,7 @@ class FolderBaseBuilder(DatasetBuilder):
 
     def _create_item(self, split: str, id: str | None = None, **item_metadata) -> BaseSchema:
         if "id" not in item_metadata:
-            item_metadata["id"] = id if self.use_image_name_as_id else shortuuid.uuid()
+            item_metadata["id"] = id if id is not None else shortuuid.uuid()
         return self.item_schema(
             split=split,
             **item_metadata,

--- a/pixano/datasets/builders/folders/base.py
+++ b/pixano/datasets/builders/folders/base.py
@@ -125,7 +125,8 @@ class FolderBaseBuilder(DatasetBuilder):
         if not self.source_dir.is_dir():
             raise ValueError("A source path (media_dir / dataset_path) is required.")
 
-        super().__init__(target_dir=Path(library_dir) / dataset_path, dataset_item=dataset_item, info=info)
+        target_dir = Path(library_dir) / "_".join(dataset_path.parts)
+        super().__init__(target_dir=target_dir, dataset_item=dataset_item, info=info)
 
         self.views_schema: dict[str, type[View]] = {}
         self.entities_schema: dict[str, type[Entity]] = {}
@@ -164,8 +165,8 @@ class FolderBaseBuilder(DatasetBuilder):
                 dataset_pieces = None
 
             if dataset_pieces is None:
-                for view_file in sorted(split.glob("*")):
-                    # only consider {split}/{item}.{ext} files
+                for view_file in sorted(split.glob("**/*")):
+                    # only consider {split}/**/{item}.{ext} files
                     if not view_file.is_file() or view_file.suffix not in self.EXTENSIONS:
                         continue
                     # create item with default values for custom fields

--- a/pixano/datasets/builders/folders/base.py
+++ b/pixano/datasets/builders/folders/base.py
@@ -233,11 +233,11 @@ class FolderBaseBuilder(DatasetBuilder):
                                     mosaic_file = mosaic(self.source_dir, split.name, v, view_name)
                                     view_file = self.source_dir / mosaic_file
                                     if not view_file.is_file():  # no split path in metadata.jsonl
-                                        view_file = self.source_dir / split / mosaic_file
+                                        view_file = self.source_dir / split.name / mosaic_file
                                 else:
                                     view_file = self.source_dir / Path(v[0])
                                     if not view_file.is_file():  # no split path in metadata.jsonl
-                                        view_file = self.source_dir / split / Path(v[0])
+                                        view_file = self.source_dir / split.name / Path(v[0])
                                 if view_file.is_file() and view_file.suffix in self.EXTENSIONS:
                                     view = self._create_view(item, view_file, view_schema)
                                     views_data.append((view_name, view))

--- a/pixano/datasets/builders/folders/video.py
+++ b/pixano/datasets/builders/folders/video.py
@@ -4,9 +4,7 @@
 # License: CECILL-C
 # =====================================
 
-from pathlib import Path
 
-from pixano.datasets.dataset_info import DatasetInfo
 from pixano.datasets.dataset_schema import DatasetItem
 from pixano.datasets.workspaces import WorkspaceType
 from pixano.datasets.workspaces.dataset_items import DefaultVideoDatasetItem
@@ -31,25 +29,4 @@ class VideoFolderBuilder(FolderBaseBuilder):
 
     EXTENSIONS = VIDEO_EXTENSIONS
     WORKSPACE_TYPE = WorkspaceType.VIDEO
-
-    def __init__(
-        self,
-        source_dir: Path | str,
-        target_dir: Path | str,
-        info: DatasetInfo,
-        dataset_item: type[DatasetItem] = DefaultVideoDatasetItem,
-        url_prefix: Path | str | None = None,
-    ) -> None:
-        """Initialize the `VideoFolderBuilder`.
-
-        Args:
-            source_dir: The source directory for the dataset.
-            target_dir: The target directory for the dataset.
-            dataset_item: The dataset item schema.
-            info: User informations (name, description, ...) for the dataset.
-            url_prefix: The path to build relative URLs for the views. Useful to build dataset libraries to pass the
-                relative path from the media directory.
-        """
-        super().__init__(
-            source_dir=source_dir, target_dir=target_dir, dataset_item=dataset_item, info=info, url_prefix=url_prefix
-        )
+    DEFAULT_SCHEMA: type[DatasetItem] = DefaultVideoDatasetItem

--- a/tests/datasets/builders/test_folders.py
+++ b/tests/datasets/builders/test_folders.py
@@ -148,6 +148,15 @@ class TestFolderBaseBuilder:
                 dataset_item=Schema,
             )
 
+        # test 5: invalid dataset_path
+        with pytest.raises(ValueError, match=r"A source path \(media_dir / dataset_path\) is required."):
+            ImageFolderBuilder(
+                media_dir=source_dir.parent,
+                library_dir=target_dir,
+                info=DatasetInfo(name="test", description="test"),
+                dataset_path="wrong_dataset_path",
+            )
+
     def test_create_item(self, image_folder_builder: ImageFolderBuilder):
         item = image_folder_builder._create_item(
             split="train",

--- a/tests/datasets/builders/test_folders.py
+++ b/tests/datasets/builders/test_folders.py
@@ -48,7 +48,6 @@ class TestFolderBaseBuilder:
         assert video_folder_builder.views_schema == {"view": Video}
         assert image_folder_builder.entities_schema == {"entities": entity_category}
         assert video_folder_builder.entities_schema == {"entities": entity_category}
-        assert image_folder_builder.url_prefix == Path(".")
 
     def test_vqa_init(self, vqa_folder_builder, vqa_folder_builder_no_jsonl):
         assert isinstance(vqa_folder_builder, VQAFolderBuilder)
@@ -61,28 +60,28 @@ class TestFolderBaseBuilder:
         assert vqa_folder_builder_no_jsonl.views_schema == {"image": Image}
         assert vqa_folder_builder.entities_schema == {"objects": Entity, "conversations": Conversation}
         assert vqa_folder_builder_no_jsonl.entities_schema == {"objects": Entity, "conversations": Conversation}
-        assert vqa_folder_builder.url_prefix == Path(".")
 
     def test_url_prefix_init(self, dataset_item_bboxes_metadata):
         source_dir = Path(tempfile.mkdtemp())
         target_dir = Path(tempfile.mkdtemp())
-        urls_relative_path = source_dir.parent.parent
+        urls_relative_path = source_dir.name
 
         ImageFolderBuilder(
-            source_dir=source_dir,
-            target_dir=target_dir,
+            media_dir=source_dir.parent,
+            library_dir=target_dir,
             info=DatasetInfo(name="test", description="test"),
             dataset_item=dataset_item_bboxes_metadata,
-            url_prefix=urls_relative_path,
+            dataset_path=urls_relative_path,
         )
 
     def test_no_jsonl(self):
         source_dir = Path(tempfile.mkdtemp())
         target_dir = Path(tempfile.mkdtemp())
         ImageFolderBuilder(
-            source_dir=source_dir,
-            target_dir=target_dir,
+            media_dir=source_dir.parent,
+            library_dir=target_dir,
             info=DatasetInfo(name="test", description="test"),
+            dataset_path=source_dir.name,
         )
 
     def test_error_init(self, entity_category) -> None:
@@ -92,9 +91,10 @@ class TestFolderBaseBuilder:
         # test 1: no schema with FolderBaseBuilder
         with pytest.raises(ValueError, match="A schema is required."):
             FolderBaseBuilder(
-                source_dir=source_dir,
-                target_dir=target_dir,
+                media_dir=source_dir.parent,
+                library_dir=target_dir,
                 info=DatasetInfo(name="test", description="test"),
+                dataset_path=source_dir.name,
             )
 
         # test 2: schema without view
@@ -107,9 +107,10 @@ class TestFolderBaseBuilder:
             ValueError, match="At least one View and one Entity schema must be defined in the schemas argument."
         ):
             ImageFolderBuilder(
-                source_dir=source_dir,
-                target_dir=target_dir,
+                media_dir=source_dir.parent,
+                library_dir=target_dir,
                 info=DatasetInfo(name="test", description="test"),
+                dataset_path=source_dir.name,
                 dataset_item=Schema,
             )
 
@@ -123,9 +124,10 @@ class TestFolderBaseBuilder:
             ValueError, match="At least one View and one Entity schema must be defined in the schemas argument."
         ):
             ImageFolderBuilder(
-                source_dir=source_dir,
-                target_dir=target_dir,
+                media_dir=source_dir.parent,
+                library_dir=target_dir,
                 info=DatasetInfo(name="test", description="test"),
+                dataset_path=source_dir.name,
                 dataset_item=Schema,
             )
 
@@ -139,9 +141,10 @@ class TestFolderBaseBuilder:
 
         with pytest.raises(ValueError, match="Only one view schema is supported in folder based builders."):
             ImageFolderBuilder(
-                source_dir=source_dir,
-                target_dir=target_dir,
+                media_dir=source_dir.parent,
+                library_dir=target_dir,
                 info=DatasetInfo(name="test", description="test"),
+                dataset_path=source_dir.name,
                 dataset_item=Schema,
             )
 
@@ -164,7 +167,7 @@ class TestFolderBaseBuilder:
         assert isinstance(view, Image)
         assert view.item_ref == ItemRef(id=item.id)
         assert isinstance(view.id, str) and len(view.id) == 22
-        assert view.url == "train/item_0.jpg"
+        assert view.url == "test_dataset/train/item_0.jpg"
         assert view.width == 586
         assert view.height == 640
         assert view.format == "JPEG"
@@ -180,7 +183,7 @@ class TestFolderBaseBuilder:
         assert isinstance(view, Video)
         assert isinstance(view.id, str) and len(view.id) == 22
         assert view.item_ref == ItemRef(id=item.id)
-        assert view.url == "train/item_0.mp4"
+        assert view.url == "test_dataset/train/item_0.mp4"
         assert view.num_frames == 209
         assert round(view.fps, 2) == 29.97
         assert view.width == 320
@@ -408,10 +411,11 @@ class TestFolderBaseBuilder:
             meatadata_list: list
 
         image_folder_builder_no_jsonl_custom_schema = ImageFolderBuilder(
-            source_dir=folder_no_jsonl,
-            target_dir=tempfile.mkdtemp(),
+            media_dir=folder_no_jsonl.parent,
+            library_dir=tempfile.mkdtemp(),
             info=DatasetInfo(name="test", description="test"),
             dataset_item=CustomSchema,
+            dataset_path=folder_no_jsonl.name,
         )
 
         with patch(
@@ -427,7 +431,7 @@ class TestFolderBaseBuilder:
             if i % 2 == 0:
                 view: Image = item["image"]
                 assert view.item_ref == ItemRef(id=actual_item.id)
-                assert view.url == f"{actual_item.split}/item_mosaic.jpg"
+                assert view.url == f"test_dataset/{actual_item.split}/item_mosaic.jpg"
             else:
                 assert "image" not in item
 
@@ -440,7 +444,7 @@ class TestFolderBaseBuilder:
             sc = split_counts[actual_item.split]
             view: Image = item["image"]
             assert view.item_ref == ItemRef(id=actual_item.id)
-            assert view.url == f"{actual_item.split}/item_{sc}.{'png' if sc % 2 else 'jpg'}"
+            assert view.url == f"test_dataset/{actual_item.split}/item_{sc}.{'png' if sc % 2 else 'jpg'}"
             split_counts[actual_item.split] += 1
 
         # test no json with custom item fields
@@ -467,7 +471,7 @@ class TestFolderBaseBuilder:
             assert actual_item.metadata == f"metadata_{i}"
 
             assert view.item_ref == ItemRef(id=actual_item.id)
-            assert view.url == f"{actual_item.split}/item_{i}.{'png' if i % 2 else 'jpg'}"
+            assert view.url == f"test_dataset/{actual_item.split}/item_{i}.{'png' if i % 2 else 'jpg'}"
 
             if i % 2:  # has entities
                 entities: list[entity_category] = item["entities"]
@@ -514,7 +518,7 @@ class TestFolderBaseBuilder:
             view: Image = item["image"]
 
             assert view.item_ref == ItemRef(id=actual_item.id)
-            assert view.url == f"{actual_item.split}/item_{i % 2}.{'png' if i % 2 else 'jpg'}"
+            assert view.url == f"test_dataset/{actual_item.split}/item_{i % 2}.{'png' if i % 2 else 'jpg'}"
 
             conversations: list[Conversation] = item["conversations"]
             messages: list[Message] = item["messages"]

--- a/tests/fixtures/datasets/builders/folder.py
+++ b/tests/fixtures/datasets/builders/folder.py
@@ -85,7 +85,7 @@ def _create_folder(
     with_jsonl: bool = True,
     mode: str = "image",
 ):
-    source_dir = Path(tempfile.mkdtemp())
+    source_dir = Path(tempfile.mkdtemp()) / "test_dataset"
     for split, num_items in zip(splits, num_items_per_split):
         for item in range(num_items):
             sample_path = samples_path[item % len(samples_path)]
@@ -141,45 +141,50 @@ def edge_case_folder():
 @pytest.fixture
 def image_folder_builder(image_folder, dataset_item_image_bboxes_keypoints):
     return ImageFolderBuilder(
-        source_dir=image_folder,
-        target_dir=tempfile.mkdtemp(),
+        media_dir=image_folder.parent,
+        library_dir=tempfile.mkdtemp(),
         info=DatasetInfo(name="test", description="test"),
         dataset_item=dataset_item_image_bboxes_keypoints,
+        dataset_path=image_folder.name,
     )
 
 
 @pytest.fixture
 def vqa_folder_builder_no_jsonl(folder_no_jsonl):
     return VQAFolderBuilder(
-        source_dir=folder_no_jsonl,
-        target_dir=tempfile.mkdtemp(),
+        media_dir=folder_no_jsonl.parent,
+        library_dir=tempfile.mkdtemp(),
         info=DatasetInfo(name="test", description="test"),
+        dataset_path=folder_no_jsonl.name,
     )
 
 
 @pytest.fixture
 def vqa_folder_builder(vqa_folder):
     return VQAFolderBuilder(
-        source_dir=vqa_folder,
-        target_dir=tempfile.mkdtemp(),
+        media_dir=vqa_folder.parent,
+        library_dir=tempfile.mkdtemp(),
         info=DatasetInfo(name="test", description="test"),
+        dataset_path=vqa_folder.name,
     )
 
 
 @pytest.fixture
 def edge_case_folder_builder(edge_case_folder):
     return ImageFolderBuilder(
-        source_dir=edge_case_folder,
-        target_dir=tempfile.mkdtemp(),
+        media_dir=edge_case_folder.parent,
+        library_dir=tempfile.mkdtemp(),
         info=DatasetInfo(name="test", description="test"),
+        dataset_path=edge_case_folder.name,
     )
 
 
 @pytest.fixture
 def video_folder_builder(video_folder, dataset_item_video_bboxes_keypoint):
     return VideoFolderBuilder(
-        source_dir=video_folder,
-        target_dir=tempfile.mkdtemp(),
+        media_dir=video_folder.parent,
+        library_dir=tempfile.mkdtemp(),
         info=DatasetInfo(name="test", description="test"),
         dataset_item=dataset_item_video_bboxes_keypoint,
+        dataset_path=video_folder.name,
     )


### PR DESCRIPTION
## Description


To simplify *FolderBuilder
replace previous (from documentation exemple)

```
builder = ImageFolderBuilder(
    source_dir=Path("./assets/health_images"),
    target_dir=Path("./pixano_library/health_dataset"),
    dataset_item=HealthDatasetItem,
    info=DatasetInfo(
        id="health_images",
        name="Health Images",
        description="A dataset of health images",
    ),
    url_prefix="/health_images"
    # By default, the images' URLs are relative to the health_images folder.
    # We assume Pixano will be launched with the "assets/" directory as media_dir.
)
```
by

```
builder = ImageFolderBuilder(
    media_dir=Path("./assets"),
    library_dir=Path("./pixano_library"),
    dataset_item=HealthDatasetItem,
    info=DatasetInfo(
        id="health_images",
        name="Health Images",
        description="A dataset of health images",
    ),
    dataset_path="/health_images"
)
```
- target_dir, source_dir and url_prefix removed.
- media_dir, library_dir, dataset_path add.

This way, we ask the 2 usual paths, the paths required by pixano itself, and we remove the url_prefix that is very confusing, or badly explained

**Note**: As we now use the dataset_path to build "target_dir" (target_dir = library_dir / dataset_path), the Pixano dataset will be built under library_dir / dataset_path
(here "./pixano_library/health_images" instead of "./pixano_library/health_dataset")

TODO:
- [x] update documentation
- [x] allows subfolder after split when no metadata.jsonl
- [x] add a flag to have consistent ids for items and images instead of a random uuid (usefull to avoid image embedding to become useless after dataset overwrite, and more "readable" ids)