### PR TITLE
fix(front): Minor UI fixes

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -321,7 +321,6 @@ License: CECILL-C
       <span
         class={cn("truncate flex-auto overflow-hidden overflow-ellipsis whitespace-nowrap", {
           "text-slate-800": highlightState !== "none",
-          "text-slate-500": highlightState === "none" && $selectedTool.type !== ToolType.Fusion,
           "text-slate-300": highlightState === "none" && $selectedTool.type === ToolType.Fusion,
         })}
         title="{entity.table_info.base_schema} ({entity.id})"

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -397,7 +397,9 @@ License: CECILL-C
           <div class="flex flex-col">
             {#if entity.ui.childs?.some((ann) => ann.ui.datasetItemType === WorkspaceType.VIDEO)}
               <p class="text-center italic">
-                {allowedChilds.length} objects visible on frame {$currentFrameIndex}
+                {allowedChilds.length > 0 ? allowableChilds.length : "No"}
+                object{allowedChilds.length === 1 ? "" : "s"}
+                visible on frame {$currentFrameIndex}
               </p>
             {/if}
             {#each allowedChilds as child}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -315,7 +315,6 @@ License: CECILL-C
     <div
       class={cn("w-fit sticky left-5 my-1 px-1 border-2 rounded-sm", {
         "text-slate-800": highlightState !== "none",
-        "text-slate-500": highlightState === "none" && $selectedTool.type !== ToolType.Fusion,
         "text-slate-300": highlightState === "none" && $selectedTool.type === ToolType.Fusion,
       })}
       style={`

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -6,6 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { ToolType } from "@pixano/canvas2d/src/tools";
   import {
     BaseSchema,
     cn,
@@ -25,7 +26,12 @@ License: CECILL-C
     getTopEntity,
     relink,
   } from "../../lib/api/objectsApi";
-  import { annotations, colorScale, saveData } from "../../lib/stores/datasetItemWorkspaceStores";
+  import {
+    annotations,
+    colorScale,
+    saveData,
+    selectedTool,
+  } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
   import RelinkAnnotation from "../SaveShape/RelinkAnnotation.svelte";
   import TrackletKeyItem from "./TrackletKeyItem.svelte";
@@ -167,7 +173,9 @@ License: CECILL-C
   <ContextMenu.Trigger
     class={cn("video-tracklet absolute scale-y-90 rounded-sm", {
       "opacity-100": tracklet.ui.highlighted === "self",
-      "opacity-30": tracklet.ui.highlighted === "none" || tracklet.ui.displayControl.hidden,
+      "opacity-30":
+        (tracklet.ui.highlighted === "none" && $selectedTool.type === ToolType.Fusion) ||
+        tracklet.ui.displayControl.hidden,
     })}
     style={`left: ${left}%; width: ${right - left}%; top: ${top}%; height: ${height}%; background-color: ${color}`}
   >


### PR DESCRIPTION
## Description

- In ObjectCard, change text depending on number of objects. This was originally done in #507 but lost in the later commits.
- For highlighting, disable changing opacity of "none" objects outside of fusion tool:
    - Making objects with highlight state equal to "none" more transparent is really only necessary in fusion tool, for objects that cannot be selected because of overlap.
    For regular highlighting, this not really needed, especially now that the highlighted object is much more visible with both the updated scroll into view, and the higher opacity colors.