### PR TITLE
display confidence even if no "display feature"

### DIFF
--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineTooltip.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineTooltip.ts
@@ -25,5 +25,5 @@ export const defineTooltip = (bbox: BBox, entity: Entity): string | null => {
       : "";
 
   const displayFeat = getDefaultDisplayFeat(entity);
-  return displayFeat ? displayFeat + confidence : null;
+  return displayFeat ? displayFeat + confidence : confidence;
 };

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineTooltip.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/defineTooltip.ts
@@ -18,12 +18,16 @@ export const defineTooltip = (bbox: BBox, entity: Entity): string | null => {
 
   const confidence =
     bbox.data.confidence !== 0.0 &&
-    source &&
-    source.data.kind !== "ground_truth" &&
-    source.data.name !== "Pixano"
-      ? " " + bbox.data.confidence.toFixed(2)
-      : "";
+    (!source || (source.data.kind !== "ground_truth" && source.data.name !== "Pixano"))
+      ? bbox.data.confidence.toFixed(2)
+      : null;
 
   const displayFeat = getDefaultDisplayFeat(entity);
-  return displayFeat ? displayFeat + confidence : confidence;
+  return displayFeat
+    ? confidence
+      ? displayFeat + " " + confidence
+      : displayFeat
+    : confidence
+      ? confidence
+      : "";
 };


### PR DESCRIPTION
## Issue

When there is no "display feature" ("name", "category", or "category_name" feature in entity), the confidence is not displayed

## Description

Always display confidence if != 0.0 and source != {kind: "ground_truth", name: "Pixano"}

TODO: 
it is not displayed with source {kind: "ground_truth", name: "Pixano"} --> check if it's really smart...
Also, maybe don't display if 1.0 ?
Maybe remove it from nonFeatureFields ? (but then it will be editable!)
