### PR TITLE
Segmentation support with Pixano Inference

### DIFF
--- a/pixano/app/routers/inference/__init__.py
+++ b/pixano/app/routers/inference/__init__.py
@@ -12,13 +12,14 @@ from pixano_inference.client import PixanoInferenceClient
 
 from pixano.app.settings import Settings, get_settings
 
-from . import conditional_generation, models, zero_shot_detection
+from . import conditional_generation, mask_generation, models, zero_shot_detection
 
 
 router = APIRouter(prefix="/inference", tags=["Inference"])
 router.include_router(conditional_generation.router)
 router.include_router(models.router)
 router.include_router(zero_shot_detection.router)
+router.include_router(mask_generation.router)
 
 
 @router.post("/connect")

--- a/pixano/app/routers/inference/mask_generation.py
+++ b/pixano/app/routers/inference/mask_generation.py
@@ -1,0 +1,105 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel
+
+from pixano.app.models import AnnotationModel, EntityModel, TableInfo, ViewModel
+from pixano.app.routers.inference.utils import get_client_from_settings
+from pixano.app.routers.utils import get_dataset
+from pixano.app.settings import Settings, get_settings
+from pixano.features import BBox, CompressedRLE, Entity, Image, NDArrayFloat, is_image
+from pixano.inference import image_mask_generation
+
+from .utils import get_model_source
+
+
+router = APIRouter(prefix="/tasks/mask-generation", tags=["Task", "Mask Generation"])
+
+# keep track of the last image used, to avoid recomputing embeddings if not necessary
+store_last_image_id: str = ""
+
+
+class ImageMaskGenerationOutput(BaseModel):
+    """Image mask generation output."""
+
+    mask: AnnotationModel
+
+
+@router.post(
+    "/image",
+    response_model=ImageMaskGenerationOutput,
+)
+async def call_image_mask_generation(
+    dataset_id: Annotated[str, Body(embed=True)],
+    image: Annotated[ViewModel, Body(embed=True)],
+    model: Annotated[str, Body(embed=True)],
+    mask_table_name: Annotated[str, Body(embed=True)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    entity: Annotated[EntityModel | None, Body(embed=True)] = None,
+    bbox: Annotated[BBox | None, Body(embed=True)] = None,
+    points: Annotated[list[list[int]] | None, Body(embed=True)] = None,
+    labels: Annotated[list[int] | None, Body(embed=True)] = None,
+) -> ImageMaskGenerationOutput:
+    """Perform image mask generation on an image.
+
+    Args:
+        dataset_id: The ID of the dataset to use.
+        image: The image to use for detection.
+        entity: The entity to use for detection.
+        model: The name of the model to use.
+        mask_table_name: The name of the table to use for masks in dataset.
+        settings: App settings.
+        bbox: Input bounding box or None.
+        points: Input points or None.
+        labels: Labels for input points, or None.
+
+    Returns:
+        The generated mask.
+    """
+    global store_last_image_id
+
+    dataset = get_dataset(dataset_id=dataset_id, dir=settings.library_dir, media_dir=settings.media_dir)
+    client = get_client_from_settings(settings=settings)
+
+    if not is_image(dataset.schema.schemas[image.table_info.name]):
+        raise HTTPException(status_code=400, detail="Image must be an image.")
+
+    image_row: Image = image.to_row(dataset)
+    entity_row: Entity | None = entity.to_row(dataset) if entity else None
+    source = get_model_source(dataset=dataset, model=model)
+
+    try:
+        mask_output: tuple[
+            CompressedRLE, float, NDArrayFloat | None, list[NDArrayFloat] | None
+        ] = await image_mask_generation(
+            client=client,
+            source=source,
+            media_dir=settings.media_dir,
+            image=image_row,
+            entity=entity_row,
+            image_embedding=None,
+            high_resolution_features=None,
+            reset_predictor=store_last_image_id != image_row.id,
+            bbox=bbox,
+            points=points,
+            labels=labels,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    # store image_id to check against for next generation
+    store_last_image_id = image_row.id
+
+    output: ImageMaskGenerationOutput = ImageMaskGenerationOutput(
+        mask=AnnotationModel.from_row(
+            row=mask_output[0],  # right now we don't use other ouputs (score, ...)
+            table_info=TableInfo(name=mask_table_name, group="annotations", base_schema="CompressedRLE"),
+        )
+    )
+    return output

--- a/pixano/inference/mask_generation.py
+++ b/pixano/inference/mask_generation.py
@@ -24,10 +24,11 @@ async def image_mask_generation(
     client: PixanoInferenceClient,
     media_dir: Path,
     image: Image,
-    entity: Entity,
+    entity: Entity | None,
     source: Source,
     image_embedding: ViewEmbedding | NDArrayFloat | LanceVector | None = None,
     high_resolution_features: list[ViewEmbedding] | list[NDArrayFloat] | list[LanceVector] | None = None,
+    reset_predictor: bool = True,
     bbox: BBox | None = None,
     points: list[list[int]] | None = None,
     labels: list[int] | None = None,
@@ -43,6 +44,7 @@ async def image_mask_generation(
         source: The source refering to the model.
         image_embedding: Image embedding.
         high_resolution_features: High resolution features.
+        reset_predictor: True (default) if it's a new image.
         bbox: Bounding box of the object in the original image.
         points: Points to generate mask for.
         labels: Labels of the points. If 0, the point is background else the point is foreground.
@@ -82,12 +84,15 @@ async def image_mask_generation(
     else:
         bbox_request = None
 
-    return_image_embedding = image_embedding is None
+    # Note: As long as we don't store pixano-inference embeddings somewhere, no need to return them
+    # More, it is VERY costly (around 13 sec) as it means to shape them and transfer them via HTTP.
+    return_image_embedding = False  # reset_predictor and image_embedding is None
 
     request = ImageMaskGenerationRequest(
         image=image_request,
         image_embedding=image_embedding_request,
         high_resolution_features=high_resolution_features_request,
+        reset_predictor=reset_predictor,
         boxes=bbox_request,
         points=points_request,
         labels=labels_request,
@@ -112,7 +117,7 @@ async def image_mask_generation(
         id=shortuuid.uuid(),
         item_ref=image.item_ref,
         view_ref=ViewRef(name=image.table_name, id=image.id),
-        entity_ref=EntityRef(name=entity.table_name, id=entity.id),
+        entity_ref=EntityRef(name=entity.table_name, id=entity.id) if entity else EntityRef(name="", id=""),
         source_ref=SourceRef(id=source.id),
         inference_metadata=inference_metadata,
         **mask_inference.model_dump(),

--- a/tests/app/routers/test_inference/test_mask_generation.py
+++ b/tests/app/routers/test_inference/test_mask_generation.py
@@ -112,6 +112,5 @@ def test_call_image_mask_generation_error(
     sample_input_json["image"]["table_info"].update({"name": "mask_image"})
     json = jsonable_encoder(sample_input_json)
     response = client.post(url, json=json)
-    print("ZZQQZQZ", response.json())
     assert response.status_code == 400
     assert response.json() == {"detail": "Image must be an image."}

--- a/tests/app/routers/test_inference/test_mask_generation.py
+++ b/tests/app/routers/test_inference/test_mask_generation.py
@@ -33,7 +33,6 @@ sample_input_json = {
     },
     "model": "model",
     "mask_table_name": "mask_image",
-    "entity": None,
     "bbox": {
         "id": "",
         "created_at": "2025-05-15T13:31:08.690Z",
@@ -112,7 +111,6 @@ def test_call_image_mask_generation_error(
     # name must be an existing table name, but not the correct one
     sample_input_json["image"]["table_info"].update({"name": "mask_image"})
     json = jsonable_encoder(sample_input_json)
-
     response = client.post(url, json=json)
     assert response.status_code == 400
     assert response.json() == {"detail": "Image must be an image."}

--- a/tests/app/routers/test_inference/test_mask_generation.py
+++ b/tests/app/routers/test_inference/test_mask_generation.py
@@ -35,8 +35,8 @@ sample_input_json = {
     "mask_table_name": "mask_image",
     "bbox": {
         "id": "",
-        "created_at": "2025-05-15T13:31:08.690Z",
-        "updated_at": "2025-05-15T13:31:08.690Z",
+        "created_at": "2025-05-15T13:31:08.690",
+        "updated_at": "2025-05-15T13:31:08.690",
         "item_ref": {"name": "", "id": ""},
         "view_ref": {"name": "", "id": ""},
         "entity_ref": {"name": "", "id": ""},
@@ -112,5 +112,6 @@ def test_call_image_mask_generation_error(
     sample_input_json["image"]["table_info"].update({"name": "mask_image"})
     json = jsonable_encoder(sample_input_json)
     response = client.post(url, json=json)
+    print("ZZQQZQZ", response.json())
     assert response.status_code == 400
     assert response.json() == {"detail": "Image must be an image."}

--- a/tests/app/routers/test_inference/test_mask_generation.py
+++ b/tests/app/routers/test_inference/test_mask_generation.py
@@ -1,0 +1,118 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from unittest.mock import patch
+
+from fastapi.applications import FastAPI
+from fastapi.encoders import jsonable_encoder
+from starlette.testclient import TestClient
+
+from pixano.app.models import AnnotationModel, TableInfo
+from pixano.app.routers.inference.mask_generation import ImageMaskGenerationOutput
+from pixano.app.settings import Settings
+from pixano.datasets.dataset import Dataset
+from pixano.features import CompressedRLE, SchemaGroup
+
+
+sample_input_json = {
+    "dataset_id": "dataset_multi_view_tracking_and_image",
+    "image": {
+        "data": {
+            "format": "JPEG",
+            "height": 640,
+            "item_ref": {"id": "1", "name": "item"},
+            "parent_ref": {"id": "", "name": ""},
+            "url": "image_jpg.jpg",
+            "width": 586,
+        },
+        "id": "orange_cats",
+        "table_info": {"base_schema": "Image", "group": "views", "name": "image"},
+    },
+    "model": "model",
+    "mask_table_name": "mask_image",
+    "entity": None,
+    "bbox": {
+        "id": "",
+        "created_at": "2025-05-15T13:31:08.690Z",
+        "updated_at": "2025-05-15T13:31:08.690Z",
+        "item_ref": {"name": "", "id": ""},
+        "view_ref": {"name": "", "id": ""},
+        "entity_ref": {"name": "", "id": ""},
+        "source_ref": {"name": "", "id": ""},
+        "coords": [10, 10, 50, 50],
+        "format": "xywh",
+        "is_normalized": False,
+        "confidence": -1,
+    },
+}
+
+
+@patch("pixano.app.routers.inference.mask_generation.image_mask_generation")
+def test_call_mask_generation(
+    mock_image_mask_generation,
+    app_and_settings_with_client_copy: tuple[FastAPI, Settings, TestClient],
+    dataset_multi_view_tracking_and_image: Dataset,
+):
+    app, settings, client = app_and_settings_with_client_copy
+
+    expected_output = ImageMaskGenerationOutput(
+        mask=AnnotationModel.from_row(
+            row=CompressedRLE(counts=b"xx", size=[400, 400]),
+            table_info=TableInfo(name="mask_image", group=SchemaGroup.ANNOTATION.value, base_schema="CompressedRLE"),
+        )
+    )
+    mock_image_mask_generation.return_value = [
+        CompressedRLE(id="m1", counts=b"xx", size=[400, 400], inference_metadata="{}")
+    ]
+
+    json = jsonable_encoder(sample_input_json)
+
+    url = "/inference/tasks/mask-generation/image"
+
+    response = client.post(url, json=json)
+    assert response.status_code == 200
+    assert expected_output.mask.to_row(dataset_multi_view_tracking_and_image).model_dump(
+        exclude="id", exclude_timestamps=True
+    ) == AnnotationModel.model_validate(response.json()["mask"]).to_row(
+        dataset_multi_view_tracking_and_image
+    ).model_dump(exclude="id", exclude_timestamps=True)
+
+    dataset = Dataset.find(
+        "dataset_multi_view_tracking_and_image", directory=settings.library_dir, media_dir=settings.media_dir
+    )
+    sources = dataset.get_data("source", limit=10)
+    assert len(sources) == 4
+
+    # Execute again to check the source is not created again.
+    response = client.post(url, json=json)
+    assert response.status_code == 200
+    assert expected_output.mask.to_row(dataset_multi_view_tracking_and_image).model_dump(
+        exclude="id", exclude_timestamps=True
+    ) == AnnotationModel.model_validate(response.json()["mask"]).to_row(
+        dataset_multi_view_tracking_and_image
+    ).model_dump(exclude="id", exclude_timestamps=True)
+
+    dataset = Dataset.find(
+        "dataset_multi_view_tracking_and_image", directory=settings.library_dir, media_dir=settings.media_dir
+    )
+    sources = dataset.get_data("source", limit=10)
+    assert len(sources) == 4
+
+
+def test_call_image_mask_generation_error(
+    app_and_settings_with_client_copy: tuple[FastAPI, Settings, TestClient],
+):
+    app, settings, client = app_and_settings_with_client_copy
+
+    url = "/inference/tasks/mask-generation/image"
+
+    # name must be an existing table name, but not the correct one
+    sample_input_json["image"]["table_info"].update({"name": "mask_image"})
+    json = jsonable_encoder(sample_input_json)
+
+    response = client.post(url, json=json)
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Image must be an image."}

--- a/ui/apps/pixano/src/lib/stores/datasetStores.ts
+++ b/ui/apps/pixano/src/lib/stores/datasetStores.ts
@@ -25,6 +25,7 @@ export const currentDatasetStore = writable<DatasetInfo>();
 export const datasetSchema = writable<DatasetSchema>();
 export const datasetsStore = writable<DatasetInfo[]>();
 export const modelsStore = writable<string[]>([]);
+export const isLocalSegmentationModel = writable<boolean>(true);
 export const sourcesStore = writable<Source[]>([]);
 export const isLoadingNewItemStore = writable<boolean>(true);
 export const datasetTableStore = writable<DatasetTableStore>(defaultDatasetTableValues);

--- a/ui/components/core/src/api/inference/listModels.ts
+++ b/ui/components/core/src/api/inference/listModels.ts
@@ -4,14 +4,14 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { MultimodalImageNLPTask } from "../../lib/types";
+import { type Task } from "../../lib/types";
 
 interface Model {
   name: string;
-  task: MultimodalImageNLPTask;
+  task: Task;
 }
 
-export async function listModels(task: MultimodalImageNLPTask | null = null): Promise<Model[]> {
+export async function listModels(task: Task | null = null): Promise<Model[]> {
   const url =
     task === null
       ? "/inference/models/list"

--- a/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
@@ -1,0 +1,132 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  import {
+    api,
+    ImageTask,
+    Input,
+    LoadingModal,
+    PrimaryButton,
+    type InputEvents,
+    type ModelConfig,
+  } from "../..";
+
+  //TMP: default values
+  const modelChoices = {
+    sam2: {
+      provider: "sam2",
+      model_name: "SAM2",
+      model_path: "facebook/sam2-hiera-tiny",
+      dtype: "bfloat16",
+    },
+  };
+  let formData = modelChoices["sam2"];
+
+  let isAddingModelRequestPending = false;
+  const dispatch = createEventDispatcher();
+
+  function handleCancel() {
+    dispatch("cancelAddModel");
+  }
+
+  const handleChange = (event: InputEvents["change"]) => {
+    if (event.target && "name" in event.target && "value" in event.target) {
+      const name: string = event.target.name as string;
+      const value: string = event.target.value as string;
+      formData = { ...formData, [name]: value };
+    }
+  };
+
+  const handleAddModel = async () => {
+    isAddingModelRequestPending = true;
+    const model_config: ModelConfig = {
+      config: {
+        name: formData.model_name,
+        task: ImageTask.MASK_GENERATION,
+        path: formData.model_path,
+        config: { dtype: formData.dtype },
+        processor_config: {},
+      },
+      provider: formData.provider,
+    };
+
+    const success = await api.instantiateModel(model_config); //NOTE: take some time (~40sec)
+
+    if (!success) {
+      console.error(`Couldn't instantiate model '${model_config.config.name}'`);
+      return;
+    }
+
+    isAddingModelRequestPending = false;
+    console.log(`Model '${model_config.config.name}' added.`);
+
+    dispatch("listModels");
+    dispatch("cancelAddModel");
+  };
+</script>
+
+<!-- stop propagation to prevent from closing the modal when clicking on the background -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+  on:click|stopPropagation={() => {}}
+  class="fixed top-[calc(80px+5px)] left-1/2 transform -translate-x-1/2 z-50 overflow-y-auto w-68 rounded-md bg-white text-slate-800 flex flex-col gap-3 item-center pb-3 max-h-[calc(100vh-80px-10px)]"
+>
+  <div class="bg-primary p-3 rounded-b-none rounded-t-md text-white">
+    <p>Instantiate Segmentation model</p>
+  </div>
+  <div class="p-3 flex flex-col gap-2">
+    <h5 class="font-medium">Provider (only use providers installed with pixano-inference)</h5>
+    <Input
+      name="provider"
+      value={formData.provider}
+      type="string"
+      on:change={handleChange}
+      on:keyup={(e) => e.stopPropagation()}
+    />
+    <h5 class="font-medium">Name</h5>
+    <Input
+      name="model_name"
+      value={formData.model_name}
+      type="string"
+      on:change={handleChange}
+      on:keyup={(e) => e.stopPropagation()}
+    />
+    <h5 class="font-medium">Path</h5>
+    <Input
+      name="model_path"
+      value={formData.model_path}
+      type="string"
+      on:change={handleChange}
+      on:keyup={(e) => e.stopPropagation()}
+    />
+    <h5 class="font-medium">Data Type (advanced users)</h5>
+    <Input
+      name="dtype"
+      value={formData.dtype}
+      type="string"
+      on:change={handleChange}
+      on:keyup={(e) => e.stopPropagation()}
+    />
+  </div>
+  <div class="flex flex-row gap-2 px-3 justify-center">
+    <PrimaryButton on:click={handleCancel}>Cancel</PrimaryButton>
+    <PrimaryButton
+      on:click={handleAddModel}
+      isSelected
+      disabled={isAddingModelRequestPending || Object.values(formData).some((v) => v === "")}
+    >
+      Add Model
+    </PrimaryButton>
+  </div>
+</div>
+
+{#if isAddingModelRequestPending}
+  <LoadingModal />
+{/if}

--- a/ui/components/core/src/components/pixano_inference_segmentation/ConnectModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/ConnectModal.svelte
@@ -7,15 +7,14 @@ License: CECILL-C
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 
-  import { api, Input, PrimaryButton, type InputEvents } from "@pixano/core";
+  import { api, Input, PrimaryButton, type InputEvents } from "../..";
+  import { pixanoInferenceSegmentationURL } from "./inference";
 
   export let isConnected = false;
-  export let url: string;
-  export let vqaSectionWidth: number;
 
   // default values
   let formData = {
-    pi_url: url,
+    pi_url: $pixanoInferenceSegmentationURL,
   };
 
   const dispatch = createEventDispatcher();
@@ -25,6 +24,7 @@ License: CECILL-C
     isConnected = await api.isInferenceApiHealthy(formData.pi_url);
     console.log("handleConnect end", isConnected);
     if (isConnected) {
+      pixanoInferenceSegmentationURL.set(formData.pi_url);
       dispatch("listModels");
       dispatch("cancelConnect"); //also close modal
     }
@@ -48,11 +48,11 @@ License: CECILL-C
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   on:click|stopPropagation={() => {}}
-  class="fixed top-[calc(80px+5px)] z-50 overflow-y-auto w-96 rounded-md bg-white text-slate-800 flex flex-col gap-3"
-  style={`left: calc(${vqaSectionWidth}px + 10px);`}
+  class="fixed top-[calc(80px+5px)] left-1/2 transform -translate-x-1/2 z-50 w-96
+  rounded-md bg-white text-slate-800 flex flex-col gap-3 item-center pb-3 max-h-[calc(100vh-80px-10px)]"
 >
   <div class="bg-primary p-3 rounded-b-none rounded-t-md text-white">
-    <p>Pixano Inference connection - Completion</p>
+    <p>Pixano Inference connection - Segmentation</p>
   </div>
 
   <div class="px-3 pb-3 flex flex-col gap-3">
@@ -67,10 +67,6 @@ License: CECILL-C
 
     <p class="italic text-justify text-sm">
       Note that the last active connection will be used, even after a failed connect attempt.
-    </p>
-    <p class="italic text-justify text-sm">
-      Also, Pixano Inference does not support several running models, so to have both Completion and
-      Segmentation you should use two different Pixano Inference instances.
     </p>
 
     <div class="flex flex-row gap-4 justify-center">

--- a/ui/components/core/src/components/pixano_inference_segmentation/ConnectModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/ConnectModal.svelte
@@ -20,9 +20,7 @@ License: CECILL-C
   const dispatch = createEventDispatcher();
 
   async function handleConnect() {
-    console.log("handleConnect");
     isConnected = await api.isInferenceApiHealthy(formData.pi_url);
-    console.log("handleConnect end", isConnected);
     if (isConnected) {
       pixanoInferenceSegmentationURL.set(formData.pi_url);
       dispatch("listModels");

--- a/ui/components/core/src/components/pixano_inference_segmentation/ModelItem.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/ModelItem.svelte
@@ -1,0 +1,45 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { Trash2 } from "lucide-svelte";
+  import { createEventDispatcher } from "svelte";
+
+  import { api, IconButton } from "../..";
+  import { pixanoInferenceSegmentationModelsStore } from "./inference";
+
+  export let modelName: string;
+
+  const dispatch = createEventDispatcher();
+
+  const handleDeleteModel = () => {
+    api
+      .deleteModel(modelName)
+      .then(() => {
+        pixanoInferenceSegmentationModelsStore.update((models) =>
+          models.filter((m) => m.name !== modelName),
+        );
+      })
+      .catch((err) => console.error("ERROR: Could not delete model.", err));
+  };
+</script>
+
+<div class="border rounded p-3 flex items-center justify-between gap-2 hover:bg-gray-50">
+  <label class="flex items-center gap-2 cursor-pointer flex-grow">
+    <input
+      type="radio"
+      name="model-selection"
+      bind:group={modelName}
+      value={modelName}
+      on:change={() => dispatch("select")}
+    />
+    <span>{modelName}</span>
+  </label>
+
+  <IconButton tooltipContent="Delete model" on:click={handleDeleteModel}>
+    <Trash2 />
+  </IconButton>
+</div>

--- a/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
@@ -1,0 +1,248 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { Plus } from "lucide-svelte";
+  import { createEventDispatcher, onMount } from "svelte";
+
+  import { api, ImageTask, PrimaryButton } from "../..";
+  import { isLocalSegmentationModel } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
+  import AddModelModal from "./AddModelModal.svelte";
+  import {
+    pixanoInferenceSegmentationModelsStore,
+    type PixanoInferenceSegmentationModel,
+  } from "./inference";
+  import ModelItem from "./ModelItem.svelte";
+
+  const dispatch = createEventDispatcher();
+
+  // Exports
+  export let choices: Array<string>;
+  export let selected: string;
+  let localOrPixinf = $isLocalSegmentationModel ? "local" : "pixinf";
+
+  let showAddModelModal = false;
+
+  let isInferenceApiConnected = false;
+  async function connectToPixanoInference() {
+    //TMP -- TODO: allow to choose pixano inference url
+    const url = "http://127.0.0.1:9152";
+    isInferenceApiConnected = await api.isInferenceApiHealthy(url);
+    if (isInferenceApiConnected) {
+      await listModels();
+    }
+  }
+
+  //Try to connect with default URL at startup
+  onMount(connectToPixanoInference);
+
+  const listModels = async () => {
+    const availableSegmentationModels = await api.listModels(ImageTask.MASK_GENERATION);
+
+    const availableSegmentationModelsNames = availableSegmentationModels.map((model) => model.name);
+
+    //inferenceModels = availableSegmentationModels.map((name) => ({ id: name, value: name }));
+    pixanoInferenceSegmentationModelsStore.update((currentList) =>
+      mergeModelLists(availableSegmentationModelsNames, currentList),
+    );
+  };
+
+  export function mergeModelLists(
+    newModelsName: string[],
+    existingModels: PixanoInferenceSegmentationModel[],
+  ): PixanoInferenceSegmentationModel[] {
+    const existingModelsMap = new Map(existingModels.map((model) => [model.name, model]));
+
+    return newModelsName.map(
+      (model) =>
+        existingModelsMap.get(model) ?? {
+          name: model,
+          selected: false,
+        },
+    );
+  }
+
+  const handleSelect = (selectedModelName: string) => {
+    pixanoInferenceSegmentationModelsStore.update((models) =>
+      models.map((m) => {
+        m.selected = m.name === selectedModelName;
+        return m;
+      }),
+    );
+  };
+  const handleOpenAddModelModal = (event: Event) => {
+    // stopPropgation is not called as event modifier
+    // because event modifiers can only be used on DOM elements
+    event.stopPropagation();
+    if (showAddModelModal) {
+      handleCloseAddModelModal();
+    } else {
+      showAddModelModal = true;
+    }
+  };
+  const handleCloseAddModelModal = () => {
+    showAddModelModal = false;
+  };
+
+  const handleLocalOrPixinfChange = () => {
+    isLocalSegmentationModel.set(localOrPixinf === "local");
+  };
+
+  function handleConfirm() {
+    dispatch("confirm");
+  }
+
+  function handleCancel() {
+    dispatch("cancel");
+  }
+</script>
+
+<!-- stop propagation to prevent from closing the modal when clicking on the background -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+  on:click|stopPropagation={() => {}}
+  class="fixed top-[calc(80px+5px)] left-1/2 transform -translate-x-1/2 z-50
+  rounded-md bg-white text-slate-800 flex flex-col gap-3 item-center pb-3 max-h-[calc(100vh-80px-10px)]"
+>
+  <div class="bg-primary p-3 rounded-b-none rounded-t-md text-white">
+    <p>Select a Mask Generation Model</p>
+  </div>
+  <div class="flex flex-col p-3 gap-5">
+    <div class="flex flex-row gap-2">
+      <label>
+        <input
+          type="radio"
+          bind:group={localOrPixinf}
+          value="local"
+          on:change={handleLocalOrPixinfChange}
+        />
+        <p>Local</p>
+        {#if choices}
+          <select
+            class="py-1 px-2 border rounded focus:outline-none
+  bg-slate-100 border-slate-300 focus:border-main"
+            bind:value={selected}
+          >
+            {#each choices as choice}
+              <option value={choice}>
+                {choice}
+              </option>
+            {/each}
+          </select>
+        {:else}
+          <p class="pb-1 italic">No local model found</p>
+        {/if}
+      </label>
+    </div>
+    <div class="flex flex-row gap-2">
+      <label>
+        <input
+          type="radio"
+          bind:group={localOrPixinf}
+          value="pixinf"
+          on:change={handleLocalOrPixinfChange}
+        />
+        <p>Pixano Inference</p>
+        <div class="p-3 flex flex-col gap-2">
+          {#if $pixanoInferenceSegmentationModelsStore.length === 0}
+            <p class="text-gray-500">No models added yet.</p>
+          {/if}
+
+          <div class="flex flex-col gap-2 max-h-[300px] overflow-y-auto">
+            {#each $pixanoInferenceSegmentationModelsStore as model}
+              <ModelItem modelName={model.name} on:select={() => handleSelect(model.name)} />
+            {/each}
+          </div>
+          <PrimaryButton on:click={handleOpenAddModelModal}>
+            <Plus />Add a model
+          </PrimaryButton>
+        </div>
+      </label>
+    </div>
+    <div class="flex flex-row gap-2 px-3 justify-center">
+      <PrimaryButton on:click={handleCancel}>Cancel</PrimaryButton>
+      <PrimaryButton on:click={handleConfirm}>OK</PrimaryButton>
+    </div>
+  </div>
+</div>
+
+{#if showAddModelModal}
+  <AddModelModal on:listModels={listModels} on:cancelAddModel={handleCloseAddModelModal} />
+{/if}
+
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+
+<script lang="ts">
+  // Imports
+  import { createEventDispatcher } from "svelte";
+
+  // Exports
+  export let choices: Array<string>;
+  export let selected: string;
+
+  const dispatch = createEventDispatcher();
+
+  function handleConfirm() {
+    dispatch("confirm");
+  }
+
+  function handleCancel() {
+    dispatch("cancel");
+  }
+</script>
+
+<div class="fixed inset-0 z-50 overflow-y-auto">
+  <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity" />
+  <div class="flex min-h-full justify-center text-center items-center">
+    <div
+      class="relative transform overflow-hidden rounded-lg p-6 max-w-2xl
+          bg-slate-50 text-slate-800"
+    >
+    <p class="pb-1">Please select a segmentation model</p>
+    <p class="pb-2">local model</p>
+    {#if choices}
+        <select
+          class="py-1 px-2 border rounded focus:outline-none
+        bg-slate-100 border-slate-300 focus:border-main"
+          bind:value={selected}
+        >
+          {#each choices as choice}
+            <option value={choice}>
+              {choice}
+            </option>
+          {/each}
+        </select>
+      {:else}
+        <p class="pb-1 italic">WHAT?</p>
+      {/if}
+
+      <p class="pb-2">served by Pixano Inference</p>
+
+      <button
+        type="button"
+        disabled={!selected}
+        class="rounded border border-transparent text-slate-50 mt-3 mx-1 py-1 px-3
+        bg-primary transition-colors hover:bg-primary-foreground disabled:bg-primary-light"
+        on:click={handleConfirm}
+      >
+        Ok
+      </button>
+      <button
+        type="button"
+        class="rounded border border-transparent text-slate-50 mt-3 mx-1 py-1 px-3
+        bg-primary transition-colors hover:bg-primary-foreground"
+        on:click={handleCancel}
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+</div>
+-------------------------------------->

--- a/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
@@ -112,57 +112,62 @@ License: CECILL-C
     <p>Select a Mask Generation Model</p>
   </div>
   <div class="flex flex-col p-3 gap-5">
-    <div class="flex flex-row gap-2">
-      <label>
+    <label>
+      <div class="flex flex-row gap-2">
         <input
           type="radio"
           bind:group={localOrPixinf}
           value="local"
           on:change={handleLocalOrPixinfChange}
         />
-        <p>Local</p>
-        {#if choices}
-          <select
-            class="py-1 px-2 border rounded focus:outline-none
-  bg-slate-100 border-slate-300 focus:border-main"
-            bind:value={selected}
-          >
-            {#each choices as choice}
-              <option value={choice}>
-                {choice}
-              </option>
-            {/each}
-          </select>
-        {:else}
-          <p class="pb-1 italic">No local model found</p>
-        {/if}
-      </label>
-    </div>
-    <div class="flex flex-row gap-2">
-      <label>
+        <div class="flex flex-col gap-2">
+          <p class="self-center">Local</p>
+          {#if choices}
+            <select
+              class="py-1 px-2 border rounded focus:outline-none bg-slate-100 border-slate-300 focus:border-main"
+              bind:value={selected}
+            >
+              {#each choices as choice}
+                <option value={choice}>
+                  {choice}
+                </option>
+              {/each}
+            </select>
+          {:else}
+            <p class="pb-1 italic">No local model found</p>
+          {/if}
+        </div>
+      </div>
+    </label>
+    <div class="h-1 bg-primary-light" />
+    <label>
+      <div class="flex flex-row gap-2">
         <input
           type="radio"
           bind:group={localOrPixinf}
           value="pixinf"
           on:change={handleLocalOrPixinfChange}
         />
-        <p>Pixano Inference</p>
-        <div class="p-3 flex flex-col gap-2">
-          {#if $pixanoInferenceSegmentationModelsStore.length === 0}
-            <p class="text-gray-500">No models added yet.</p>
-          {/if}
+        <div class="flex flex-col gap-2">
+          <p class="self-center">Pixano Inference</p>
+          <div class="p-3 flex flex-col gap-2">
+            {#if $pixanoInferenceSegmentationModelsStore.length === 0}
+              <p class="text-gray-500">No models added yet.</p>
+            {/if}
 
-          <div class="flex flex-col gap-2 max-h-[300px] overflow-y-auto">
-            {#each $pixanoInferenceSegmentationModelsStore as model}
-              <ModelItem modelName={model.name} on:select={() => handleSelect(model.name)} />
-            {/each}
+            <div class="flex flex-col gap-2 max-h-[300px] overflow-y-auto">
+              {#each $pixanoInferenceSegmentationModelsStore as model}
+                <ModelItem modelName={model.name} on:select={() => handleSelect(model.name)} />
+              {/each}
+            </div>
+            <PrimaryButton on:click={handleOpenAddModelModal}>
+              <Plus />Add a model
+            </PrimaryButton>
           </div>
-          <PrimaryButton on:click={handleOpenAddModelModal}>
-            <Plus />Add a model
-          </PrimaryButton>
         </div>
-      </label>
-    </div>
+      </div>
+    </label>
+    <div class="h-1 bg-primary-light" />
     <div class="flex flex-row gap-2 px-3 justify-center">
       <PrimaryButton on:click={handleCancel}>Cancel</PrimaryButton>
       <PrimaryButton on:click={handleConfirm}>OK</PrimaryButton>

--- a/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
+++ b/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
@@ -8,6 +8,8 @@ import { writable } from "svelte/store";
 
 import type { AnnotationType, MaskType } from "../../lib/types";
 
+const DEFAULT_URL = "http://localhost:9152";
+
 export type PixanoInferenceSegmentationModel = {
   selected: boolean;
   name: string;
@@ -30,3 +32,4 @@ export type PixanoInferenceSegmentationOutput = {
 export const pixanoInferenceSegmentationModelsStore = writable<PixanoInferenceSegmentationModel[]>(
   [],
 );
+export const pixanoInferenceSegmentationURL = writable<string>(DEFAULT_URL);

--- a/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
+++ b/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
@@ -1,0 +1,16 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { writable } from "svelte/store";
+
+export type PixanoInferenceSegmentationModel = {
+  selected: boolean;
+  name: string;
+};
+
+export const pixanoInferenceSegmentationModelsStore = writable<PixanoInferenceSegmentationModel[]>(
+  [],
+);

--- a/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
+++ b/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
@@ -6,9 +6,25 @@ License: CECILL-C
 
 import { writable } from "svelte/store";
 
+import type { AnnotationType, MaskType } from "../../lib/types";
+
 export type PixanoInferenceSegmentationModel = {
   selected: boolean;
   name: string;
+};
+
+export type PixanoInferenceSegmentationOutput = {
+  mask: {
+    id: string;
+    created_at: string;
+    updated_at: string;
+    table_info: {
+      name: string;
+      group: string;
+      base_schema: string;
+    };
+    data: MaskType & AnnotationType;
+  };
 };
 
 export const pixanoInferenceSegmentationModelsStore = writable<PixanoInferenceSegmentationModel[]>(

--- a/ui/components/core/src/index.ts
+++ b/ui/components/core/src/index.ts
@@ -18,6 +18,7 @@ export { default as LoadingModal } from "./components/modals/LoadingModal.svelte
 export { default as PromptModal } from "./components/modals/PromptModal.svelte";
 export { default as SelectModal } from "./components/modals/SelectModal.svelte";
 export { default as WarningModal } from "./components/modals/WarningModal.svelte";
+export { default as SelectLocalOrDistantModelModal } from "./components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte";
 // ui
 export { AutoResizeTextarea } from "./components/ui/autoresize-textarea";
 export { Button } from "./components/ui/button";

--- a/ui/components/core/src/lib/types/index.ts
+++ b/ui/components/core/src/lib/types/index.ts
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 export * from "./dataset";
-export * from "./inference/inference";
+export * from "./inference";
 export * from "./modelsTypes";
 export * from "./objectTypes";
 export * from "./toolsTypes";

--- a/ui/components/core/src/lib/types/inference.ts
+++ b/ui/components/core/src/lib/types/inference.ts
@@ -4,7 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { Entity, Message, QuestionTypeEnum } from "../dataset";
+import { Entity, Message, QuestionTypeEnum } from "./dataset";
 
 export enum MultimodalImageNLPTask {
   //Multimodal tasks
@@ -14,6 +14,22 @@ export enum MultimodalImageNLPTask {
   MATCHING = "image_text_matching",
   QUESTION_ANSWERING = "image_question_answering",
 }
+
+export enum ImageTask {
+  CLASSIFICATION = "image_classification",
+  DEPTH_ESTIMATION = "depth_estimation",
+  INSTANCE_SEGMENTATION = "instance_segmentation",
+  FEATURE_EXTRACTION = "image_feature_extraction",
+  KEYPOINT_DETECTION = "keypoint_detection",
+  MASK_GENERATION = "image_mask_generation",
+  OBJECT_DETECTION = "object_detection",
+  SEMANTIC_SEGMENTATION = "semantic_segmentation",
+  UNIVERSAL_SEGMENTATION = "universal_segmentation",
+  ZERO_SHOT_CLASSIFICATION = "image_zero_shot_classification",
+  ZERO_SHOT_DETECTION = "image_zero_shot_detection",
+}
+
+export type Task = MultimodalImageNLPTask | ImageTask;
 
 export interface SystemPrompt {
   content: string;

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -8,9 +8,19 @@ License: CECILL-C
   // Imports
   import { Loader2Icon } from "lucide-svelte";
 
-  import { WorkspaceType, type DatasetItem } from "@pixano/core";
+  import {
+    api,
+    Mask,
+    WorkspaceType,
+    type Box,
+    type DatasetItem,
+    type LabeledClick,
+    type Reference,
+  } from "@pixano/core";
+  import { pixanoInferenceSegmentationModelsStore } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
+  import { rleFrString } from "../../../../canvas2d/src/api/maskApi";
   import { loadViewEmbeddings } from "../../lib/api/modelsApi";
   import { modelsUiStore } from "../../lib/stores/datasetItemWorkspaceStores";
   import ThreeDimensionsViewer from "./3DViewer.svelte";
@@ -27,6 +37,72 @@ License: CECILL-C
   modelsUiStore.subscribe(() => {
     if (selectedItem) loadViewEmbeddings();
   });
+
+  const pixanoInferenceSegmentation = async (
+    viewRef: Reference,
+    points: LabeledClick[],
+    box: Box,
+  ): Promise<Mask | undefined> => {
+    console.time("timer");
+    const isConnected = await api.isInferenceApiHealthy("http://localhost:9152");
+    if (!isConnected) return;
+    const models = await api.listModels();
+    console.log("Models:", models);
+    const selectedMaskModel = $pixanoInferenceSegmentationModelsStore.find((m) => m.selected);
+    const maskModelName = selectedMaskModel ? selectedMaskModel.name : "SAM2";
+    if (!models.map((m) => m.name).includes(maskModelName)) return;
+    let image = selectedItem.views[viewRef.name];
+    if (Array.isArray(image)) {
+      const candidate_image = image.find((v) => v.id === viewRef.id);
+      if (candidate_image) image = candidate_image;
+      else return;
+    }
+    //need to remove "/media" from image url !
+    const fixed_image = structuredClone(image);
+    fixed_image.data.url = (fixed_image.data.url as string).replace("media/", "");
+    const base_input = {
+      dataset_id: selectedItem.ui.datasetId,
+      image: fixed_image,
+      model: maskModelName,
+      entity: null,
+      bbox: box,
+      mask_table_name: "masks", //TODO : get correct masks table name
+    };
+    let input;
+    if (points) {
+      let pts = [];
+      let labels = [];
+      for (const pt of points) {
+        pts.push([Math.round(pt.x), Math.round(pt.y)]);
+        labels.push(pt.label);
+      }
+      input = { ...base_input, points: pts, labels: labels };
+    }
+    if (box) {
+      //TODO -> need a BBox object !!
+    }
+    console.log("INPUT:", input);
+    const response = await fetch("/inference/tasks/mask-generation/image", {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+    if (response.ok) {
+      const result = await response.json(); //TODO define the output type... -_-'
+      console.log("rerere", result);
+      result.mask.data.counts = rleFrString(result.mask.data.counts as string);
+      console.timeEnd("timer");
+      return result.mask as Mask;
+    } else {
+      console.log("no answer!", response);
+      console.log("...", await response.json());
+    }
+    console.timeEnd("timer");
+    return;
+  };
 </script>
 
 <div class="max-h-[calc(100vh-80px)] w-full max-w-full bg-slate-800">
@@ -35,13 +111,13 @@ License: CECILL-C
       <Loader2Icon class="animate-spin text-white" />
     </div>
   {:else if selectedItem.ui.type === WorkspaceType.VIDEO}
-    <VideoViewer {selectedItem} {resize} bind:currentAnn />
+    <VideoViewer {selectedItem} {pixanoInferenceSegmentation} {resize} bind:currentAnn />
   {:else if selectedItem.ui.type === WorkspaceType.IMAGE_VQA}
-    <VqaViewer {selectedItem} {resize} bind:currentAnn />
+    <VqaViewer {selectedItem} {pixanoInferenceSegmentation} {resize} bind:currentAnn />
   {:else if selectedItem.ui.type === WorkspaceType.IMAGE_TEXT_ENTITY_LINKING}
-    <EntityLinkingViewer {selectedItem} {resize} bind:currentAnn />
+    <EntityLinkingViewer {selectedItem} {pixanoInferenceSegmentation} {resize} bind:currentAnn />
   {:else if selectedItem.ui.type === WorkspaceType.IMAGE || !selectedItem.ui.type}
-    <ImageViewer {selectedItem} {resize} bind:currentAnn />
+    <ImageViewer {selectedItem} {pixanoInferenceSegmentation} {resize} bind:currentAnn />
   {:else if selectedItem.ui.type === WorkspaceType.PCL_3D}
     <ThreeDimensionsViewer />
   {/if}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -18,7 +18,10 @@ License: CECILL-C
     type LabeledClick,
     type Reference,
   } from "@pixano/core";
-  import { pixanoInferenceSegmentationModelsStore } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
+  import {
+    pixanoInferenceSegmentationModelsStore,
+    type PixanoInferenceSegmentationOutput,
+  } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
   import { rleFrString } from "../../../../canvas2d/src/api/maskApi";
@@ -130,7 +133,7 @@ License: CECILL-C
       body: JSON.stringify(input),
     });
     if (response.ok) {
-      const result = await response.json(); //TODO define the output type... -_-'
+      const result = (await response.json()) as PixanoInferenceSegmentationOutput;
       result.mask.data.counts = rleFrString(result.mask.data.counts as string);
       return result.mask as Mask;
     } else {

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -68,7 +68,6 @@ License: CECILL-C
       image: fixed_image,
       model: maskModelName,
       entity: null, //unused, we don't create a mask object, we only need the mask RLE
-      bbox: box,
       mask_table_name: "", //unused, we don't create a mask object, we only need the mask RLE
     };
     let input;

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -20,6 +20,7 @@ License: CECILL-C
   } from "@pixano/core";
   import {
     pixanoInferenceSegmentationModelsStore,
+    pixanoInferenceSegmentationURL,
     type PixanoInferenceSegmentationOutput,
   } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
@@ -47,8 +48,7 @@ License: CECILL-C
     points: LabeledClick[],
     box: Box,
   ): Promise<Mask | undefined> => {
-    //TODO config URL !
-    const isConnected = await api.isInferenceApiHealthy("http://localhost:9152");
+    const isConnected = await api.isInferenceApiHealthy($pixanoInferenceSegmentationURL);
     if (!isConnected) return;
     const models = await api.listModels();
     const selectedMaskModel = $pixanoInferenceSegmentationModelsStore.find((m) => m.selected);

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -47,6 +47,7 @@ License: CECILL-C
     points: LabeledClick[],
     box: Box,
   ): Promise<Mask | undefined> => {
+    //TODO config URL !
     const isConnected = await api.isInferenceApiHealthy("http://localhost:9152");
     if (!isConnected) return;
     const models = await api.listModels();

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/EntityLinkingViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/EntityLinkingViewer.svelte
@@ -14,8 +14,12 @@ License: CECILL-C
     DatasetItem,
     Image,
     isImage,
+    Mask,
     Message,
+    type Box,
     type ImagesPerView,
+    type LabeledClick,
+    type Reference,
     type SaveItem,
   } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
@@ -48,6 +52,11 @@ License: CECILL-C
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
   export let resize: number;
+  export let pixanoInferenceSegmentation: (
+    viewRef: Reference,
+    points: LabeledClick[],
+    box: Box,
+  ) => Promise<Mask | undefined>;
 
   // Images per view type
   let imagesPerView: ImagesPerView = {};
@@ -218,6 +227,7 @@ License: CECILL-C
         )}
         embeddings={$embeddings}
         {filters}
+        {pixanoInferenceSegmentation}
         canvasSize={entityLinkingAreaWidth + resize}
         imageSmoothing={$imageSmoothing}
         bind:selectedTool={$selectedTool}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/ImageViewer.svelte
@@ -12,7 +12,16 @@ License: CECILL-C
   // Import stores and API functions
 
   import { Canvas2D } from "@pixano/canvas2d";
-  import { DatasetItem, Image, isImage, type ImagesPerView } from "@pixano/core";
+  import {
+    DatasetItem,
+    Image,
+    isImage,
+    Mask,
+    type Box,
+    type ImagesPerView,
+    type LabeledClick,
+    type Reference,
+  } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
   import { updateExistingObject } from "../../lib/api/objectsApi";
@@ -38,6 +47,11 @@ License: CECILL-C
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
   export let resize: number;
+  export let pixanoInferenceSegmentation: (
+    viewRef: Reference,
+    points: LabeledClick[],
+    box: Box,
+  ) => Promise<Mask | undefined>;
 
   // Images per view type
   let imagesPerView: ImagesPerView = {};
@@ -153,6 +167,7 @@ License: CECILL-C
     selectedKeypointTemplate={templates.find((t) => t.template_id === $selectedKeypointsTemplate)}
     embeddings={$embeddings}
     {filters}
+    {pixanoInferenceSegmentation}
     canvasSize={resize}
     imageSmoothing={$imageSmoothing}
     bind:selectedTool={$selectedTool}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VideoViewer.svelte
@@ -17,10 +17,14 @@ License: CECILL-C
     DatasetItem,
     Entity,
     Keypoints,
+    Mask,
     SaveShapeType,
     SequenceFrame,
     Tracklet,
+    type Box,
     type EditShape,
+    type LabeledClick,
+    type Reference,
     type SaveItem,
   } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
@@ -63,6 +67,11 @@ License: CECILL-C
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
   export let resize: number;
+  export let pixanoInferenceSegmentation: (
+    viewRef: Reference,
+    points: LabeledClick[],
+    box: Box,
+  ) => Promise<Mask | undefined>;
 
   $: {
     if (selectedItem) {
@@ -411,6 +420,7 @@ License: CECILL-C
         selectedKeypointTemplate={templates.find(
           (t) => t.template_id === $selectedKeypointsTemplate,
         )}
+        {pixanoInferenceSegmentation}
         canvasSize={inspectorMaxHeight + resize}
         isVideo={true}
         embeddings={$embeddings}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VqaViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VqaViewer.svelte
@@ -10,7 +10,17 @@ License: CECILL-C
   import { Loader2Icon } from "lucide-svelte";
 
   import { Canvas2D } from "@pixano/canvas2d";
-  import { BaseSchema, DatasetItem, Image, LoadingModal, type ImagesPerView } from "@pixano/core";
+  import {
+    BaseSchema,
+    DatasetItem,
+    Image,
+    LoadingModal,
+    Mask,
+    type Box,
+    type ImagesPerView,
+    type LabeledClick,
+    type Reference,
+  } from "@pixano/core";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
   import { VqaArea } from "@pixano/vqa-canvas";
   import type { StoreQuestionEvent } from "@pixano/vqa-canvas/src/features/addQuestion/types";
@@ -52,6 +62,11 @@ License: CECILL-C
   export let selectedItem: DatasetItem;
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
   export let resize: number;
+  export let pixanoInferenceSegmentation: (
+    viewRef: Reference,
+    points: LabeledClick[],
+    box: Box,
+  ) => Promise<Mask | undefined>;
 
   // utility vars for resizing with slide bar
   let vqaAreaMaxWidth = 450; //default width
@@ -240,6 +255,7 @@ License: CECILL-C
         )}
         embeddings={$embeddings}
         {filters}
+        {pixanoInferenceSegmentation}
         canvasSize={vqaAreaMaxWidth + resize}
         imageSmoothing={$imageSmoothing}
         bind:selectedTool={$selectedTool}

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -10,6 +10,7 @@ License: CECILL-C
     MinusCircleIcon,
     MousePointer,
     PlusCircleIcon,
+    Settings,
     Share2,
     Square,
     Wand2Icon,
@@ -19,7 +20,9 @@ License: CECILL-C
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import type { SelectionTool } from "@pixano/core";
   import { cn, IconButton } from "@pixano/core/src";
+  import { pixanoInferenceSegmentationModelsStore } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
 
+  import { isLocalSegmentationModel } from "../../../../apps/pixano/src/lib/stores/datasetStores";
   import { clearHighlighting } from "../lib/api/objectsApi/clearHighlighting";
   import {
     addSmartPointTool,
@@ -59,9 +62,18 @@ License: CECILL-C
   const handleSmartToolClick = () => {
     if (!showSmartTools) {
       selectTool(addSmartPointTool);
-      if ($modelsUiStore.selectedModelName === "" || $modelsUiStore.selectedTableName === "")
-        modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
+      if (
+        ($isLocalSegmentationModel &&
+          ($modelsUiStore.selectedModelName === "" || $modelsUiStore.selectedTableName === "")) ||
+        (!$isLocalSegmentationModel &&
+          $pixanoInferenceSegmentationModelsStore.filter((m) => m.selected).length > 0)
+      )
+        configSmartToolClick();
     } else selectTool(panTool);
+  };
+
+  const configSmartToolClick = () => {
+    modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
   };
 
   interactiveSegmenterModel.subscribe((segmenter) => {
@@ -142,6 +154,13 @@ License: CECILL-C
         selected={$selectedTool?.type === ToolType.Rectangle && $selectedTool.isSmart}
       >
         <Square />
+      </IconButton>
+      <div class="w-1 -m-3.5 h-full bg-primary-light"></div>
+      <IconButton
+        tooltipContent={"Smart segmentation model settings"}
+        on:click={() => configSmartToolClick()}
+      >
+        <Settings />
       </IconButton>
     {/if}
   </div>

--- a/ui/components/vqaCanvas/src/features/manageModels/components/ConnectModal.svelte
+++ b/ui/components/vqaCanvas/src/features/manageModels/components/ConnectModal.svelte
@@ -21,9 +21,7 @@ License: CECILL-C
   const dispatch = createEventDispatcher();
 
   async function handleConnect() {
-    console.log("handleConnect");
     isConnected = await api.isInferenceApiHealthy(formData.pi_url);
-    console.log("handleConnect end", isConnected);
     if (isConnected) {
       dispatch("listModels");
       dispatch("cancelConnect"); //also close modal

--- a/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
+++ b/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
@@ -54,7 +54,7 @@ License: CECILL-C
     isInferenceApiConnected = await api.isInferenceApiHealthy(url);
     if (isInferenceApiConnected) {
       await listModels();
-    } else return Promise.reject();
+    } else return Promise.reject(new Error(`Unable to connect to Pixano Inference at ${url}`));
   }
 
   const listModels = async () => {
@@ -90,8 +90,8 @@ License: CECILL-C
     );
   };
 
-  connectToPixanoInference().catch(() => {
-    console.warn(`Pixano Inference API not connected on ${url}`);
+  connectToPixanoInference().catch((err) => {
+    console.warn(err);
   });
 
   const handleKeyDown = (

--- a/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
+++ b/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
@@ -54,11 +54,8 @@ License: CECILL-C
     isInferenceApiConnected = await api.isInferenceApiHealthy(url);
     if (isInferenceApiConnected) {
       await listModels();
-    }
+    } else return Promise.reject();
   }
-
-  //Try to connect with default URL at startup
-  //onMount(connectToPixanoInference);
 
   const listModels = async () => {
     const availableModels = await api.listModels();
@@ -94,7 +91,7 @@ License: CECILL-C
   };
 
   connectToPixanoInference().catch(() => {
-    console.error("Can't connect to Pixano Inference API");
+    console.warn(`Pixano Inference API not connected on ${url}`);
   });
 
   const handleKeyDown = (

--- a/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
+++ b/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
@@ -6,7 +6,6 @@ License: CECILL-C
 
 <script lang="ts">
   import { Plus, Settings, Sparkles } from "lucide-svelte";
-  import { onMount } from "svelte";
 
   import {
     api,
@@ -59,7 +58,7 @@ License: CECILL-C
   }
 
   //Try to connect with default URL at startup
-  onMount(connectToPixanoInference);
+  //onMount(connectToPixanoInference);
 
   const listModels = async () => {
     const availableModels = await api.listModels();

--- a/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
+++ b/ui/components/vqaCanvas/src/features/manageModels/components/ModelManagerForm.svelte
@@ -97,57 +97,6 @@ License: CECILL-C
     console.error("Can't connect to Pixano Inference API");
   });
 
-  const handleOpenConnectModal = (event: MouseEvent) => {
-    // stopPropgation is not called as event modifier
-    // because event modifiers can only be used on DOM elements
-    event.stopPropagation();
-    if (showConnectModal) {
-      handleCloseConnectModal();
-    } else {
-      showConnectModal = true;
-      document.body.addEventListener("click", handleCloseConnectModal);
-    }
-  };
-
-  const handleCloseConnectModal = () => {
-    showConnectModal = false;
-    document.body.removeEventListener("click", handleCloseConnectModal);
-  };
-
-  const handleOpenAddModelModal = (event: MouseEvent) => {
-    // stopPropgation is not called as event modifier
-    // because event modifiers can only be used on DOM elements
-    event.stopPropagation();
-    if (showAddModelModal) {
-      handleCloseAddModelModal();
-    } else {
-      showAddModelModal = true;
-      document.body.addEventListener("click", handleCloseAddModelModal);
-    }
-  };
-
-  const handleCloseAddModelModal = () => {
-    showAddModelModal = false;
-    document.body.removeEventListener("click", handleCloseAddModelModal);
-  };
-
-  const handleOpenPromptModal = (event: MouseEvent) => {
-    // stopPropgation is not called as event modifier
-    // because event modifiers can only be used on DOM elements
-    event.stopPropagation();
-    if (showPromptModal) {
-      handleClosePromptModal();
-    } else {
-      showPromptModal = true;
-      document.body.addEventListener("click", handleClosePromptModal);
-    }
-  };
-
-  const handleClosePromptModal = () => {
-    showPromptModal = false;
-    document.body.removeEventListener("click", handleClosePromptModal);
-  };
-
   const handleKeyDown = (
     event: KeyboardEvent & {
       currentTarget: EventTarget & Window;
@@ -162,7 +111,10 @@ License: CECILL-C
 </script>
 
 <div class="flex flex-row gap-2">
-  <IconButton tooltipContent="Pixano Inference connection" on:click={handleOpenConnectModal}>
+  <IconButton
+    tooltipContent="Pixano Inference connection"
+    on:click={() => (showConnectModal = !showConnectModal)}
+  >
     <Sparkles
       size={20}
       class={isInferenceApiConnected
@@ -191,14 +143,14 @@ License: CECILL-C
       ? "Instantiate a model"
       : "Pixano Inference is not connected"}
     disabled={!isInferenceApiConnected}
-    on:click={handleOpenAddModelModal}
+    on:click={() => (showAddModelModal = !showAddModelModal)}
   >
     <Plus />
   </IconButton>
   <IconButton
     tooltipContent="Configure generation prompts and temperature"
     disabled={$completionModelsStore.length === 0}
-    on:click={handleOpenPromptModal}
+    on:click={() => (showPromptModal = !showPromptModal)}
   >
     <Settings />
   </IconButton>
@@ -210,7 +162,7 @@ License: CECILL-C
     {vqaSectionWidth}
     {url}
     bind:isConnected={isInferenceApiConnected}
-    on:cancelConnect={handleCloseConnectModal}
+    on:cancelConnect={() => (showConnectModal = false)}
     on:listModels={listModels}
   />
 {/if}
@@ -219,10 +171,10 @@ License: CECILL-C
   <AddModelModal
     {vqaSectionWidth}
     on:listModels={listModels}
-    on:cancelAddModel={handleCloseAddModelModal}
+    on:cancelAddModel={() => (showAddModelModal = false)}
   />
 {/if}
 
 {#if showPromptModal}
-  <ConfigurePromptModal {vqaSectionWidth} on:cancelPrompt={handleClosePromptModal} />
+  <ConfigurePromptModal {vqaSectionWidth} on:cancelPrompt={() => (showPromptModal = false)} />
 {/if}


### PR DESCRIPTION
## Description

Allow SAM2 (or other segmentation model with same input / output) with Pixano Inference, using actual inputs

![image](https://github.com/user-attachments/assets/4fe61fdd-0c3d-4233-b363-5568b5c4b76b)
User is asked to enter either local or Pixano Inference model (in which case it can be added if not previously registered).
This is asked when clicking on the smart tool button if no model is set. Later you can access this panel with the "settings" button.

TODO: 
- [x] : allow user to choose Pixano Inference URL (currently fixed default http://localhost:9152)