### PR TITLE
Add table_info to keypointsTemplate

### DIFF
--- a/ui/components/core/src/lib/types/dataset/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/dataset/datasetTypes.ts
@@ -38,7 +38,7 @@ export const tableInfoSchema = z
     base_schema: z.nativeEnum(BaseSchema),
   })
   .strict();
-type TableInfo = z.infer<typeof tableInfoSchema>;
+export type TableInfo = z.infer<typeof tableInfoSchema>;
 
 //note: this one is needed only to parse in BaseData<T> constructor
 //because I can't find a way to parse with the generic typed version

--- a/ui/components/core/src/lib/types/objectTypes.ts
+++ b/ui/components/core/src/lib/types/objectTypes.ts
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { SegmentationResult } from ".";
-import type { BBox, DisplayControl, Entity, Mask, Reference } from "./dataset";
+import type { BBox, DisplayControl, Entity, Mask, Reference, TableInfo } from "./dataset";
 
 // OBJECTS FEATURES
 export type TextFeature = {
@@ -114,6 +114,7 @@ export type KeypointsTemplate = {
     startRef?: KeypointsTemplate;
     top_entities?: Entity[];
   };
+  table_info?: TableInfo;
 };
 
 export type CreateKeypointShape = {

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/mapObjectToKeypoints.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/mapObjectToKeypoints.ts
@@ -44,6 +44,7 @@ export const mapObjectToKeypoints = (
     vertices,
     edges: template.edges,
     ui: keypoints.ui,
+    table_info: keypoints.table_info,
   } as KeypointsTemplate;
   if ("frame_index" in keypoints.ui) kptTemplate.ui!.frame_index = keypoints.ui.frame_index;
   if ("top_entities" in keypoints.ui) kptTemplate.ui!.top_entities = keypoints.ui.top_entities;


### PR DESCRIPTION
## Issue

KeypointsTemplate do not have table_info field
it is now required for ChildCard display, so we add it when mapping from KeyPoints to KeypointsTemplate



