### PR TITLE
feat(front): Change highlight frame only if outside of track bounds

### DIFF
--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/highlightObject.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/highlightObject.ts
@@ -15,7 +15,8 @@ import { getTopEntity } from "./getTopEntity";
 import { scrollIntoView } from "./scrollIntoView";
 
 export const highlightObject = (entity_id: string, isHighlighted: boolean): number => {
-  let highlightFrameIndex = get(lastFrameIndex) + 1;
+  let trackStart = get(lastFrameIndex) + 1;
+  let trackEnd = 0;
   annotations.update((objects) =>
     objects.map((ann) => {
       if (get(selectedTool).type !== ToolType.Fusion) {
@@ -26,14 +27,20 @@ export const highlightObject = (entity_id: string, isHighlighted: boolean): numb
             : "none";
       }
       if (getTopEntity(ann).id === entity_id && ann.is_type(BaseSchema.Tracklet)) {
-        highlightFrameIndex = Math.min(highlightFrameIndex, (ann as Tracklet).data.start_timestep);
+        trackStart = Math.min(trackStart, (ann as Tracklet).data.start_timestep);
+        trackEnd = Math.max(trackEnd, (ann as Tracklet).data.end_timestep);
       }
       return ann;
     }),
   );
+  // Scroll
   if (!isHighlighted) scrollIntoView(entity_id);
-  if (!isHighlighted && highlightFrameIndex != get(lastFrameIndex) + 1) {
-    return highlightFrameIndex;
+  // Return frame index
+  if (
+    !isHighlighted &&
+    (get(currentFrameIndex) < trackStart || get(currentFrameIndex) > trackEnd)
+  ) {
+    return trackStart;
   } else {
     return get(currentFrameIndex);
   }


### PR DESCRIPTION
## Description

On highlighting, if highlighted track is already visible on the current frame, no need to change and go the the first frame of track.

I thought I had already added this check but I guess not.
