### PR TITLE
TextSpan enhancements

### DIFF
--- a/ui/components/textCanvas/src/TextSpanArea.svelte
+++ b/ui/components/textCanvas/src/TextSpanArea.svelte
@@ -46,16 +46,18 @@ License: CECILL-C
   };
 </script>
 
-<div class="bg-white p-2 flex flex-col gap-2 h-full overflow-y-auto">
+<div class="bg-white p-2 flex flex-col gap-2 h-full">
   <button class="bg-primary text-white p-2 rounded-md w-fit" on:click={onTagText} id="tagButton">
     Tag Selected Text
   </button>
-  {#each textViews as textView}
-    <SpannableTextView
-      {textView}
-      {colorScale}
-      textSpans={spansByViewId[textView.id]}
-      bind:textSpanAttributes
-    />
-  {/each}
+  <div class="overflow-y-auto">
+    {#each textViews as textView}
+      <SpannableTextView
+        {textView}
+        {colorScale}
+        textSpans={spansByViewId[textView.id]}
+        bind:textSpanAttributes
+      />
+    {/each}
+  </div>
 </div>

--- a/ui/components/textCanvas/src/components/SpannableTextView.svelte
+++ b/ui/components/textCanvas/src/components/SpannableTextView.svelte
@@ -9,6 +9,10 @@ License: CECILL-C
 
   import type { TextSpan, TextSpanType, TextView } from "@pixano/core";
 
+  import {
+    getTopEntity,
+    highlightObject,
+  } from "../../../datasetItemWorkspace/src/lib/api/objectsApi";
   import { editorSelectionToTextSpan, textSpansToHtml } from "../lib";
 
   export let textSpans: TextSpan[] = [];
@@ -28,8 +32,24 @@ License: CECILL-C
       name: textView.table_info.name,
     });
   };
+
+  const clickHandler = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (target && target.dataset.id) {
+      const selectedTextSpan = textSpans.find((ts) => ts.id === target.dataset.id);
+      if (selectedTextSpan) {
+        highlightObject(getTopEntity(selectedTextSpan).id, false);
+      }
+    }
+  };
 </script>
 
-<div on:mouseup={mouseupListener} class="border rounded-lg p-2" role="textbox" tabindex="0">
+<div
+  on:mouseup={mouseupListener}
+  on:mousedown={clickHandler}
+  class="border rounded-lg p-2"
+  role="textbox"
+  tabindex="0"
+>
   {@html richEditorContent}
 </div>

