### PR TITLE
do not select tracklet on right click when fusion

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ChildCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ChildCard.svelte
@@ -147,16 +147,16 @@ License: CECILL-C
       >
         <Pencil class="h-4" />
       </IconButton>
+      <IconButton
+        tooltipContent="Relink object"
+        selected={showRelink}
+        on:click={() => {
+          showRelink = !showRelink;
+        }}
+      >
+        <Link class="h-4" />
+      </IconButton>
     {/if}
-    <IconButton
-      tooltipContent="Relink object"
-      selected={showRelink}
-      on:click={() => {
-        showRelink = !showRelink;
-      }}
-    >
-      <Link class="h-4" />
-    </IconButton>
     <IconButton
       tooltipContent="Delete object"
       redconfirm

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -98,7 +98,7 @@ License: CECILL-C
   };
 
   const onContextMenu = (tracklet: Tracklet | null = null) => {
-    if (tracklet) {
+    if (tracklet && $selectedTool.type !== ToolType.Fusion) {
       const tracklet_childs_ids = tracklet.ui.childs.map((ann) => ann.id);
       annotations.update((oldObjects) =>
         oldObjects.map((ann) => {

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -319,16 +319,20 @@ License: CECILL-C
         Split tracklet after frame {$currentFrameIndex}
       </ContextMenu.Item>
     {/if}
-    {#if leftTracklet}
-      <ContextMenu.Item on:click={() => onGlueTrackletClick("left")}>Glue to left</ContextMenu.Item>
-    {/if}
-    {#if rightTracklet}
-      <ContextMenu.Item on:click={() => onGlueTrackletClick("right")}>
-        Glue to right
-      </ContextMenu.Item>
+    {#if $selectedTool.type !== ToolType.Fusion}
+      {#if leftTracklet}
+        <ContextMenu.Item on:click={() => onGlueTrackletClick("left")}>
+          Glue to left
+        </ContextMenu.Item>
+      {/if}
+      {#if rightTracklet}
+        <ContextMenu.Item on:click={() => onGlueTrackletClick("right")}>
+          Glue to right
+        </ContextMenu.Item>
+      {/if}
+      <ContextMenu.Item on:click={onRelinkTrackletClick}>Relink tracklet</ContextMenu.Item>
     {/if}
     <ContextMenu.Item on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
-    <ContextMenu.Item on:click={onRelinkTrackletClick}>Relink tracklet</ContextMenu.Item>
     {#if showRelink}
       <div class="flex flex-row gap-4 items-center mr-4">
         <RelinkAnnotation

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/deleteObject.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/deleteObject.ts
@@ -6,9 +6,16 @@ License: CECILL-C
 
 import { get } from "svelte/store";
 
+import { ToolType } from "@pixano/canvas2d/src/tools";
 import { Annotation, BaseSchema, Entity, Tracklet, type SaveItem } from "@pixano/core";
 
-import { annotations, entities, saveData } from "../../stores/datasetItemWorkspaceStores";
+import {
+  annotations,
+  entities,
+  merges,
+  saveData,
+  selectedTool,
+} from "../../stores/datasetItemWorkspaceStores";
 import { addOrUpdateSaveItem } from "./addOrUpdateSaveItem";
 
 function listsAreEqual(list1: string[], list2: string[]): boolean {
@@ -54,6 +61,15 @@ const deleteEntity = (entity: Entity) => {
   entities.update((oldObjects) =>
     oldObjects.filter((ent) => ent.id !== entity.id && ent.data.parent_ref.id !== entity.id),
   );
+
+  //in case we are in fusion mode, remove from to_fuse / forbids
+  if (get(selectedTool).type === ToolType.Fusion) {
+    merges.update((merge) => {
+      merge.forbids = merge.forbids.filter((ent) => ent.id !== entity.id);
+      merge.to_fuse = merge.to_fuse.filter((ent) => ent.id !== entity.id);
+      return merge;
+    });
+  }
 };
 
 export const deleteObject = (entity: Entity, child: Annotation | null = null) => {


### PR DESCRIPTION
## Issue

Right clicking on a tracklet (in VideoInspector) while in fuison mode lose current selection.

Fixes #534 

## Description

Prevent selection of right-clicked tracklet when in fusion mode.

Manage delete in fusion mode (update "to fuse" and "forbidden" lists)

Also, removed ability to relink & glue while in fusion mode, as it could create confusion with the current "to_fuse" selection.

@cpvannier In fact I should also probably remove split, as it also may create buggy cases. Another option is to limit split & glue to tracks outside of the ones selected for fusion, but it may change the forbidden list too, so need a specific manangement. I think it's better to just disallow them. (For relink, it's too confusing to relink while fusing -- which is the same thing in fact).

@cpvannier Another note: the relink feature is now more permissive than the fusion one. (it allow overlap of interpolated tracklet, if no keyframes overlap) We should discuss this maybe ?