### PR TITLE
textspan: compute background luminace to choose text color

### DIFF
--- a/ui/components/textCanvas/src/lib/utils/createHtmlTags.ts
+++ b/ui/components/textCanvas/src/lib/utils/createHtmlTags.ts
@@ -6,6 +6,18 @@ License: CECILL-C
 
 const TAG_NAME = "span";
 
+function getTextColor(backgroundColor: string): string {
+  //compute background color luminance to choose either white or black font color
+  const hex = backgroundColor.replace(/^#/, "");
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+  return luminance > 128 ? "black" : "white";
+}
+
 export const createHtmlTags = ({
   content,
   metadata,
@@ -20,7 +32,7 @@ export const createHtmlTags = ({
   const element = document.createElement(TAG_NAME);
 
   element.style.backgroundColor = bgColor;
-  element.style.color = "white";
+  element.style.color = getTextColor(bgColor);
   element.style.padding = "1px 4px";
   element.style.borderRadius = "6px";
   element.style.margin = "0px 1px";


### PR DESCRIPTION
## Issue

With some colors, text becomes hard to read
![Image](https://github.com/user-attachments/assets/27187b55-3240-4345-9bf0-2b7f66326dd2)

## Description

Compute luminance of background color to choose black or white font color
![image](https://github.com/user-attachments/assets/fefe26a3-5798-48cd-bf48-272e822fc96b)
