### PR TITLE
Allow filtering of datasetItems on browser page

### DIFF
--- a/pixano/app/routers/browser.py
+++ b/pixano/app/routers/browser.py
@@ -28,6 +28,7 @@ async def get_browser(
     skip: int = 0,
     query: str = "",
     embedding_table: str = "",
+    where: str | None = None,
 ) -> DatasetBrowser:  # type: ignore
     """Load dataset items for the explorer page.
 
@@ -38,6 +39,7 @@ async def get_browser(
         skip: Skip number of items.
         query: Text query for semantic search.
         embedding_table: Table name for embeddings.
+        where: Where clause.
 
     Returns:
         Dataset explorer page.
@@ -69,7 +71,7 @@ async def get_browser(
         except DatasetAccessError as e:
             raise HTTPException(status_code=400, detail=str(e))
     else:
-        item_rows = get_rows(dataset=dataset, table=table_item, limit=limit, skip=skip)
+        item_rows = get_rows(dataset=dataset, table=table_item, limit=limit, skip=skip, where=where)
 
     item_ids = [item.id for item in item_rows]
     item_first_media: dict[str, dict] = {}

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -55,6 +55,14 @@ License: CECILL-C
       query,
     }));
   }
+
+  function handleFilter(where: string) {
+    datasetTableStore.update((value) => ({
+      ...value,
+      currentPage: 1,
+      where,
+    }));
+  }
 </script>
 
 <div class="w-full px-20 bg-slate-50 flex flex-col text-slate-800 min-h-[calc(100vh-80px)]">
@@ -76,6 +84,7 @@ License: CECILL-C
       <Table
         items={selectedDataset.table_data}
         on:selectItem={(event) => handleSelectItem(event.detail)}
+        on:filter={(event) => handleFilter(event.detail)}
       />
     {:else}
       <div

--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -6,8 +6,6 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { ArrowLeft, ArrowRight, Loader2Icon } from "lucide-svelte";
-
   import { ConfirmModal, IconButton, PrimaryButton } from "@pixano/core/src";
   import pixanoLogo from "@pixano/core/src/assets/pixano.png";
 
@@ -150,27 +148,6 @@ License: CECILL-C
           {$currentDatasetStore.name}
         </div>
       </div>
-    {/if}
-    {#if currentItemId}
-      {#if isLoading}
-        <Loader2Icon class="animate-spin" />
-      {:else}
-        <div class="flex items-center gap-4">
-          <IconButton
-            on:click={() => goToNeighborItem("previous")}
-            tooltipContent="Previous item (shift + left arrow)"
-          >
-            <ArrowLeft />
-          </IconButton>
-          {currentItemId}
-          <IconButton
-            on:click={() => goToNeighborItem("next")}
-            tooltipContent="Next item (shift + right arrow)"
-          >
-            <ArrowRight />
-          </IconButton>
-        </div>
-      {/if}
     {/if}
     <div class="flex gap-4">
       {#each navItems as { name, Icon }}

--- a/ui/apps/pixano/src/lib/stores/datasetStores.ts
+++ b/ui/apps/pixano/src/lib/stores/datasetStores.ts
@@ -28,6 +28,7 @@ export const modelsStore = writable<string[]>([]);
 export const sourcesStore = writable<Source[]>([]);
 export const isLoadingNewItemStore = writable<boolean>(true);
 export const datasetTableStore = writable<DatasetTableStore>(defaultDatasetTableValues);
+export const datasetTotalItemsCount = writable<number>(0);
 export const canSaveCurrentItemStore = writable<boolean>();
 export const saveCurrentItemStore = writable<{ shouldSave: boolean; canSave: boolean }>({
   shouldSave: false,

--- a/ui/apps/pixano/src/lib/types/pixanoTypes.ts
+++ b/ui/apps/pixano/src/lib/types/pixanoTypes.ts
@@ -11,4 +11,5 @@ export type DatasetTableStore = {
     model: string;
     search: string;
   };
+  where?: string;
 };

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -17,6 +17,7 @@ License: CECILL-C
     currentDatasetStore,
     datasetsStore,
     datasetTableStore,
+    datasetTotalItemsCount,
     defaultDatasetTableValues,
     modelsStore,
   } from "../lib/stores/datasetStores";
@@ -48,14 +49,16 @@ License: CECILL-C
   $: void getCurrentDatasetItemsIds(currentDatasetId); //void here to avoid .then/.catch. But maybe we could manage error ?
 
   datasetTableStore.subscribe(async (value) => {
-    if (value.where) {
+    if (value.where != undefined) {
       currentDatasetItemsIds = await api.getDatasetItemsIds(currentDatasetId, value.where);
+      datasetTotalItemsCount.set(currentDatasetItemsIds.length);
     }
   });
 
   const getCurrentDatasetItemsIds = async (datasetId: string) => {
     if (datasetId === undefined) return;
     currentDatasetItemsIds = await api.getDatasetItemsIds(datasetId);
+    datasetTotalItemsCount.set(currentDatasetItemsIds.length);
   };
 
   $: page.subscribe((value) => {

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -47,6 +47,12 @@ License: CECILL-C
   // Get all the ids of the items of the selected dataset
   $: void getCurrentDatasetItemsIds(currentDatasetId); //void here to avoid .then/.catch. But maybe we could manage error ?
 
+  datasetTableStore.subscribe(async (value) => {
+    if (value.where) {
+      currentDatasetItemsIds = await api.getDatasetItemsIds(currentDatasetId, value.where);
+    }
+  });
+
   const getCurrentDatasetItemsIds = async (datasetId: string) => {
     if (datasetId === undefined) return;
     currentDatasetItemsIds = await api.getDatasetItemsIds(datasetId);

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/+page.svelte
@@ -15,7 +15,7 @@ License: CECILL-C
   import DatasetExplorer from "../../../components/dataset/DatasetExplorer.svelte";
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
-  import { datasetTableStore } from "$lib/stores/datasetStores";
+  import { datasetTableStore, datasetTotalItemsCount } from "$lib/stores/datasetStores";
 
   let selectedDatasetId: string;
   let selectedDataset: DatasetBrowser;
@@ -35,6 +35,8 @@ License: CECILL-C
         .then((datasetItems) => {
           if (datasetItems.id) {
             selectedDataset = datasetItems;
+            //$datasetTotalItemsCount is fetched before and have the real count (different if filtered)
+            selectedDataset.pagination.total_size = $datasetTotalItemsCount;
           } else {
             showNoRowModal = true;
             //do not change current selectedDataset if error / no row.
@@ -57,17 +59,8 @@ License: CECILL-C
   <DatasetExplorer {selectedDataset} on:selectItem={handleSelectItem} />
 {/if}
 {#if showNoRowModal}
-  <!-- TODO Manage filtered row count !
-    -- but here we only have pagesize (20) rows, we don't know the real count.
-    -- And back doesn't know either because it seek with limit=page_size
-    -- Back should also launch a select COUNT() without limit to get the filtered count, and pass it in answer...
-    -- so for now, we provide a warning when we go too far in pagination...
-    -- At least, we should be able to avoid increasing the current page when it goes too far
-  -->
   <WarningModal
     message="No rows found. Keeping previous state."
-    details="Or no more rows in sub selelection."
-    moreDetails=" (WARNING - UNDER DEVELOPMENT) Actually we don't get the total number of rows in filtered list. The current page may be wrong after this message."
     on:confirm={() => {
       showNoRowModal = false;
     }}

--- a/ui/components/core/src/api/getBrowser.ts
+++ b/ui/components/core/src/api/getBrowser.ts
@@ -11,6 +11,7 @@ export async function getBrowser(
   page: number = 1,
   size: number = 100,
   query: Record<string, string> | undefined,
+  where: string | undefined,
 ): Promise<DatasetBrowser> {
   let datasetItems: DatasetBrowser;
   let datasetItems_raw: DatasetBrowserType;
@@ -19,9 +20,13 @@ export async function getBrowser(
   if (query && query.model !== "" && query.search !== "") {
     query_qparams = `&query=${query.search}&embedding_table=${query.model}`;
   }
+  let where_qparams = "";
+  if (where && where !== "") {
+    where_qparams = `&where=${where}`;
+  }
   try {
     const response = await fetch(
-      `/browser/${datasetId}/?skip=${(page - 1) * size}&limit=${size}${query_qparams}`,
+      `/browser/${datasetId}/?skip=${(page - 1) * size}&limit=${size}${query_qparams}${where_qparams}`,
     );
     if (response.ok) {
       datasetItems_raw = (await response.json()) as DatasetBrowserType;

--- a/ui/components/core/src/api/getDatasetItemsIds.ts
+++ b/ui/components/core/src/api/getDatasetItemsIds.ts
@@ -7,12 +7,22 @@ License: CECILL-C
 import type { Item } from "../lib/types";
 
 // Request API to get all the items ids for a given dataset
-export async function getDatasetItemsIds(datasetId: string): Promise<Array<string>> {
+export async function getDatasetItemsIds(
+  datasetId: string,
+  where: string | undefined = undefined,
+): Promise<Array<string>> {
   const datasetItemsIds: string[] = [];
   const page_size = 1000;
+
+  let where_qparams = "";
+  if (where && where !== "") {
+    where_qparams = `&where=${where}`;
+  }
   for (let skip = 0; ; skip += page_size) {
     try {
-      const response = await fetch(`/items/${datasetId}/?limit=${page_size}&skip=${skip}`);
+      const response = await fetch(
+        `/items/${datasetId}/?limit=${page_size}&skip=${skip}${where_qparams}`,
+      );
       if (response.ok) {
         const res = (await response.json()) as Item[];
         datasetItemsIds.push(...res.map((item) => item.id));

--- a/ui/components/table/package.json
+++ b/ui/components/table/package.json
@@ -21,7 +21,8 @@
     "tailwindcss": "^3.4.1",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",
-    "vite": "^5.1.3"
+    "vite": "^5.1.3",
+    "lucide-svelte": "^0.292.0"
   },
   "dependencies": {
     "@pixano/core": "workspace:^",

--- a/ui/components/table/src/Table.svelte
+++ b/ui/components/table/src/Table.svelte
@@ -16,10 +16,9 @@ License: CECILL-C
 
   // Pixano Core Imports
   import type { TableData } from "@pixano/core";
-  import { icons } from "@pixano/core";
-  import Button from "@pixano/core/src/components/ui/button/button.svelte";
-  import Checkbox from "@pixano/core/src/components/ui/checkbox/checkbox.svelte";
+  import { Button, Checkbox, icons } from "@pixano/core";
 
+  import FilterTable from "./filterTable.svelte";
   import { TableCell } from "./TableCell";
 
   // Exports
@@ -90,6 +89,10 @@ License: CECILL-C
 
   // Settings popup status
   let popupOpened = false;
+
+  const handleFilter = (where: string) => {
+    dispatch("filter", where);
+  };
 </script>
 
 <!-- Settings popup -->
@@ -159,7 +162,7 @@ License: CECILL-C
                 </th>
               </Subscribe>
             {/each}
-            <th class="w-full"></th>
+            <th class="w-full"><FilterTable columns={items.columns} {handleFilter} /></th>
             <th class="pr-4">
               <!-- Settings button -->
               <Button

--- a/ui/components/table/src/filterTable.svelte
+++ b/ui/components/table/src/filterTable.svelte
@@ -1,0 +1,83 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { CircleSlash2 } from "lucide-svelte";
+  import { onMount } from "svelte";
+
+  import { IconButton } from "@pixano/core";
+
+  export let columns: { type?: string; name?: string }[] = [];
+  export let handleFilter: (where: string) => void;
+
+  let selectEl: HTMLSelectElement;
+  let ghostEl: HTMLSpanElement;
+  let selectWidth = 50;
+
+  let filterText: string = "";
+  let selectedCol: string = columns.find((col) => col.type === "str" && col.name).name ?? "";
+
+  //Note: as we adjust select size depending on value, chars here are "important"
+  //also, it should be something a user won't use as an attribute, hopefully
+  const FREE = "!!!!-FREE-!!!!";
+
+  const handleFilterText = () => {
+    if (selectedCol === FREE) {
+      handleFilter(filterText);
+    } else {
+      if (filterText === "") {
+        handleFilter("");
+      } else {
+        handleFilter(`${selectedCol} = '${filterText}'`);
+      }
+    }
+  };
+
+  const handleClearFilter = () => {
+    filterText = "";
+    handleFilter("");
+  };
+
+  // cosmetic: use a ghost span to measure width and adjust select width accordingly
+  function updateWidth() {
+    if (!ghostEl || !selectEl) return;
+    ghostEl.textContent = selectedCol;
+    const width = ghostEl.getBoundingClientRect().width + 10; // +padding
+    selectWidth = Math.max(width, 50); // min width
+  }
+
+  $: if (selectedCol) updateWidth();
+
+  onMount(updateWidth);
+</script>
+
+<div class="flex justify-end gap-2">
+  <!-- Hidden ghost element for measuring -->
+  <span bind:this={ghostEl} class="invisible absolute whitespace-nowrap px-2 font-normal" />
+  <select
+    class="rounded-lg"
+    style="width: {selectWidth}px"
+    bind:this={selectEl}
+    bind:value={selectedCol}
+  >
+    {#each columns as { type, name }}
+      {#if type === "str" && name}
+        <option value={name}>
+          {name}
+        </option>
+      {/if}
+    {/each}
+    <option value={FREE}>Free mode - enter a where clause</option>
+  </select>
+  <input
+    type="text"
+    bind:value={filterText}
+    placeholder="filter"
+    class="h-10 pl-10 pr-4 rounded-lg border text-slate-800 placeholder-slate-500 bg-slate-50 border-slate-300 shadow-slate-300"
+    on:change={handleFilterText}
+  />
+  <IconButton on:click={handleClearFilter}><CircleSlash2 /></IconButton>
+</div>

--- a/ui/components/table/src/filterTable.svelte
+++ b/ui/components/table/src/filterTable.svelte
@@ -58,7 +58,7 @@ License: CECILL-C
   onMount(updateWidth);
 </script>
 
-<div class="flex justify-end gap-2">
+<div class="flex justify-end gap-2 mr-4">
   <!-- Hidden ghost element for measuring -->
   <span bind:this={ghostEl} class="invisible absolute whitespace-nowrap px-2 font-normal" />
   <select

--- a/ui/components/table/src/filterTable.svelte
+++ b/ui/components/table/src/filterTable.svelte
@@ -63,7 +63,7 @@ License: CECILL-C
   <span bind:this={ghostEl} class="invisible absolute whitespace-nowrap px-2 font-normal" />
   <select
     title="Select column to filter on (equality), or Free mode"
-    class="rounded-lg"
+    class="rounded-lg font-normal"
     style="width: {selectWidth}px"
     bind:this={selectEl}
     bind:value={selectedCol}
@@ -80,8 +80,8 @@ License: CECILL-C
   <input
     type="text"
     bind:value={filterText}
-    placeholder="filter"
-    class="h-10 pl-10 pr-4 rounded-lg border text-slate-800 placeholder-slate-500 bg-slate-50 border-slate-300 shadow-slate-300"
+    placeholder="filter value"
+    class="h-10 pl-10 pr-4 rounded-lg border font-normal text-slate-800 placeholder-slate-500 bg-slate-50 border-slate-300 shadow-slate-300"
     on:change={handleFilterText}
   />
   <IconButton on:click={handleClearFilter} tooltipContent={"Clear filter"}>

--- a/ui/components/table/src/filterTable.svelte
+++ b/ui/components/table/src/filterTable.svelte
@@ -62,6 +62,7 @@ License: CECILL-C
   <!-- Hidden ghost element for measuring -->
   <span bind:this={ghostEl} class="invisible absolute whitespace-nowrap px-2 font-normal" />
   <select
+    title="Select column to filter on (equality), or Free mode"
     class="rounded-lg"
     style="width: {selectWidth}px"
     bind:this={selectEl}
@@ -83,5 +84,7 @@ License: CECILL-C
     class="h-10 pl-10 pr-4 rounded-lg border text-slate-800 placeholder-slate-500 bg-slate-50 border-slate-300 shadow-slate-300"
     on:change={handleFilterText}
   />
-  <IconButton on:click={handleClearFilter}><CircleSlash2 /></IconButton>
+  <IconButton on:click={handleClearFilter} tooltipContent={"Clear filter"}>
+    <CircleSlash2 />
+  </IconButton>
 </div>

--- a/ui/components/table/src/filterTable.svelte
+++ b/ui/components/table/src/filterTable.svelte
@@ -17,8 +17,10 @@ License: CECILL-C
   let ghostEl: HTMLSpanElement;
   let selectWidth = 50;
 
+  const allowedTypes = ["str", "int", "float"];
   let filterText: string = "";
-  let selectedCol: string = columns.find((col) => col.type === "str" && col.name).name ?? "";
+  let selectedCol: string =
+    columns.find((col) => allowedTypes.includes(col.type) && col.name).name ?? "";
 
   //Note: as we adjust select size depending on value, chars here are "important"
   //also, it should be something a user won't use as an attribute, hopefully
@@ -31,7 +33,9 @@ License: CECILL-C
       if (filterText === "") {
         handleFilter("");
       } else {
-        handleFilter(`${selectedCol} = '${filterText}'`);
+        const colType = columns.find((col) => col.name === selectedCol).type;
+        if (colType === "str") handleFilter(`${selectedCol} = '${filterText}'`);
+        else handleFilter(`${selectedCol} = ${filterText}`);
       }
     }
   };
@@ -64,7 +68,7 @@ License: CECILL-C
     bind:value={selectedCol}
   >
     {#each columns as { type, name }}
-      {#if type === "str" && name}
+      {#if allowedTypes.includes(type) && name}
         <option value={name}>
           {name}
         </option>

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       '@tsconfig/svelte':
         specifier: ^5.0.2
         version: 5.0.4
+      lucide-svelte:
+        specifier: ^0.292.0
+        version: 0.292.0(svelte@4.2.19)
       svelte:
         specifier: ^4.2.11
         version: 4.2.19


### PR DESCRIPTION
## Description

Allow to filter dataset items in browser page.

A selector allows to choose a column amongst columns (restricted to string/int/float types)
An input field allows to enter the value to seek in this column (check for equality)

Typing enter in this input launch the filter

A button allows to clear the filter

A "special" free mode allows to enter a "where" clause directly (for more specific / complex / composed filter)


Also, the filtered selection is kept when navigating in dataset Item page.
