### PR TITLE
allow schema overwrite

### DIFF
--- a/pixano/datasets/dataset.py
+++ b/pixano/datasets/dataset.py
@@ -237,7 +237,7 @@ class Dataset:
             schema: Table schema.
             relation_item: Relation with the `'item'` table (table to item).
             data: Table data.
-            mode: Table mode ('create', 'overwrite'd).
+            mode: Table mode ('create', 'overwrite').
             exist_ok: If True, do not raise an error if the table already exists.
             on_bad_vectors: Raise an error, drop or fill bad vectors ("error", "drop", "fill").
             fill_value: Value to fill bad vectors.
@@ -255,7 +255,7 @@ class Dataset:
             fill_value=fill_value,
             embedding_functions=None,
         )
-        self.schema.add_schema(name, schema, relation_item)
+        self.schema.add_schema(name, schema, relation_item, exist_ok and mode == "overwrite")
         self.schema.to_json(self._schema_file)
         self._reload_schema()
         return table

--- a/pixano/datasets/dataset.py
+++ b/pixano/datasets/dataset.py
@@ -255,7 +255,7 @@ class Dataset:
             fill_value=fill_value,
             embedding_functions=None,
         )
-        self.schema.add_schema(name, schema, relation_item, exist_ok and mode == "overwrite")
+        self.schema.add_schema(name, schema, relation_item, exist_ok or mode == "overwrite")
         self.schema.to_json(self._schema_file)
         self._reload_schema()
         return table

--- a/pixano/datasets/dataset_schema.py
+++ b/pixano/datasets/dataset_schema.py
@@ -66,7 +66,7 @@ class DatasetSchema(BaseModel):
         """
         table_name = self.format_table_name(table_name)
         if table_name in self.schemas:
-            raise ValueError(f"Table {table_name} already exists in the schemas.")
+            print(f"WARNING: Table {table_name} already exists in the schemas. It will be replaced.")
         elif not issubclass(schema, BaseSchema):
             raise ValueError(f"Schema {schema} should be a subclass of BaseSchema.")
         elif not isinstance(relation_item, SchemaRelation):

--- a/pixano/datasets/dataset_schema.py
+++ b/pixano/datasets/dataset_schema.py
@@ -53,20 +53,23 @@ class DatasetSchema(BaseModel):
     relations: dict[str, dict[str, SchemaRelation]]
     groups: dict[SchemaGroup, set[str]] = {key: set() for key in SchemaGroup if key != SchemaGroup.SOURCE}
 
-    def add_schema(self, table_name: str, schema: type[BaseSchema], relation_item: SchemaRelation) -> Self:
+    def add_schema(
+        self, table_name: str, schema: type[BaseSchema], relation_item: SchemaRelation, overwrite_schema: bool = False
+    ) -> Self:
         """Add a schema to the dataset schema.
 
         Args:
             table_name: Name of the table to add to the dataset schema.
             schema: Schema of the table.
             relation_item: Relationship with the item schema.
+            overwrite_schema: If True, existing schema will be overwritten, else raise ValueError.
 
         Returns:
             The dataset schema.
         """
         table_name = self.format_table_name(table_name)
-        if table_name in self.schemas:
-            print(f"WARNING: Table {table_name} already exists in the schemas. It will be replaced.")
+        if not overwrite_schema and table_name in self.schemas:
+            raise ValueError(f"Table {table_name} already exists in the schemas.")
         elif not issubclass(schema, BaseSchema):
             raise ValueError(f"Schema {schema} should be a subclass of BaseSchema.")
         elif not isinstance(relation_item, SchemaRelation):

--- a/tests/datasets/test_dataset_schema.py
+++ b/tests/datasets/test_dataset_schema.py
@@ -402,9 +402,6 @@ class TestDatasetSchema:
         assert schema.relations["item"]["new_table"] == item_relation
 
     def test_add_error(self, dataset_schema_item_categories_image_bbox):
-        with pytest.raises(ValueError, match="Table image already exists in the schemas."):
-            dataset_schema_item_categories_image_bbox.add_schema("image", Image, SchemaRelation.ONE_TO_ONE)
-
         with pytest.raises(ValueError, match="Schema <class 'str'> should be a subclass of BaseSchema."):
             dataset_schema_item_categories_image_bbox.add_schema("new_table", str, SchemaRelation.ONE_TO_ONE)
 

--- a/tests/datasets/test_dataset_schema.py
+++ b/tests/datasets/test_dataset_schema.py
@@ -400,10 +400,13 @@ class TestDatasetSchema:
         assert schema.relations["new_table"] == {"item": relation}
         assert set(schema.groups[SchemaGroup.VIEW]) == {"image", "new_table"}
         assert schema.relations["item"]["new_table"] == item_relation
-        schema = dataset_schema_item_categories_image_bbox.add_schema("image", Image, relation)
+        schema = dataset_schema_item_categories_image_bbox.add_schema("image", Image, relation, overwrite_schema=True)
         assert schema.relations["item"]["image"] == item_relation
 
     def test_add_error(self, dataset_schema_item_categories_image_bbox):
+        with pytest.raises(ValueError, match="Table image already exists in the schemas."):
+            dataset_schema_item_categories_image_bbox.add_schema("image", Image, SchemaRelation.ONE_TO_ONE)
+
         with pytest.raises(ValueError, match="Schema <class 'str'> should be a subclass of BaseSchema."):
             dataset_schema_item_categories_image_bbox.add_schema("new_table", str, SchemaRelation.ONE_TO_ONE)
 

--- a/tests/datasets/test_dataset_schema.py
+++ b/tests/datasets/test_dataset_schema.py
@@ -400,6 +400,8 @@ class TestDatasetSchema:
         assert schema.relations["new_table"] == {"item": relation}
         assert set(schema.groups[SchemaGroup.VIEW]) == {"image", "new_table"}
         assert schema.relations["item"]["new_table"] == item_relation
+        schema = dataset_schema_item_categories_image_bbox.add_schema("image", Image, relation)
+        assert schema.relations["item"]["image"] == item_relation
 
     def test_add_error(self, dataset_schema_item_categories_image_bbox):
         with pytest.raises(ValueError, match="Schema <class 'str'> should be a subclass of BaseSchema."):


### PR DESCRIPTION
## Issue

If a schema already exist in schema.json, raise an error. 
It is really annoying for SAM embeddings, when something went wrong while computing them (eg. Out of memory error)

## Description

Allow shema overwrite