### PR TITLE
fix(ci): Fix docs deployment conflicts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "pixano/**"
+      - "!pixano/__version__.py"
 
 jobs:
   deploy_docs:


### PR DESCRIPTION
## Description

When publishing a release by updating the Pixano version, the release GitHub action tries to publish the updated documentation (with a new stable version alias), and fails as the documentation branch has already been changed by the standard documentation GitHub action that runs on every commit with a change in `pixano/**`.

Exclude `pixano/__version__.py` from the standard documentation GitHub action to prevent those conflicts.
