### PR TITLE
allow SAM2 tracking

### DIFF
--- a/pixano/app/routers/inference/mask_generation.py
+++ b/pixano/app/routers/inference/mask_generation.py
@@ -13,8 +13,17 @@ from pixano.app.models import AnnotationModel, EntityModel, TableInfo, ViewModel
 from pixano.app.routers.inference.utils import get_client_from_settings
 from pixano.app.routers.utils import get_dataset
 from pixano.app.settings import Settings, get_settings
-from pixano.features import BBox, CompressedRLE, Entity, Image, NDArrayFloat, is_image
-from pixano.inference import image_mask_generation
+from pixano.features import (
+    BBox,
+    CompressedRLE,
+    Entity,
+    Image,
+    NDArrayFloat,
+    SequenceFrame,
+    is_image,
+    is_sequence_frame,
+)
+from pixano.inference import image_mask_generation, video_mask_generation
 
 from .utils import get_model_source
 
@@ -101,5 +110,72 @@ async def call_image_mask_generation(
             row=mask_output[0],  # right now we don't use other ouputs (score, ...)
             table_info=TableInfo(name=mask_table_name, group="annotations", base_schema="CompressedRLE"),
         )
+    )
+    return output
+
+
+class VideoMaskGenerationOutput(BaseModel):
+    """Video masks generation output."""
+
+    masks: list[AnnotationModel]
+
+
+@router.post(
+    "/video",
+    response_model=VideoMaskGenerationOutput,
+)
+async def call_video_mask_generation(
+    dataset_id: Annotated[str, Body(embed=True)],
+    video: Annotated[list[ViewModel], Body(embed=True)],
+    model: Annotated[str, Body(embed=True)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    bbox: Annotated[BBox | None, Body(embed=True)] = None,
+    points: Annotated[list[list[int]] | None, Body(embed=True)] = None,
+    labels: Annotated[list[int] | None, Body(embed=True)] = None,
+) -> VideoMaskGenerationOutput:
+    """Perform video mask generation on a video.
+
+    Args:
+        dataset_id: The ID of the dataset to use.
+        video: The video as a list of SequenceFrame (or a subset).
+        model: The name of the model to use.
+        settings: App settings.
+        bbox: Input bounding box or None.
+        points: Input points or None.
+        labels: Labels for input points, or None.
+
+    Returns:
+        The generated masks.
+    """
+    dataset = get_dataset(dataset_id=dataset_id, dir=settings.library_dir, media_dir=settings.media_dir)
+    client = get_client_from_settings(settings=settings)
+
+    if not is_sequence_frame(dataset.schema.schemas[video[0].table_info.name]):
+        raise HTTPException(status_code=400, detail="Video must be a list of SequenceFrame.")
+
+    video_row: list[SequenceFrame] = [vm.to_row(dataset) for vm in video]
+    source = get_model_source(dataset=dataset, model=model)
+
+    try:
+        mask_output: tuple[list[CompressedRLE], list[int], list[int]] = await video_mask_generation(
+            client=client,
+            source=source,
+            media_dir=settings.media_dir,
+            video=video_row,
+            bbox=bbox,
+            points=points,
+            labels=labels,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    output: VideoMaskGenerationOutput = VideoMaskGenerationOutput(
+        masks=[
+            AnnotationModel.from_row(
+                row=m,  # only use mask (don't send obj_ids & frame_idx => viewRef has the frame_index info)
+                table_info=TableInfo(name="mask_table_name", group="annotations", base_schema="CompressedRLE"),
+            )
+            for m in mask_output[0]
+        ]
     )
     return output

--- a/pixano/datasets/utils/mosaic.py
+++ b/pixano/datasets/utils/mosaic.py
@@ -97,9 +97,12 @@ def create_mosaic(
         img_rgb = Image.new("RGB", img_resized.size, (0, 0, 0))
         img_rgb.paste(img_resized, mask=img_resized.split()[3])  # Apply alpha channel
         # Add label
-        label_text = f"{label_prefix} {idx + 1}"
-        img_labeled = add_label_above(img_rgb, label_text, label_height)
-        images_resized.append(img_labeled)
+        if label_prefix != "":
+            label_text = f"{label_prefix} {idx + 1}"
+            img_labeled = add_label_above(img_rgb, label_text, label_height)
+            images_resized.append(img_labeled)
+        else:
+            images_resized.append(img_rgb)
 
     mosaic_width = cols * (avg_width + padding) - padding
     mosaic_height = rows * (avg_height + label_height + padding) - padding
@@ -117,7 +120,7 @@ def create_mosaic(
 
 
 def mosaic(source_dir: Path, split: str, image_files: list[str], view_name: str, mosaic_filename: str = "") -> str:
-    """Create a mosaic from input images."""
+    """Create a mosaic from input images. Add a label if view_name is not empty string."""
     if not mosaic_filename:
         mosaic_filename = generate_mosaic_name(image_files)
     create_mosaic(source_dir, split, image_files, mosaic_filename, label_prefix=view_name, label_height=30, padding=5)

--- a/pixano/datasets/workspaces/dataset_items.py
+++ b/pixano/datasets/workspaces/dataset_items.py
@@ -39,6 +39,7 @@ class DefaultVideoDatasetItem(DatasetItem):
     tracks: list[Track]
     tracklets: list[Tracklet]
     bboxes: list[BBox]
+    masks: list[CompressedRLE]
     keypoints: list[KeyPoints]
 
 

--- a/pixano/inference/__init__.py
+++ b/pixano/inference/__init__.py
@@ -6,7 +6,7 @@
 
 from pixano_inference.client import PixanoInferenceClient
 
-from .mask_generation import image_mask_generation
+from .mask_generation import image_mask_generation, video_mask_generation
 from .text_image_conditional_generation import messages_to_prompt, text_image_conditional_generation
 from .zero_shot_detection import image_zero_shot_detection
 
@@ -14,6 +14,7 @@ from .zero_shot_detection import image_zero_shot_detection
 __all__ = [
     "PixanoInferenceClient",
     "image_mask_generation",
+    "video_mask_generation",
     "messages_to_prompt",
     "text_image_conditional_generation",
     "image_zero_shot_detection",

--- a/pixano/inference/mask_generation.py
+++ b/pixano/inference/mask_generation.py
@@ -162,7 +162,7 @@ async def video_mask_generation(
         resolution features The features are returned if not provided in the arguments otherwise None is returned.
     """
     if not isinstance(video, list):
-        raise "Video format not currently supported, please use sequence frames."
+        raise ValueError("Video format not currently supported, please use sequence frames.")
     video_request = [sf.url if is_url(sf.url) else sf.open(media_dir, "base64") for sf in video]
 
     if points is not None:

--- a/pixano/inference/mask_generation.py
+++ b/pixano/inference/mask_generation.py
@@ -12,10 +12,16 @@ from fastapi.encoders import jsonable_encoder
 from pixano_inference.client import PixanoInferenceClient
 from pixano_inference.pydantic import LanceVector
 from pixano_inference.pydantic.tasks import CompressedRLE as PixanoInferenceCompressedRLE
-from pixano_inference.pydantic.tasks import ImageMaskGenerationRequest, ImageMaskGenerationResponse
+from pixano_inference.pydantic.tasks import (
+    ImageMaskGenerationRequest,
+    ImageMaskGenerationResponse,
+    VideoMaskGenerationOutput,
+    VideoMaskGenerationRequest,
+    VideoMaskGenerationResponse,
+)
 from pixano_inference.utils import is_url
 
-from pixano.features import BBox, CompressedRLE, Image, NDArrayFloat, Source, ViewEmbedding
+from pixano.features import BBox, CompressedRLE, Image, NDArrayFloat, SequenceFrame, Source, ViewEmbedding
 from pixano.features.schemas.entities.entity import Entity
 from pixano.features.types.schema_reference import EntityRef, SourceRef, ViewRef
 
@@ -125,3 +131,99 @@ async def image_mask_generation(
     score = response.data.scores.values[0]
 
     return mask, score, response.data.image_embedding, response.data.high_resolution_features
+
+
+async def video_mask_generation(
+    client: PixanoInferenceClient,
+    media_dir: Path,
+    video: list[SequenceFrame],
+    source: Source,
+    entity: Entity | None = None,
+    bbox: BBox | None = None,
+    points: list[list[int]] | None = None,
+    labels: list[int] | None = None,
+    **client_kwargs: Any,
+) -> tuple[list[CompressedRLE], list[int], list[int]]:
+    """Image mask generation task.
+
+    Args:
+        client: Pixano inference client.
+        media_dir: Media directory.
+        video: Video as list of SequenceFrame.
+        source: The source refering to the model.
+        entity: Entity to put objects in, if provided.
+        bbox: Bounding box of the object in the original image.
+        points: Points to generate mask for.
+        labels: Labels of the points. If 0, the point is background else the point is foreground.
+        client_kwargs: Additional kwargs for the client to be passed.
+
+    Returns:
+        tuple of the compressed RLE mask, its score, the source of the image, the image embeddings and the high
+        resolution features The features are returned if not provided in the arguments otherwise None is returned.
+    """
+    if not isinstance(video, list):
+        raise "Video format not currently supported, please use sequence frames."
+    video_request = [sf.url if is_url(sf.url) else sf.open(media_dir, "base64") for sf in video]
+
+    if points is not None:
+        points_request = [points]
+    else:
+        points_request = None
+    if labels is not None:
+        labels_request = [labels]
+    else:
+        labels_request = None
+    if bbox is not None:
+        if bbox.is_normalized:
+            bbox = bbox.denormalize(height=video[0].height, width=video[0].width)
+        bbox_request = [[int(c) for c in bbox.xyxy_coords]]
+    else:
+        bbox_request = None
+
+    request = VideoMaskGenerationRequest(
+        video=video_request,
+        objects_ids=range(len(video)),
+        frame_indexes=range(len(video)),
+        boxes=bbox_request,
+        points=points_request,
+        labels=labels_request,
+        model=source.name,
+    )
+
+    response: VideoMaskGenerationResponse = await client.video_mask_generation(request, **client_kwargs)
+
+    inference_metadata = jsonable_encoder(
+        {
+            "timestamp": response.timestamp,
+            "processing_time": response.processing_time,
+            **response.metadata,
+        }
+    )
+
+    masks: list[CompressedRLE] = []
+    objects_ids: list[int] = []
+    frame_indexes: list[int] = []
+
+    if response.status == "SUCCESS":
+        output: VideoMaskGenerationOutput = response.data
+        entity_ref_id = shortuuid.uuid()  # used to check masks are from same generation when no entity in input
+
+        for o_mask, obj_id, frame_idx in zip(output.masks, output.objects_ids, output.frame_indexes):
+            image = video[frame_idx]
+            mask_inference: PixanoInferenceCompressedRLE = o_mask
+            mask = CompressedRLE(
+                id=shortuuid.uuid(),
+                item_ref=image.item_ref,
+                view_ref=ViewRef(name=image.table_name, id=image.id),
+                entity_ref=EntityRef(name=entity.table_name, id=entity.id)
+                if entity
+                else EntityRef(name="", id=entity_ref_id),
+                source_ref=SourceRef(id=source.id),
+                inference_metadata=inference_metadata,
+                **mask_inference.model_dump(),
+            )
+            masks.append(mask)
+            objects_ids.append(obj_id)
+            frame_indexes.append(frame_idx)
+
+    return masks, objects_ids, frame_indexes

--- a/tests/app/routers/test_inference/test_mask_generation.py
+++ b/tests/app/routers/test_inference/test_mask_generation.py
@@ -11,7 +11,7 @@ from fastapi.encoders import jsonable_encoder
 from starlette.testclient import TestClient
 
 from pixano.app.models import AnnotationModel, TableInfo
-from pixano.app.routers.inference.mask_generation import ImageMaskGenerationOutput
+from pixano.app.routers.inference.mask_generation import ImageMaskGenerationOutput, VideoMaskGenerationOutput
 from pixano.app.settings import Settings
 from pixano.datasets.dataset import Dataset
 from pixano.features import CompressedRLE, SchemaGroup
@@ -33,6 +33,43 @@ sample_input_json = {
     },
     "model": "model",
     "mask_table_name": "mask_image",
+    "bbox": {
+        "id": "",
+        "created_at": "2025-05-15T13:31:08.690",
+        "updated_at": "2025-05-15T13:31:08.690",
+        "item_ref": {"name": "", "id": ""},
+        "view_ref": {"name": "", "id": ""},
+        "entity_ref": {"name": "", "id": ""},
+        "source_ref": {"name": "", "id": ""},
+        "coords": [10, 10, 50, 50],
+        "format": "xywh",
+        "is_normalized": False,
+        "confidence": -1,
+    },
+}
+
+sample_input_video_json = {
+    "dataset_id": "dataset_multi_view_tracking_and_image",
+    "video": [
+        {
+            "data": {
+                "format": "JPEG",
+                "height": 640,
+                "item_ref": {"id": "1", "name": "item"},
+                "parent_ref": {"id": "", "name": ""},
+                "url": "video_0.jpg",
+                "width": 586,
+                "frame_index": 0,
+                "timestamp": 0,
+                "category": "something",
+            },
+            "id": "orange_cats",
+            "table_info": {"base_schema": "SequenceFrame", "group": "views", "name": "video"},
+            "created_at": "2025-05-15T13:31:08.690",
+            "updated_at": "2025-05-15T13:31:08.690",
+        }
+    ],
+    "model": "model",
     "bbox": {
         "id": "",
         "created_at": "2025-05-15T13:31:08.690",
@@ -72,6 +109,7 @@ def test_call_mask_generation(
     url = "/inference/tasks/mask-generation/image"
 
     response = client.post(url, json=json)
+    print("RESPONSE:", response, response.json())
     assert response.status_code == 200
     assert expected_output.mask.to_row(dataset_multi_view_tracking_and_image).model_dump(
         exclude="id", exclude_timestamps=True
@@ -114,3 +152,84 @@ def test_call_image_mask_generation_error(
     response = client.post(url, json=json)
     assert response.status_code == 400
     assert response.json() == {"detail": "Image must be an image."}
+
+
+@patch("pixano.app.routers.inference.mask_generation.video_mask_generation")
+def test_call_video_mask_generation(
+    mock_video_mask_generation,
+    app_and_settings_with_client_copy: tuple[FastAPI, Settings, TestClient],
+    dataset_multi_view_tracking_and_image: Dataset,
+):
+    app, settings, client = app_and_settings_with_client_copy
+
+    expected_output = VideoMaskGenerationOutput(
+        masks=[
+            AnnotationModel.from_row(
+                row=CompressedRLE(counts=b"xx", size=[400, 400]),
+                table_info=TableInfo(
+                    name="mask_image", group=SchemaGroup.ANNOTATION.value, base_schema="CompressedRLE"
+                ),
+            )
+        ]
+    )
+    mock_video_mask_generation.return_value = ([CompressedRLE(counts=b"xx", size=[400, 400])], [0], [0])
+
+    json = jsonable_encoder(sample_input_video_json)
+
+    url = "/inference/tasks/mask-generation/video"
+
+    response = client.post(url, json=json)
+    print(response, response.json())
+    assert response.status_code == 200
+    # route put an incorrect (but unused) "mask_table_name" for generated masks table name
+    # here we need to put the correct mask table name from dataset_multi_view_tracking_and_image: "mask_image"
+    ann_model_response = AnnotationModel.model_validate(response.json()["masks"][0])
+    assert ann_model_response.table_info.name == "mask_table_name"
+    ann_model_response.table_info.name = "mask_image"
+    assert expected_output.masks[0].to_row(dataset_multi_view_tracking_and_image).model_dump(
+        exclude="id", exclude_timestamps=True
+    ) == ann_model_response.to_row(dataset_multi_view_tracking_and_image).model_dump(
+        exclude="id", exclude_timestamps=True
+    )
+
+    dataset = Dataset.find(
+        "dataset_multi_view_tracking_and_image", directory=settings.library_dir, media_dir=settings.media_dir
+    )
+    sources = dataset.get_data("source", limit=10)
+    assert len(sources) == 4
+
+    # Execute again to check the source is not created again.
+    response = client.post(url, json=json)
+    assert response.status_code == 200
+    # route put an incorrect (but unused) "mask_table_name" for generated masks table name
+    # here we need to put the correct mask table name from dataset_multi_view_tracking_and_image: "mask_image"
+    ann_model_response = AnnotationModel.model_validate(response.json()["masks"][0])
+    assert ann_model_response.table_info.name == "mask_table_name"
+    ann_model_response.table_info.name = "mask_image"
+
+    assert expected_output.masks[0].to_row(dataset_multi_view_tracking_and_image).model_dump(
+        exclude="id", exclude_timestamps=True
+    ) == ann_model_response.to_row(dataset_multi_view_tracking_and_image).model_dump(
+        exclude="id", exclude_timestamps=True
+    )
+
+    dataset = Dataset.find(
+        "dataset_multi_view_tracking_and_image", directory=settings.library_dir, media_dir=settings.media_dir
+    )
+    sources = dataset.get_data("source", limit=10)
+    assert len(sources) == 4
+
+
+def test_call_video_mask_generation_error(
+    app_and_settings_with_client_copy: tuple[FastAPI, Settings, TestClient],
+):
+    app, settings, client = app_and_settings_with_client_copy
+
+    url = "/inference/tasks/mask-generation/video"
+
+    # name must be an existing table name, but not the correct one
+    sample_input_video_json["video"][0]["table_info"].update({"name": "mask_image"})
+    json = jsonable_encoder(sample_input_video_json)
+    response = client.post(url, json=json)
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Video must be a list of SequenceFrame."}

--- a/tests/datasets/utils/test_mosaic.py
+++ b/tests/datasets/utils/test_mosaic.py
@@ -1,0 +1,75 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from pixano.datasets.utils.mosaic import (
+    add_label_above,
+    arrange_grid,
+    compute_average_size,
+    create_mosaic,
+    generate_mosaic_name,
+    mosaic,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
+
+
+def test_generate_mosaic_name():
+    image_files = ["/path/to/image1.jpg", "/path/to/image2.jpg"]
+    assert generate_mosaic_name(image_files) == "/path/to/image_mosaic.jpg"
+
+    image_files = []
+    assert generate_mosaic_name(image_files) == "mosaic.jpg"
+
+
+def test_arrange_grid():
+    assert arrange_grid(4) == (2, 2)
+    assert arrange_grid(5) == (2, 3)
+    assert arrange_grid(9) == (3, 3)
+
+
+def test_compute_average_size():
+    images = [Image.new("RGB", (100, 200)), Image.new("RGB", (200, 300))]
+    assert compute_average_size(images) == (150, 250)
+
+
+def test_add_label_above():
+    image = Image.new("RGB", (100, 200), color="red")
+    labeled_image = add_label_above(image, "Test Label")
+    assert labeled_image.size == (100, 230)  # 200 + 30 (label_height)
+
+
+def test_create_mosaic(temp_dir):
+    # Create some test images
+    image_files = ["image1.jpg", "image2.jpg"]
+    for img_file in image_files:
+        img = Image.new("RGB", (100, 100), color="red")
+        img.save(temp_dir / img_file)
+
+    output_path = "mosaic.jpg"
+    create_mosaic(temp_dir, "", image_files, output_path, label_prefix="Test", padding=10, label_height=30)
+
+    assert (temp_dir / output_path).exists()
+
+
+def test_mosaic(temp_dir):
+    # Create some test images
+    image_files = ["image1.jpg", "image2.jpg"]
+    for img_file in image_files:
+        img = Image.new("RGB", (100, 100), color="red")
+        img.save(temp_dir / img_file)
+
+    mosaic_filename = mosaic(temp_dir, "", image_files, "Test View", "")
+    assert (temp_dir / mosaic_filename).exists()

--- a/tests/inference/test_mask_generation.py
+++ b/tests/inference/test_mask_generation.py
@@ -19,6 +19,8 @@ from pixano_inference.pydantic import (
 from pixano_inference.pydantic import (
     ImageMaskGenerationOutput,
     ImageMaskGenerationResponse,
+    VideoMaskGenerationOutput,
+    VideoMaskGenerationResponse,
 )
 
 from pixano.features import (
@@ -34,7 +36,7 @@ from pixano.features import (
     ViewEmbedding,
     ViewRef,
 )
-from pixano.inference.mask_generation import image_mask_generation
+from pixano.inference.mask_generation import image_mask_generation, video_mask_generation
 
 
 FILE_PATH = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -184,3 +186,116 @@ async def test_image_mask_generation(
     assert score == expected_score
     assert out_image_embedding == expected_image_embedding
     assert out_high_resolution_features == expected_high_resolution_features
+
+
+@pytest.mark.asyncio
+@patch("pixano_inference.client.PixanoInferenceClient.video_mask_generation")
+@pytest.mark.parametrize(
+    "response, expected_output, bbox, points, labels",
+    [
+        (
+            VideoMaskGenerationResponse(
+                id="id",
+                status="SUCCESS",
+                timestamp=datetime(year=2025, month=2, day=19),
+                processing_time=1.0,
+                metadata={"metadata": "value"},
+                data=VideoMaskGenerationOutput(
+                    masks=[PixanoInferenceCompressedRLE(size=[10, 2], counts=bytes([3, 4]))],
+                    objects_ids=[0],
+                    frame_indexes=[0],
+                ),
+            ),
+            (
+                CompressedRLE(
+                    size=[10, 2],
+                    counts=bytes([3, 4]),
+                    entity_ref=EntityRef(id="test_entity", name="entity"),
+                    view_ref=ViewRef(id="image", name="image"),
+                    item_ref=ItemRef(id="test_item"),
+                    source_ref=SourceRef(id="test_source"),
+                    inference_metadata=jsonable_encoder(
+                        {
+                            "timestamp": datetime(year=2025, month=2, day=19),
+                            "processing_time": 1.0,
+                            "metadata": "value",
+                        }
+                    ),
+                ),
+                [0],
+                [0],
+            ),
+            None,
+            None,
+            None,
+        ),
+        (
+            VideoMaskGenerationResponse(
+                id="id",
+                status="SUCCESS",
+                timestamp=datetime(year=2025, month=2, day=19),
+                processing_time=1.0,
+                metadata={"metadata": "value"},
+                data=VideoMaskGenerationOutput(
+                    masks=[PixanoInferenceCompressedRLE(size=[10, 2], counts=bytes([3, 4]))],
+                    objects_ids=[0],
+                    frame_indexes=[0],
+                ),
+            ),
+            (
+                CompressedRLE(
+                    size=[10, 2],
+                    counts=bytes([3, 4]),
+                    entity_ref=EntityRef(id="test_entity", name="entity"),
+                    view_ref=ViewRef(id="image", name="image"),
+                    item_ref=ItemRef(id="test_item"),
+                    source_ref=SourceRef(id="test_source"),
+                    inference_metadata=jsonable_encoder(
+                        {
+                            "timestamp": datetime(year=2025, month=2, day=19),
+                            "processing_time": 1.0,
+                            "metadata": "value",
+                        }
+                    ),
+                ),
+                [0],
+                [0],
+            ),
+            BBox(coords=[1, 2, 3, 4], is_normalized=False, format="xyxy"),
+            [[1, 2]],
+            [0],
+        ),
+    ],
+)
+async def test_video_mask_generation(
+    mock_video_mask_generation,
+    simple_pixano_inference_client: PixanoInferenceClient,
+    response: ImageMaskGenerationResponse,
+    expected_output: tuple[CompressedRLE, float, NDArrayFloat | None, list[NDArrayFloat] | None],
+    bbox: BBox | None,
+    points: list[list[int]] | None,
+    labels: list[int],
+    image_url: Image,
+):
+    mock_video_mask_generation.return_value = response
+
+    entity = Entity(id="test_entity")
+    entity.table_name = "entity"
+
+    masks, objects_ids, frame_indexes = await video_mask_generation(
+        client=simple_pixano_inference_client,
+        media_dir=Path("."),
+        video=[image_url],
+        entity=entity,
+        source=Source(id="test_source", name="test_source", kind="model"),
+        bbox=bbox,
+        points=points,
+        labels=labels,
+    )
+
+    expected_mask, expected_objects_ids, expected_frame_indexes = expected_output
+
+    exclude_keys = ["id", "created_at", "updated_at"]
+    assert masks[0].model_dump(exclude=exclude_keys) == expected_mask.model_dump(exclude=exclude_keys)
+    assert objects_ids == expected_objects_ids
+    assert frame_indexes == expected_frame_indexes

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -29,6 +29,7 @@ License: CECILL-C
     type Vertex,
   } from "@pixano/core";
   import { cn } from "@pixano/core/src";
+  import { pixanoInferenceToValidateTrackingMasks } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
   import type { Filters } from "@pixano/dataset-item-workspace/src/lib/types/datasetItemWorkspaceTypes";
   import type { Box, InteractiveImageSegmenterOutput, LabeledClick } from "@pixano/models";
   import { convertSegmentsToSVG, generatePolygonSegments } from "@pixano/models/src/mask_utils";
@@ -1009,6 +1010,7 @@ License: CECILL-C
     for (const view_name of Object.keys(imagesPerView)) {
       clearInputs(view_name);
       clearCurrentAnn(view_name, stage, selectedTool);
+      pixanoInferenceToValidateTrackingMasks.set([]);
     }
     if (selectedTool) {
       stage.container().style.cursor = selectedTool.cursor;

--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -29,7 +29,10 @@ License: CECILL-C
     type Vertex,
   } from "@pixano/core";
   import { cn } from "@pixano/core/src";
-  import { pixanoInferenceToValidateTrackingMasks } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
+  import {
+    pixanoInferenceToValidateTrackingMasks,
+    pixanoInferenceTracking,
+  } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
   import type { Filters } from "@pixano/dataset-item-workspace/src/lib/types/datasetItemWorkspaceTypes";
   import type { Box, InteractiveImageSegmenterOutput, LabeledClick } from "@pixano/models";
   import { convertSegmentsToSVG, generatePolygonSegments } from "@pixano/models/src/mask_utils";
@@ -87,6 +90,8 @@ License: CECILL-C
   let numberOfBBoxes: number;
   let prevSelectedTool: SelectionTool;
   let zoomFactor: Record<string, number> = {}; // {view_name: zoomFactor}
+
+  let lastInputViewRef: Reference;
 
   $: {
     if (
@@ -455,6 +460,18 @@ License: CECILL-C
 
   // ********** BOUNDING BOXES AND MASKS ********** //
 
+  // launch tracking on validate
+  $: if (
+    isVideo &&
+    !$isLocalSegmentationModel &&
+    $pixanoInferenceTracking.mustValidate &&
+    $pixanoInferenceTracking.validated
+  ) {
+    if (lastInputViewRef != undefined) {
+      void updateCurrentMask(lastInputViewRef);
+    }
+  }
+
   async function updateCurrentMask(viewRef: Reference) {
     let results: SegmentationResult = null;
 
@@ -480,23 +497,31 @@ License: CECILL-C
       }
     } else {
       // infer
-      const pixinf_res = await pixanoInferenceSegmentation(viewRef, points, box);
-      if (pixinf_res) {
-        const maskPolygons = generatePolygonSegments(
-          pixinf_res.data.counts as number[],
-          currentImage.height,
-        );
-        const masksSVG = convertSegmentsToSVG(maskPolygons);
+      if (
+        (isVideo &&
+          (($pixanoInferenceTracking.mustValidate && $pixanoInferenceTracking.validated) ||
+            !$pixanoInferenceTracking.mustValidate)) ||
+        !isVideo
+      ) {
+        const pixinf_res = await pixanoInferenceSegmentation(viewRef, points, box);
+        $pixanoInferenceTracking.validated = false;
+        if (pixinf_res) {
+          const maskPolygons = generatePolygonSegments(
+            pixinf_res.data.counts as number[],
+            currentImage.height,
+          );
+          const masksSVG = convertSegmentsToSVG(maskPolygons);
 
-        results = {
-          masksImageSVG: masksSVG,
-          rle: {
-            counts: pixinf_res.data.counts,
-            size: pixinf_res.data.size,
-            id: pixinf_res.id,
-            ref_name: pixinf_res.table_info.name,
-          },
-        };
+          results = {
+            masksImageSVG: masksSVG,
+            rle: {
+              counts: pixinf_res.data.counts,
+              size: pixinf_res.data.size,
+              id: pixinf_res.id,
+              ref_name: pixinf_res.table_info.name,
+            },
+          };
+        }
       }
     }
 
@@ -812,6 +837,7 @@ License: CECILL-C
     } else if (drag_point.y() > img_size.height) {
       drag_point.y(img_size.height);
     }
+    lastInputViewRef = viewRef;
 
     // new currentAnn on new location
     clearTimeout(timerId); // reinit timer on each move move
@@ -974,13 +1000,14 @@ License: CECILL-C
             };
           }
           if (selectedTool.isSmart) {
+            lastInputViewRef = viewRef;
             await updateCurrentMask(viewRef);
           }
         }
         viewLayer.off("pointermove");
         viewLayer.off("pointerup");
       }
-      if (selectedTool.isSmart) {
+      if (selectedTool.isSmart && !$pixanoInferenceTracking.mustValidate) {
         rect.destroy();
       }
     }
@@ -1131,6 +1158,7 @@ License: CECILL-C
       const inputGroup: Konva.Group = viewLayer.findOne("#input");
       inputGroup.add(input_point);
       highlightInputPoint(input_point, viewRef.name);
+      lastInputViewRef = viewRef;
       await updateCurrentMask(viewRef);
     } else if (selectedTool?.type == ToolType.Rectangle) {
       viewLayer.on("pointermove", () => dragInputRectMove(viewRef));

--- a/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
@@ -9,7 +9,7 @@ License: CECILL-C
 
   import {
     api,
-    // ImageTask,
+    ImageTask,
     Input,
     LoadingModal,
     PrimaryButton,
@@ -17,6 +17,8 @@ License: CECILL-C
     type InputEvents,
     type ModelConfig,
   } from "../..";
+
+  export let isVideo: boolean = false;
 
   //TMP: default values
   const modelChoices = {
@@ -46,44 +48,23 @@ License: CECILL-C
 
   const handleAddModel = async () => {
     isAddingModelRequestPending = true;
-    // const model_config: ModelConfig = {
-    //   config: {
-    //     name: formData.model_name,
-    //     task: ImageTask.MASK_GENERATION,
-    //     path: formData.model_path,
-    //     config: { dtype: formData.dtype },
-    //     processor_config: {},
-    //   },
-    //   provider: formData.provider,
-    // };
-
-    // const success = await api.instantiateModel(model_config); //NOTE: take some time (~40sec)
-    // if (!success) {
-    //   console.error(`Couldn't instantiate model '${model_config.config.name}'`);
-    //   return;
-    // } else {
-    //   console.log(`Model '${model_config.config.name}' added.`);
-    // }
-
-    //Also add segmentation model for video (tracking)
-    const model_config_video: ModelConfig = {
+    const model_config: ModelConfig = {
       config: {
-        name: formData.model_name + "-video",
-        task: VideoTask.MASK_GENERATION,
+        name: formData.model_name + isVideo ? "-video" : "",
+        task: isVideo ? VideoTask.MASK_GENERATION : ImageTask.MASK_GENERATION,
         path: formData.model_path,
-        config: { torch_dtype: formData.dtype },
+        // Note: dtype or torch_dtype ? >> some model requires dtype, others torch_dtype, so use both
+        config: { dtype: formData.dtype, torch_dtype: formData.dtype },
         processor_config: {},
       },
       provider: formData.provider,
     };
-
-    const success_video = await api.instantiateModel(model_config_video);
-
-    if (!success_video) {
-      console.error(`Couldn't instantiate model '${model_config_video.config.name}' for tracking`);
+    const success = await api.instantiateModel(model_config); //NOTE: may take some time
+    if (!success) {
+      console.error(`Couldn't instantiate model '${model_config.config.name}'`);
       return;
     } else {
-      console.log(`Model '${model_config_video.config.name}' added.`);
+      console.log(`Model '${model_config.config.name}' added.`);
     }
 
     isAddingModelRequestPending = false;

--- a/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
@@ -50,7 +50,7 @@ License: CECILL-C
     isAddingModelRequestPending = true;
     const model_config: ModelConfig = {
       config: {
-        name: formData.model_name + isVideo ? "-video" : "",
+        name: formData.model_name + (isVideo ? "-video" : ""),
         task: isVideo ? VideoTask.MASK_GENERATION : ImageTask.MASK_GENERATION,
         path: formData.model_path,
         // Note: dtype or torch_dtype ? >> some model requires dtype, others torch_dtype, so use both

--- a/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
@@ -9,10 +9,11 @@ License: CECILL-C
 
   import {
     api,
-    ImageTask,
+    // ImageTask,
     Input,
     LoadingModal,
     PrimaryButton,
+    VideoTask,
     type InputEvents,
     type ModelConfig,
   } from "../..";
@@ -23,7 +24,7 @@ License: CECILL-C
       provider: "sam2",
       model_name: "SAM2",
       model_path: "facebook/sam2-hiera-tiny",
-      dtype: "bfloat16",
+      dtype: "float32",
     },
   };
   let formData = modelChoices["sam2"];
@@ -45,26 +46,47 @@ License: CECILL-C
 
   const handleAddModel = async () => {
     isAddingModelRequestPending = true;
-    const model_config: ModelConfig = {
+    // const model_config: ModelConfig = {
+    //   config: {
+    //     name: formData.model_name,
+    //     task: ImageTask.MASK_GENERATION,
+    //     path: formData.model_path,
+    //     config: { dtype: formData.dtype },
+    //     processor_config: {},
+    //   },
+    //   provider: formData.provider,
+    // };
+
+    // const success = await api.instantiateModel(model_config); //NOTE: take some time (~40sec)
+    // if (!success) {
+    //   console.error(`Couldn't instantiate model '${model_config.config.name}'`);
+    //   return;
+    // } else {
+    //   console.log(`Model '${model_config.config.name}' added.`);
+    // }
+
+    //Also add segmentation model for video (tracking)
+    const model_config_video: ModelConfig = {
       config: {
-        name: formData.model_name,
-        task: ImageTask.MASK_GENERATION,
+        name: formData.model_name + "-video",
+        task: VideoTask.MASK_GENERATION,
         path: formData.model_path,
-        config: { dtype: formData.dtype },
+        config: { torch_dtype: formData.dtype },
         processor_config: {},
       },
       provider: formData.provider,
     };
 
-    const success = await api.instantiateModel(model_config); //NOTE: take some time (~40sec)
+    const success_video = await api.instantiateModel(model_config_video);
 
-    if (!success) {
-      console.error(`Couldn't instantiate model '${model_config.config.name}'`);
+    if (!success_video) {
+      console.error(`Couldn't instantiate model '${model_config_video.config.name}' for tracking`);
       return;
+    } else {
+      console.log(`Model '${model_config_video.config.name}' added.`);
     }
 
     isAddingModelRequestPending = false;
-    console.log(`Model '${model_config.config.name}' added.`);
 
     dispatch("listModels");
     dispatch("cancelAddModel");

--- a/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
@@ -24,7 +24,7 @@ License: CECILL-C
   const modelChoices = {
     sam2: {
       provider: "sam2",
-      model_name: "SAM2",
+      model_name: "SAM2" + (isVideo ? "_video" : ""),
       model_path: "facebook/sam2-hiera-tiny",
       dtype: "float32",
     },
@@ -50,7 +50,7 @@ License: CECILL-C
     isAddingModelRequestPending = true;
     const model_config: ModelConfig = {
       config: {
-        name: formData.model_name + (isVideo ? "_video" : ""),
+        name: formData.model_name,
         task: isVideo ? VideoTask.MASK_GENERATION : ImageTask.MASK_GENERATION,
         path: formData.model_path,
         // Note: dtype or torch_dtype ? >> some model requires dtype, others torch_dtype, so use both
@@ -82,7 +82,7 @@ License: CECILL-C
   class="fixed top-[calc(80px+5px)] left-1/2 transform -translate-x-1/2 z-50 overflow-y-auto w-68 rounded-md bg-white text-slate-800 flex flex-col gap-3 item-center pb-3 max-h-[calc(100vh-80px-10px)]"
 >
   <div class="bg-primary p-3 rounded-b-none rounded-t-md text-white">
-    <p>Instantiate Segmentation model</p>
+    <p>Instantiate Segmentation model {isVideo ? " for Video" : ""}</p>
   </div>
   <div class="p-3 flex flex-col gap-2">
     <h5 class="font-medium">Provider (only use providers installed with pixano-inference)</h5>

--- a/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/AddModelModal.svelte
@@ -50,7 +50,7 @@ License: CECILL-C
     isAddingModelRequestPending = true;
     const model_config: ModelConfig = {
       config: {
-        name: formData.model_name + (isVideo ? "-video" : ""),
+        name: formData.model_name + (isVideo ? "_video" : ""),
         task: isVideo ? VideoTask.MASK_GENERATION : ImageTask.MASK_GENERATION,
         path: formData.model_path,
         // Note: dtype or torch_dtype ? >> some model requires dtype, others torch_dtype, so use both

--- a/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
@@ -8,8 +8,11 @@ License: CECILL-C
   import { Plus, Sparkles } from "lucide-svelte";
   import { createEventDispatcher, onMount } from "svelte";
 
-  import { api, IconButton, PrimaryButton } from "../.."; //TMP: ImageTask
-  import { isLocalSegmentationModel } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
+  import { api, IconButton, ImageTask, PrimaryButton, VideoTask, WorkspaceType } from "../.."; //TMP: ImageTask
+  import {
+    currentDatasetStore,
+    isLocalSegmentationModel,
+  } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import AddModelModal from "./AddModelModal.svelte";
   import ConnectModal from "./ConnectModal.svelte";
   import {
@@ -41,7 +44,11 @@ License: CECILL-C
   onMount(connectToPixanoInference);
 
   const listModels = async () => {
-    const availableSegmentationModels = await api.listModels(); //TMP: ImageTask.MASK_GENERATION);
+    const task =
+      $currentDatasetStore.workspace === WorkspaceType.VIDEO
+        ? VideoTask.MASK_GENERATION
+        : ImageTask.MASK_GENERATION;
+    const availableSegmentationModels = await api.listModels(task);
 
     const availableSegmentationModelsNames = availableSegmentationModels.map((model) => model.name);
 
@@ -200,5 +207,9 @@ License: CECILL-C
 {/if}
 
 {#if showAddModelModal}
-  <AddModelModal on:listModels={listModels} on:cancelAddModel={handleCloseAddModelModal} />
+  <AddModelModal
+    isVideo={$currentDatasetStore.workspace === WorkspaceType.VIDEO}
+    on:listModels={listModels}
+    on:cancelAddModel={handleCloseAddModelModal}
+  />
 {/if}

--- a/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
@@ -13,13 +13,16 @@ License: CECILL-C
     currentDatasetStore,
     isLocalSegmentationModel,
   } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
+  import Checkbox from "../ui/checkbox/checkbox.svelte";
   import AddModelModal from "./AddModelModal.svelte";
   import ConnectModal from "./ConnectModal.svelte";
   import {
     pixanoInferenceSegmentationModelsStore,
     pixanoInferenceSegmentationURL,
+    pixanoInferenceTracking,
     pixanoInferenceTrackingNbAdditionalFrames,
     type PixanoInferenceSegmentationModel,
+    type PixanoInferenceTrackingCfg,
   } from "./inference";
   import ModelItem from "./ModelItem.svelte";
 
@@ -97,6 +100,13 @@ License: CECILL-C
 
   const handleLocalOrPixinfChange = () => {
     isLocalSegmentationModel.set(localOrPixinf === "local");
+  };
+
+  const handleValTrackingClick = (checked: boolean) => {
+    pixanoInferenceTracking.set({
+      mustValidate: checked,
+      validated: false,
+    } as PixanoInferenceTrackingCfg);
   };
 
   function handleConfirm() {
@@ -214,6 +224,14 @@ License: CECILL-C
       <p class="w-60 ml-2 italic text-gray-500">
         First use of a tracking model may be long. A small value is advised first.
       </p>
+      <div class="h-1 bg-primary-light" />
+      <div class="ml-4 flex gap-4 items-center">
+        <Checkbox
+          handleClick={handleValTrackingClick}
+          checked={$pixanoInferenceTracking.mustValidate}
+        />
+        <span>Validate before tracking</span>
+      </div>
     {/if}
     <div class="h-1 bg-primary-light" />
     <div class="flex flex-row gap-2 px-3 justify-center">

--- a/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   import { Plus, Sparkles } from "lucide-svelte";
   import { createEventDispatcher, onMount } from "svelte";
 
-  import { api, IconButton, ImageTask, PrimaryButton } from "../..";
+  import { api, IconButton, PrimaryButton } from "../.."; //TMP: ImageTask
   import { isLocalSegmentationModel } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import AddModelModal from "./AddModelModal.svelte";
   import ConnectModal from "./ConnectModal.svelte";
@@ -41,7 +41,7 @@ License: CECILL-C
   onMount(connectToPixanoInference);
 
   const listModels = async () => {
-    const availableSegmentationModels = await api.listModels(ImageTask.MASK_GENERATION);
+    const availableSegmentationModels = await api.listModels(); //TMP: ImageTask.MASK_GENERATION);
 
     const availableSegmentationModelsNames = availableSegmentationModels.map((model) => model.name);
 

--- a/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
+++ b/ui/components/core/src/components/pixano_inference_segmentation/SelectLocalOrDistantModelModal.svelte
@@ -84,6 +84,18 @@ License: CECILL-C
       }),
     );
   };
+
+  const handleLocalOrPixinfChange = () => {
+    isLocalSegmentationModel.set(localOrPixinf === "local");
+    if (localOrPixinf !== "local") {
+      //if no PixInf model is selected, select first (can happens with only one model or on reload)
+      const selectedModel = $pixanoInferenceSegmentationModelsStore.find((m) => m.selected);
+      if (!selectedModel && $pixanoInferenceSegmentationModelsStore.length > 0) {
+        $pixanoInferenceSegmentationModelsStore[0].selected = true;
+      }
+    }
+  };
+
   const handleOpenAddModelModal = (event: Event) => {
     // stopPropgation is not called as event modifier
     // because event modifiers can only be used on DOM elements
@@ -96,10 +108,6 @@ License: CECILL-C
   };
   const handleCloseAddModelModal = () => {
     showAddModelModal = false;
-  };
-
-  const handleLocalOrPixinfChange = () => {
-    isLocalSegmentationModel.set(localOrPixinf === "local");
   };
 
   const handleValTrackingClick = (checked: boolean) => {

--- a/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
+++ b/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
@@ -41,3 +41,5 @@ export const pixanoInferenceSegmentationModelsStore = writable<PixanoInferenceSe
 export const pixanoInferenceSegmentationURL = writable<string>(DEFAULT_URL);
 
 export const pixanoInferenceToValidateTrackingMasks = writable<MaskSegmentationOutput[]>([]);
+
+export const pixanoInferenceTrackingNbAdditionalFrames = writable<number>(5);

--- a/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
+++ b/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
@@ -6,7 +6,7 @@ License: CECILL-C
 
 import { writable } from "svelte/store";
 
-import type { AnnotationType, MaskType } from "../../lib/types";
+import type { AnnotationType, BaseSchema, MaskType } from "../../lib/types";
 
 const DEFAULT_URL = "http://localhost:9152";
 
@@ -15,21 +15,29 @@ export type PixanoInferenceSegmentationModel = {
   name: string;
 };
 
-export type PixanoInferenceSegmentationOutput = {
-  mask: {
-    id: string;
-    created_at: string;
-    updated_at: string;
-    table_info: {
-      name: string;
-      group: string;
-      base_schema: string;
-    };
-    data: MaskType & AnnotationType;
+export type MaskSegmentationOutput = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  table_info: {
+    name: string;
+    group: string;
+    base_schema: BaseSchema;
   };
+  data: MaskType & AnnotationType;
+};
+
+export type PixanoInferenceSegmentationOutput = {
+  mask: MaskSegmentationOutput;
+};
+
+export type PixanoInferenceVideoSegmentationOutput = {
+  masks: MaskSegmentationOutput[];
 };
 
 export const pixanoInferenceSegmentationModelsStore = writable<PixanoInferenceSegmentationModel[]>(
   [],
 );
 export const pixanoInferenceSegmentationURL = writable<string>(DEFAULT_URL);
+
+export const pixanoInferenceToValidateTrackingMasks = writable<MaskSegmentationOutput[]>([]);

--- a/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
+++ b/ui/components/core/src/components/pixano_inference_segmentation/inference.ts
@@ -35,6 +35,11 @@ export type PixanoInferenceVideoSegmentationOutput = {
   masks: MaskSegmentationOutput[];
 };
 
+export type PixanoInferenceTrackingCfg = {
+  mustValidate: boolean;
+  validated: boolean;
+};
+
 export const pixanoInferenceSegmentationModelsStore = writable<PixanoInferenceSegmentationModel[]>(
   [],
 );
@@ -43,3 +48,8 @@ export const pixanoInferenceSegmentationURL = writable<string>(DEFAULT_URL);
 export const pixanoInferenceToValidateTrackingMasks = writable<MaskSegmentationOutput[]>([]);
 
 export const pixanoInferenceTrackingNbAdditionalFrames = writable<number>(5);
+
+export const pixanoInferenceTracking = writable<PixanoInferenceTrackingCfg>({
+  mustValidate: false,
+  validated: false,
+});

--- a/ui/components/core/src/lib/types/inference.ts
+++ b/ui/components/core/src/lib/types/inference.ts
@@ -29,7 +29,11 @@ export enum ImageTask {
   ZERO_SHOT_DETECTION = "image_zero_shot_detection",
 }
 
-export type Task = MultimodalImageNLPTask | ImageTask;
+export enum VideoTask {
+  MASK_GENERATION = "video_mask_generation",
+}
+
+export type Task = MultimodalImageNLPTask | ImageTask | VideoTask;
 
 export interface SystemPrompt {
   content: string;

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -150,7 +150,7 @@ License: CECILL-C
     viewRef: Reference,
     points: LabeledClick[],
     box: Box,
-    num_frames: number = 2,
+    num_frames: number = 10,
   ): Promise<Mask | undefined> => {
     const isConnected = await api.isInferenceApiHealthy($pixanoInferenceSegmentationURL);
     if (!isConnected) return;

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -24,6 +24,7 @@ License: CECILL-C
     pixanoInferenceSegmentationModelsStore,
     pixanoInferenceSegmentationURL,
     pixanoInferenceToValidateTrackingMasks,
+    pixanoInferenceTrackingNbAdditionalFrames,
     type PixanoInferenceSegmentationOutput,
     type PixanoInferenceVideoSegmentationOutput,
   } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
@@ -156,7 +157,6 @@ License: CECILL-C
     viewRef: Reference,
     points: LabeledClick[],
     box: Box,
-    num_frames: number = 10,
   ): Promise<Mask | undefined> => {
     const isConnected = await api.isInferenceApiHealthy($pixanoInferenceSegmentationURL);
     if (!isConnected) return;
@@ -179,7 +179,8 @@ License: CECILL-C
     const sub_video = full_video.filter(
       (sf) =>
         (sf as SequenceFrame).data.frame_index >= first_frame.data.frame_index &&
-        (sf as SequenceFrame).data.frame_index <= first_frame.data.frame_index + num_frames,
+        (sf as SequenceFrame).data.frame_index <=
+          first_frame.data.frame_index + $pixanoInferenceTrackingNbAdditionalFrames,
     );
 
     //need to remove "/media" from seqframes url, and move "data" outside !

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -130,6 +130,7 @@ License: CECILL-C
       };
       input = { ...base_input, bbox: input_bbox };
     }
+    modelWorking = true;
     const response = await fetch("/inference/tasks/mask-generation/image", {
       headers: {
         Accept: "application/json",
@@ -141,11 +142,13 @@ License: CECILL-C
     if (response.ok) {
       const result = (await response.json()) as PixanoInferenceSegmentationOutput;
       result.mask.data.counts = rleFrString(result.mask.data.counts as string);
+      modelWorking = false;
       return result.mask as Mask;
     } else {
       console.error("ERROR: Unable to segment", response);
       console.log("  error details:", await response.json());
     }
+    modelWorking = false;
     return;
   };
 
@@ -246,7 +249,7 @@ License: CECILL-C
       };
       input = { ...base_input, bbox: input_bbox };
     }
-    console.log("INPUT:", input);
+    //console.log("INPUT:", input);
     modelWorking = true;
     const response = await fetch("/inference/tasks/mask-generation/video", {
       headers: {
@@ -258,7 +261,7 @@ License: CECILL-C
     });
     if (response.ok) {
       const result = (await response.json()) as PixanoInferenceVideoSegmentationOutput;
-      console.log("RAW OUTPUT", result);
+      //console.log("RAW OUTPUT", result);
       //TODO: rebuild
       for (const mask of result.masks) {
         mask.data.counts = rleFrString(mask.data.counts as string);

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -162,7 +162,7 @@ License: CECILL-C
     if (!isConnected) return;
     const models = await api.listModels();
     const selectedMaskModel = $pixanoInferenceSegmentationModelsStore.find((m) => m.selected);
-    const maskModelName = (selectedMaskModel ? selectedMaskModel.name : "SAM2") + "-video";
+    const maskModelName = (selectedMaskModel ? selectedMaskModel.name : "SAM2") + "_video";
     if (!models.map((m) => m.name).includes(maskModelName)) return;
 
     //get video from viewRef (current frame) & num_frames

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -12,6 +12,7 @@ License: CECILL-C
     api,
     BaseSchema,
     Mask,
+    SequenceFrame,
     WorkspaceType,
     type Box,
     type DatasetItem,
@@ -21,7 +22,9 @@ License: CECILL-C
   import {
     pixanoInferenceSegmentationModelsStore,
     pixanoInferenceSegmentationURL,
+    pixanoInferenceToValidateTrackingMasks,
     type PixanoInferenceSegmentationOutput,
+    type PixanoInferenceVideoSegmentationOutput,
   } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
   import type { InteractiveImageSegmenterOutput } from "@pixano/models";
 
@@ -142,6 +145,130 @@ License: CECILL-C
     }
     return;
   };
+
+  const pixanoInferenceSegmentationVideo = async (
+    viewRef: Reference,
+    points: LabeledClick[],
+    box: Box,
+    num_frames: number = 2,
+  ): Promise<Mask | undefined> => {
+    const isConnected = await api.isInferenceApiHealthy($pixanoInferenceSegmentationURL);
+    if (!isConnected) return;
+    const models = await api.listModels();
+    const selectedMaskModel = $pixanoInferenceSegmentationModelsStore.find((m) => m.selected);
+    const maskModelName = (selectedMaskModel ? selectedMaskModel.name : "SAM2") + "-video";
+    if (!models.map((m) => m.name).includes(maskModelName)) return;
+
+    //get video from viewRef (current frame) & num_frames
+    let full_video = selectedItem.views[viewRef.name];
+    if (!Array.isArray(full_video)) {
+      console.error("Tracking available only for video!");
+      return;
+    }
+    const first_frame = full_video.find((sf) => sf.id === viewRef.id) as SequenceFrame;
+    if (!first_frame) {
+      console.error("ERROR: frame unavailable");
+      return;
+    }
+    const sub_video = full_video.filter(
+      (sf) =>
+        (sf as SequenceFrame).data.frame_index >= first_frame.data.frame_index &&
+        (sf as SequenceFrame).data.frame_index <= first_frame.data.frame_index + num_frames,
+    );
+
+    //need to remove "/media" from seqframes url, and move "data" outside !
+    const video = sub_video.map((sf) => {
+      const fixed_sf = structuredClone(sf);
+      fixed_sf.data.url = (fixed_sf.data.url as string).replace("media/", "");
+      return fixed_sf;
+    });
+
+    const base_input = {
+      dataset_id: selectedItem.ui.datasetId,
+      video,
+      model: maskModelName,
+    };
+
+    let input;
+    if (points) {
+      let pts = [];
+      let labels = [];
+      for (const pt of points) {
+        pts.push([Math.round(pt.x), Math.round(pt.y)]);
+        labels.push(pt.label);
+      }
+      input = { ...base_input, points: pts, labels: labels };
+    }
+    if (box) {
+      //coords must be positive
+      const positiveBBox = (bbox: Box): Box => {
+        let { x, y, width, height } = bbox;
+        if (width < 0) {
+          x += width;
+          width = -width;
+        }
+        if (height < 0) {
+          y += height;
+          height = -height;
+        }
+        if (x < 0) {
+          width += x;
+          x = 0;
+        }
+        if (y < 0) {
+          height += y;
+          y = 0;
+        }
+        width = Math.max(0, width);
+        height = Math.max(0, height);
+        return { x, y, width, height } as Box;
+      };
+      box = positiveBBox(box);
+      //need a somehow BBox object (not exactly).
+      const now = new Date(Date.now()).toISOString().replace(/Z$/, "+00:00");
+      const input_bbox = {
+        id: "",
+        created_at: now,
+        updated_at: now,
+        table_info: { name: "", group: "annotations", base_schema: BaseSchema.BBox },
+        coords: [
+          Math.round(box.x),
+          Math.round(box.y),
+          Math.round(box.width),
+          Math.round(box.height),
+        ],
+        format: "xywh",
+        is_normalized: false,
+        confidence: 1,
+      };
+      input = { ...base_input, bbox: input_bbox };
+    }
+    console.log("INPUT:", input);
+    const response = await fetch("/inference/tasks/mask-generation/video", {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+    if (response.ok) {
+      const result = (await response.json()) as PixanoInferenceVideoSegmentationOutput;
+      console.log("RAW OUTPUT", result);
+      //TODO: rebuild
+      for (const mask of result.masks) {
+        mask.data.counts = rleFrString(mask.data.counts as string);
+        //correct viewref..etc ?
+      }
+      //We will store masks so that when validated, they are used to fill the created Track
+      pixanoInferenceToValidateTrackingMasks.set(result.masks);
+      return result.masks[0] as Mask;
+    } else {
+      console.error("ERROR: Unable to track", response);
+      console.log("  error details:", await response.json());
+    }
+    return;
+  };
 </script>
 
 <div class="max-h-[calc(100vh-80px)] w-full max-w-full bg-slate-800">
@@ -150,7 +277,12 @@ License: CECILL-C
       <Loader2Icon class="animate-spin text-white" />
     </div>
   {:else if selectedItem.ui.type === WorkspaceType.VIDEO}
-    <VideoViewer {selectedItem} {pixanoInferenceSegmentation} {resize} bind:currentAnn />
+    <VideoViewer
+      {selectedItem}
+      pixanoInferenceSegmentation={pixanoInferenceSegmentationVideo}
+      {resize}
+      bind:currentAnn
+    />
   {:else if selectedItem.ui.type === WorkspaceType.IMAGE_VQA}
     <VqaViewer {selectedItem} {pixanoInferenceSegmentation} {resize} bind:currentAnn />
   {:else if selectedItem.ui.type === WorkspaceType.IMAGE_TEXT_ENTITY_LINKING}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -11,6 +11,7 @@ License: CECILL-C
   import {
     api,
     BaseSchema,
+    LoadingModal,
     Mask,
     SequenceFrame,
     WorkspaceType,
@@ -41,6 +42,8 @@ License: CECILL-C
   export let currentAnn: InteractiveImageSegmenterOutput | null = null;
   export let isLoading: boolean;
   export let resize: number;
+
+  let modelWorking: boolean = false;
 
   modelsUiStore.subscribe(() => {
     if (selectedItem) loadViewEmbeddings();
@@ -244,6 +247,7 @@ License: CECILL-C
       input = { ...base_input, bbox: input_bbox };
     }
     console.log("INPUT:", input);
+    modelWorking = true;
     const response = await fetch("/inference/tasks/mask-generation/video", {
       headers: {
         Accept: "application/json",
@@ -262,11 +266,13 @@ License: CECILL-C
       }
       //We will store masks so that when validated, they are used to fill the created Track
       pixanoInferenceToValidateTrackingMasks.set(result.masks);
+      modelWorking = false;
       return result.masks[0] as Mask;
     } else {
       console.error("ERROR: Unable to track", response);
       console.log("  error details:", await response.json());
     }
+    modelWorking = false;
     return;
   };
 </script>
@@ -293,3 +299,6 @@ License: CECILL-C
     <ThreeDimensionsViewer />
   {/if}
 </div>
+{#if modelWorking}
+  <LoadingModal />
+{/if}

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -162,7 +162,7 @@ License: CECILL-C
     if (!isConnected) return;
     const models = await api.listModels();
     const selectedMaskModel = $pixanoInferenceSegmentationModelsStore.find((m) => m.selected);
-    const maskModelName = (selectedMaskModel ? selectedMaskModel.name : "SAM2") + "_video";
+    const maskModelName = selectedMaskModel ? selectedMaskModel.name : "SAM2_video";
     if (!models.map((m) => m.name).includes(maskModelName)) return;
 
     //get video from viewRef (current frame) & num_frames

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -7,6 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import {
+    Check,
     MinusCircleIcon,
     MousePointer,
     PlusCircleIcon,
@@ -14,13 +15,17 @@ License: CECILL-C
     Share2,
     Square,
     Wand2Icon,
+    X,
   } from "lucide-svelte";
   import { onMount } from "svelte";
 
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import type { SelectionTool } from "@pixano/core";
   import { cn, IconButton } from "@pixano/core/src";
-  import { pixanoInferenceSegmentationModelsStore } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
+  import {
+    pixanoInferenceSegmentationModelsStore,
+    pixanoInferenceTracking,
+  } from "@pixano/core/src/components/pixano_inference_segmentation/inference";
 
   import { isLocalSegmentationModel } from "../../../../apps/pixano/src/lib/stores/datasetStores";
   import { clearHighlighting } from "../lib/api/objectsApi/clearHighlighting";
@@ -70,6 +75,10 @@ License: CECILL-C
       )
         configSmartToolClick();
     } else selectTool(panTool);
+  };
+
+  const onAbort = () => {
+    newShape.set({ status: "none", shouldReset: true });
   };
 
   const configSmartToolClick = () => {
@@ -155,6 +164,20 @@ License: CECILL-C
       >
         <Square />
       </IconButton>
+      {#if isVideo && $pixanoInferenceTracking.mustValidate}
+        <IconButton
+          tooltipContent={"Track"}
+          on:click={() =>
+            pixanoInferenceTracking.set({ ...$pixanoInferenceTracking, validated: true })}
+          selected={false}
+        >
+          <Check />
+        </IconButton>
+        <IconButton tooltipContent={"Abort tracking (Escape)"} on:click={onAbort} selected={false}>
+          <X />
+        </IconButton>
+      {/if}
+
       <div class="w-1 -m-3.5 h-full bg-primary-light"></div>
       <IconButton
         tooltipContent={"Smart segmentation model settings"}

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/getFrameIndexFromViewRef.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/getFrameIndexFromViewRef.ts
@@ -1,0 +1,22 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { get } from "svelte/store";
+
+import type { Reference, SequenceFrame } from "@pixano/core";
+
+import { views } from "../../stores/datasetItemWorkspaceStores";
+
+export const getFrameIndexFromViewRef = (viewRef: Reference): number => {
+  const vs = get(views);
+  if (!Array.isArray(vs[viewRef.name])) return 0;
+  const view = (vs[viewRef.name] as SequenceFrame[]).find((sf) => sf.id === viewRef.id);
+  if (view) return view.data.frame_index;
+  else {
+    console.error("Could not find a matching view:", viewRef);
+    return 0;
+  }
+};

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/index.ts
@@ -26,6 +26,7 @@ export * from "./defineCreatedObject";
 export * from "./defineObjectThumbnail";
 export * from "./deleteObject";
 export * from "./findOrCreateTopAndSubEntities";
+export * from "./getFrameIndexFromViewRef";
 export * from "./getPixanoSource";
 export * from "./getTable";
 export * from "./getTopEntity";

--- a/ui/components/vqaCanvas/src/features/manageModels/components/AddModelModal.svelte
+++ b/ui/components/vqaCanvas/src/features/manageModels/components/AddModelModal.svelte
@@ -40,7 +40,7 @@ License: CECILL-C
       dtype: "float16",
     },
   };
-  let formData = modelChoices["llava-mistral"];
+  let formData = modelChoices["llava-qwen"];
 
   let isAddingModelRequestPending = false;
   const dispatch = createEventDispatcher();


### PR DESCRIPTION
## Description

Allow tracking with Pixano Inference.

TODO:
- [x] choose number of frames to track: setting in model config panel.
- [x] better handling of image vs video tracking in SelectModel
- [x] better handling for launching request (option to validate before segmentation, which allows to put several +/- points)
- [x] tests back