--- a/ui/components/textCanvas/src/lib/utils/createHtmlTags.ts
+++ b/ui/components/textCanvas/src/lib/utils/createHtmlTags.ts
@@ -17,11 +17,13 @@ export const createHtmlTags = ({
   metadata,
   bgColor,
   hidden,
+  highlighted,
 }: {
   content: string;
   metadata: Record<string, string>;
   bgColor: string;
   hidden: boolean;
+  highlighted: boolean;
 }) => {
   const element = document.createElement(TAG_NAME);
 
@@ -36,6 +38,10 @@ export const createHtmlTags = ({
   if (hidden) {
     element.style.backgroundColor = "transparent";
     element.style.color = "black";
+  }
+  if (highlighted) {
+    // glow effect + small outline
+    element.style.boxShadow = `0 0 0 1px rgba(0, 0, 0, 0.2), 0 0 10px ${bgColor}`;
   }
 
   for (const [key, value] of Object.entries(metadata)) {

--- a/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
+++ b/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
@@ -46,7 +46,7 @@ const getTextSpanPositions = (
     //glue next span if it's the next word
     while (
       textSpan.data.spans_start.length > i + 1 &&
-      (textSpan.data.spans_start[i + 1] === end + 1 || textSpan.data.spans_start[i + 1] === end + 2)
+      textSpan.data.spans_start[i + 1] - end <= 2
     ) {
       end = textSpan.data.spans_end[i + 1];
       i = i + 1; //jump over next word
@@ -59,6 +59,7 @@ const getTextSpanPositions = (
       metadata: getMetadataOfTextSpan(textSpan),
       bgColor: colorScale(textSpan.data.entity_ref.id),
       hidden: textSpan.ui.displayControl.hidden ?? false,
+      highlighted: textSpan.ui.displayControl.highlighted === "self",
     });
 
     const spanEnd = spanHtml.length - CLOSING_TAG.length;

--- a/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
+++ b/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
@@ -170,5 +170,5 @@ export const textSpansToHtml = ({
 
   const html = getHtmlFromTree(spanTree);
 
-  return html;
+  return html.replaceAll("\n", "<br>");
 };

--- a/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
+++ b/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
@@ -40,7 +40,7 @@ const getTextSpanPosition = (
   colorScale: (value: string) => string,
 ): SpanPosition => {
   const start = textSpan.data.spans_start[0];
-  const end = textSpan.data.spans_end[0] + 1;
+  const end = textSpan.data.spans_end[textSpan.data.spans_end.length - 1];
   const content = text.slice(start, end);
 
   const spanHtml = createHtmlTags({

--- a/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
+++ b/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
@@ -34,26 +34,39 @@ const getMetadataOfTextSpan = (textSpan: TextSpan): HTMLTextSpanDataAttributes =
   id: textSpan.id,
 });
 
-const getTextSpanPosition = (
+const getTextSpanPositions = (
   text: string,
   textSpan: TextSpan,
   colorScale: (value: string) => string,
-): SpanPosition => {
-  const start = textSpan.data.spans_start[0];
-  const end = textSpan.data.spans_end[textSpan.data.spans_end.length - 1];
-  const content = text.slice(start, end);
+): SpanPosition[] => {
+  const positions: SpanPosition[] = [];
+  for (let i = 0; i < textSpan.data.spans_start.length; i++) {
+    const start = textSpan.data.spans_start[i];
+    let end = textSpan.data.spans_end[i];
+    //glue next span if it's the next word
+    while (
+      textSpan.data.spans_start.length > i + 1 &&
+      (textSpan.data.spans_start[i + 1] === end + 1 || textSpan.data.spans_start[i + 1] === end + 2)
+    ) {
+      end = textSpan.data.spans_end[i + 1];
+      i = i + 1; //jump over next word
+    }
 
-  const spanHtml = createHtmlTags({
-    content,
-    metadata: getMetadataOfTextSpan(textSpan),
-    bgColor: colorScale(textSpan.data.entity_ref.id),
-    hidden: textSpan.ui.displayControl.hidden ?? false,
-  });
+    const content = text.slice(start, end);
 
-  const spanEnd = spanHtml.length - CLOSING_TAG.length;
-  const spanStart = spanEnd - content.length;
+    const spanHtml = createHtmlTags({
+      content,
+      metadata: getMetadataOfTextSpan(textSpan),
+      bgColor: colorScale(textSpan.data.entity_ref.id),
+      hidden: textSpan.ui.displayControl.hidden ?? false,
+    });
 
-  return { start, end, spanStart, spanEnd, html: spanHtml };
+    const spanEnd = spanHtml.length - CLOSING_TAG.length;
+    const spanStart = spanEnd - content.length;
+
+    positions.push({ start, end, spanStart, spanEnd, html: spanHtml });
+  }
+  return positions;
 };
 
 const getHtmlFromTree = (tree: SpanTree): string => {
@@ -102,19 +115,21 @@ const buildSpanTree = ({
   };
 
   for (const textSpan of textSpans) {
-    const spanPosition = getTextSpanPosition(text, textSpan, colorScale);
+    const spanPositions = getTextSpanPositions(text, textSpan, colorScale);
     let currentNode: SpanTree = tree;
 
-    while (true) {
-      const parentNode = currentNode.children.find(
-        (node) => node.start <= spanPosition.start && node.end >= spanPosition.end,
-      );
+    for (const spanPosition of spanPositions) {
+      while (true) {
+        const parentNode = currentNode.children.find(
+          (node) => node.start <= spanPosition.start && node.end >= spanPosition.end,
+        );
 
-      if (!parentNode) {
-        currentNode.children.push({ ...spanPosition, textSpan, children: [] });
-        break;
+        if (!parentNode) {
+          currentNode.children.push({ ...spanPosition, textSpan, children: [] });
+          break;
+        }
+        currentNode = parentNode;
       }
-      currentNode = parentNode;
     }
   }
 


### PR DESCRIPTION
## Issue

With textSpan of composed words, the HTML span only take the first word (+ 1 char !)

Need to be able to select a TextSpan, and see it is selected.

## Description

- Fixed textSpan color highlight (now, it take each word (internal span) separatly, but glue them if they follow
  (end[N] - start[N+1] <= 2  --> this allow 1 or two chars between two words (aka a space, or punctuation + space))

- TextSpan can now be selected in TextView (by a click) -> it highlight them (with a glow effect) ans also select the corresponding entity

- also fix line feeds (\n -> \<br>)
