### PR TITLE
fix position and avoid linefeed replace

### DIFF
--- a/ui/components/textCanvas/src/components/SpannableTextView.svelte
+++ b/ui/components/textCanvas/src/components/SpannableTextView.svelte
@@ -47,7 +47,7 @@ License: CECILL-C
 <div
   on:mouseup={mouseupListener}
   on:mousedown={clickHandler}
-  class="border rounded-lg p-2"
+  class="border rounded-lg p-2 whitespace-pre-wrap"
   role="textbox"
   tabindex="0"
 >

--- a/ui/components/textCanvas/src/components/SpannableTextView.svelte
+++ b/ui/components/textCanvas/src/components/SpannableTextView.svelte
@@ -20,7 +20,17 @@ License: CECILL-C
   export let textSpanAttributes: TextSpanType | null = null;
   export let textView: TextView;
 
-  $: richEditorContent = textSpansToHtml({ text: textView.data.content, textSpans, colorScale });
+  function escapeHtmlTagsOnly(text: string): string {
+    return text.replace(/<\/?[a-zA-Z][^<>]*?>/g, (match) => {
+      return match.replace("<", "-").replace(">", "-");
+    });
+  }
+
+  $: richEditorContent = textSpansToHtml({
+    text: escapeHtmlTagsOnly(textView.data.content),
+    textSpans,
+    colorScale,
+  });
 
   const mouseupListener = (
     e: MouseEvent & {

--- a/ui/components/textCanvas/src/lib/utils/editorSelectionToTextSpan.ts
+++ b/ui/components/textCanvas/src/lib/utils/editorSelectionToTextSpan.ts
@@ -32,7 +32,7 @@ export const editorSelectionToTextSpan = (
 
   return {
     spans_start: [span_start],
-    spans_end: [span_start + selectedText.length - 1],
+    spans_end: [span_start + selectedText.length],
     mention: selectedText,
     view_ref: viewRef,
   } as TextSpanTypeWithViewRef;

--- a/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
+++ b/ui/components/textCanvas/src/lib/utils/textSpansToHtml.ts
@@ -171,5 +171,5 @@ export const textSpansToHtml = ({
 
   const html = getHtmlFromTree(spanTree);
 
-  return html.replaceAll("\n", "<br>");
+  return html;
 };


### PR DESCRIPTION
## Issue

Incorrect TextSpan position since a previous change

Fixes #546 

## Description

- remove incorrect "-1" for textspan length
- remove the replaceAll("\n",  "\<br>") that changed positionning, instead using "whitespace-pre-wrap" div class
