### PR TITLE
feature update: missing MultiModalEntity in allowed Entities

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -201,7 +201,11 @@ License: CECILL-C
     propertyName: string,
     obj: Item | Entity | Annotation,
   ) => {
-    if ([BaseSchema.Track, BaseSchema.Entity].includes(obj.table_info.base_schema)) {
+    if (
+      [BaseSchema.Track, BaseSchema.Entity, BaseSchema.MultiModalEntity].includes(
+        obj.table_info.base_schema,
+      )
+    ) {
       entities.update((oldObjects) =>
         oldObjects.map((object) => {
           if (object === obj) {


### PR DESCRIPTION
## Issue

In a EntityLinking workspace, features edition doesn't work

## Description

In EntityLinking, entities are MultiModalEntity, and where not correctly handled by previous filter (only on Track and Entity)
Added MultiModalEntity to allowed kind of entities