### PR TITLE
add index of count in header

### DIFF
--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -42,6 +42,11 @@ License: CECILL-C
     currentItemId = value.params.itemId;
   });
 
+  const getDatasetItemDisplayCount = () => {
+    const index = datasetItemsIds.indexOf(currentItemId);
+    return `${index + 1} of ${datasetItemsIds.length}`;
+  };
+
   // Handle bi-directional navigation using arrows
   const goToNeighborItem = async (direction: "previous" | "next") => {
     // Find the neighbor item id
@@ -135,6 +140,7 @@ License: CECILL-C
       {goToNeighborItem}
       {handleReturnToPreviousPage}
       {navigateTo}
+      {getDatasetItemDisplayCount}
     />
   {:else}
     {#if $currentDatasetStore}

--- a/ui/apps/pixano/src/components/layout/DatasetItemHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetItemHeader.svelte
@@ -19,6 +19,7 @@ License: CECILL-C
   export let handleReturnToPreviousPage: () => void;
   export let handleSave: () => void;
   export let navigateTo: (route: string) => Promise<string | undefined>;
+  export let getDatasetItemDisplayCount: () => string;
 
   const onKeyUp = async (event: KeyboardEvent) => {
     const activeElement = document.activeElement;
@@ -66,6 +67,7 @@ License: CECILL-C
       >
         <ArrowRight />
       </IconButton>
+      <span>{getDatasetItemDisplayCount()}</span>
     </div>
     <Toolbar isVideo={$currentDatasetStore.workspace == WorkspaceType.VIDEO} />
   {/if}


### PR DESCRIPTION
## Issue

When annotating (from DatasetItem view), it's convenient to know where we are in the dataset items.

## Description

Add "{index} of {num_items}"  in the header.
It take account of the current filter if any
