### PR TITLE
chore(front): Remove capitalization of names of object features

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
@@ -27,7 +27,7 @@ License: CECILL-C
 {#each features as feature}
   <div class="flex w-full gap-4 mt-2 px-4">
     {#if isEditing || feature.value !== undefined}
-      <p class="capitalize flex items-center">
+      <p class="flex items-center">
         {feature.label.replace("_", " ")}
       </p>
     {/if}


### PR DESCRIPTION
## Description

To prevent weird capitalization like "Category Id" instead of either "ID" or "id", don't capitalize the names of object features and leave the text in lowercase, as is already done in the DatasetExplorer Table.