### PR TITLE
fix semantic search issues

### DIFF
--- a/pixano/app/models/datasets.py
+++ b/pixano/app/models/datasets.py
@@ -135,6 +135,7 @@ class DatasetBrowser(BaseModel):
         table_data: table data
         pagination: pagination infos
         semantic_search: list of semantic search available models
+        item_ids: full list of item ids returned
     """
 
     id: str
@@ -142,3 +143,4 @@ class DatasetBrowser(BaseModel):
     table_data: TableData
     pagination: PaginationInfo
     semantic_search: list[str]
+    item_ids: list[str]

--- a/tests/app/models/test_datasets.py
+++ b/tests/app/models/test_datasets.py
@@ -17,6 +17,7 @@ class TestDatasetBrowser:
             table_data=TableData(columns=[PaginationColumn(name="col", type="col")], rows=[{"metadata": 123}]),
             pagination=PaginationInfo(current_page=1, page_size=10, total_size=20),
             semantic_search=["search1", "search2"],
+            item_ids=["id0"],
         )
 
 

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -1192,7 +1192,7 @@ class TestDataset:
             return df_semantic_search
 
         with patch("lancedb.query.LanceQueryBuilder.to_polars", _mock_to_polars):
-            items, distances = dataset_multi_view_tracking_and_image.semantic_search(
+            items, distances, list_ids = dataset_multi_view_tracking_and_image.semantic_search(
                 "some_text", "image_embedding", limit=50, skip=0
             )
 
@@ -1203,6 +1203,9 @@ class TestDataset:
             assert isinstance(distance, float)
             assert item.id == sorted_df["item_ref.id"][i]
             assert distance == sorted_df["_distance"][i]
+        assert len(items) == len(list_ids)
+        for i in range(len(items)):
+            assert items[i].id == list_ids[i]
 
         with pytest.raises(DatasetAccessError, match="query must be a string"):
             dataset_multi_view_tracking_and_image.semantic_search(0, "image_embedding", limit=50, skip=0)

--- a/tests/fixtures/app/routers/browser.py
+++ b/tests/fixtures/app/routers/browser.py
@@ -71,6 +71,7 @@ def browser_dataset_image_bboxes_keypoint() -> DatasetBrowser:
         ),
         pagination=PaginationInfo(current_page=0, page_size=50, total_size=5),
         semantic_search=[],
+        item_ids=["0", "1", "2", "3", "4"],
     )
 
 
@@ -144,6 +145,7 @@ def browser_dataset_multi_view_tracking_and_image() -> DatasetBrowser:
         ),
         pagination=PaginationInfo(current_page=0, page_size=50, total_size=5),
         semantic_search=["image_embedding", "video_embeddings"],
+        item_ids=["0", "1", "2", "3", "4"],
     )
 
 
@@ -228,4 +230,5 @@ def browser_dataset_multi_view_tracking_and_image_semantic_search() -> DatasetBr
         ),
         pagination=PaginationInfo(current_page=0, page_size=50, total_size=5),
         semantic_search=["image_embedding", "video_embeddings"],
+        item_ids=["2", "3", "4", "1", "0"],
     )

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -32,7 +32,7 @@ License: CECILL-C
   let datasetErrorModal = false;
 
   // Semantic search
-  let searchInput: string = "";
+  let searchInput: string = $datasetTableStore.query?.search ?? "";
   let selectedSearchModel: string | undefined;
 
   const dispatch = createEventDispatcher();

--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -16,13 +16,13 @@ License: CECILL-C
   import { navItems } from "$lib/constants/headerConstants";
   import {
     currentDatasetStore,
+    datasetItemIds,
     datasetTableStore,
     isLoadingNewItemStore,
     saveCurrentItemStore,
   } from "$lib/stores/datasetStores";
 
   export let pageId: string | null;
-  export let datasetItemsIds: string[];
 
   let currentItemId: string;
   let isLoading: boolean;
@@ -43,14 +43,14 @@ License: CECILL-C
   });
 
   const getDatasetItemDisplayCount = () => {
-    const index = datasetItemsIds.indexOf(currentItemId);
-    return `${index + 1} of ${datasetItemsIds.length}`;
+    const index = $datasetItemIds.indexOf(currentItemId);
+    return `${index + 1} of ${$datasetItemIds.length}`;
   };
 
   // Handle bi-directional navigation using arrows
   const goToNeighborItem = async (direction: "previous" | "next") => {
     // Find the neighbor item id
-    const neighborId = findNeighborItemId(datasetItemsIds, direction, currentItemId);
+    const neighborId = findNeighborItemId($datasetItemIds, direction, currentItemId);
 
     // If a neighbor item has been found
     if (neighborId) {
@@ -92,7 +92,7 @@ License: CECILL-C
     if (currentItemId) {
       // Update the current page to ensure that we follow the selected item
       datasetTableStore.update((pagination) => {
-        pagination.currentPage = getPageFromItemId(datasetItemsIds, currentItemId);
+        pagination.currentPage = getPageFromItemId($datasetItemIds, currentItemId);
         return pagination;
       });
       await navigateTo(`/${$currentDatasetStore.id}/dataset`);

--- a/ui/apps/pixano/src/lib/stores/datasetStores.ts
+++ b/ui/apps/pixano/src/lib/stores/datasetStores.ts
@@ -29,6 +29,7 @@ export const isLocalSegmentationModel = writable<boolean>(true);
 export const sourcesStore = writable<Source[]>([]);
 export const isLoadingNewItemStore = writable<boolean>(true);
 export const datasetTableStore = writable<DatasetTableStore>(defaultDatasetTableValues);
+export const datasetItemIds = writable<Array<string>>([]);
 export const datasetTotalItemsCount = writable<number>(0);
 export const canSaveCurrentItemStore = writable<boolean>();
 export const saveCurrentItemStore = writable<{ shouldSave: boolean; canSave: boolean }>({

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -15,6 +15,7 @@ License: CECILL-C
   import MainHeader from "../components/layout/MainHeader.svelte";
   import {
     currentDatasetStore,
+    datasetItemIds,
     datasetsStore,
     datasetTableStore,
     datasetTotalItemsCount,
@@ -26,7 +27,6 @@ License: CECILL-C
   import "./styles.css";
 
   let currentDatasetId: string;
-  let currentDatasetItemsIds: string[];
 
   const HOME_ROUTE_ID = "/";
 
@@ -48,17 +48,21 @@ License: CECILL-C
   // Get all the ids of the items of the selected dataset
   $: void getCurrentDatasetItemsIds(currentDatasetId); //void here to avoid .then/.catch. But maybe we could manage error ?
 
-  datasetTableStore.subscribe(async (value) => {
+  datasetTableStore.subscribe((value) => {
     if (value.where != undefined) {
-      currentDatasetItemsIds = await api.getDatasetItemsIds(currentDatasetId, value.where);
-      datasetTotalItemsCount.set(currentDatasetItemsIds.length);
+      datasetTotalItemsCount.set($datasetItemIds.length);
     }
   });
 
   const getCurrentDatasetItemsIds = async (datasetId: string) => {
     if (datasetId === undefined) return;
-    currentDatasetItemsIds = await api.getDatasetItemsIds(datasetId);
-    datasetTotalItemsCount.set(currentDatasetItemsIds.length);
+    if ($datasetItemIds.length === 0) {
+      const item_ids = await api.getDatasetItemsIds(datasetId);
+      datasetItemIds.set(item_ids);
+      datasetTotalItemsCount.set($datasetItemIds.length);
+    } else {
+      datasetTotalItemsCount.set($datasetItemIds.length);
+    }
   };
 
   $: page.subscribe((value) => {
@@ -91,7 +95,7 @@ License: CECILL-C
   {#if $page.route.id === HOME_ROUTE_ID}
     <MainHeader datasets={$datasetsStore} />
   {:else}
-    <DatasetHeader pageId={$page.route.id} datasetItemsIds={currentDatasetItemsIds} />
+    <DatasetHeader pageId={$page.route.id} />
   {/if}
   <main
     class={cn("bg-slate-50 flex flex-col h-screen", $page.route.id !== HOME_ROUTE_ID && "pt-20")}

--- a/ui/components/core/src/api/getBrowser.ts
+++ b/ui/components/core/src/api/getBrowser.ts
@@ -26,7 +26,7 @@ export async function getBrowser(
   }
   try {
     const response = await fetch(
-      `/browser/${datasetId}/?skip=${(page - 1) * size}&limit=${size}${query_qparams}${where_qparams}`,
+      `/browser/${datasetId}?skip=${(page - 1) * size}&limit=${size}${query_qparams}${where_qparams}`,
     );
     if (response.ok) {
       datasetItems_raw = (await response.json()) as DatasetBrowserType;

--- a/ui/components/core/src/api/getDatasetItemsIds.ts
+++ b/ui/components/core/src/api/getDatasetItemsIds.ts
@@ -4,44 +4,25 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { Item } from "../lib/types";
-
 // Request API to get all the items ids for a given dataset
-export async function getDatasetItemsIds(
-  datasetId: string,
-  where: string | undefined = undefined,
-): Promise<Array<string>> {
-  const datasetItemsIds: string[] = [];
-  const page_size = 1000;
+export async function getDatasetItemsIds(datasetId: string): Promise<Array<string>> {
+  let datasetItemsIds: string[] = [];
 
-  let where_qparams = "";
-  if (where && where !== "") {
-    where_qparams = `&where=${where}`;
-  }
-  for (let skip = 0; ; skip += page_size) {
-    try {
-      const response = await fetch(
-        `/items/${datasetId}/?limit=${page_size}&skip=${skip}${where_qparams}`,
-      );
-      if (response.ok) {
-        const res = (await response.json()) as Item[];
-        datasetItemsIds.push(...res.map((item) => item.id));
-        if (res && res.length < page_size) {
-          break; //just to avoid 404 error log (will still appear if num items % page_size == 0)
-        }
-      } else {
-        if (response.status != 404)
-          console.log(
-            "api.getDatasetItemsIds -",
-            response.status,
-            response.statusText,
-            await response.text(),
-          ); // Handle API errors
-        break;
-      }
-    } catch (e) {
-      console.log("api.getDatasetItemsIds -", e); // Handle other errors
+  try {
+    const response = await fetch(`/browser/item_ids/${datasetId}`);
+    if (response.ok) {
+      datasetItemsIds = (await response.json()) as string[];
+    } else {
+      if (response.status != 404)
+        console.log(
+          "api.getDatasetItemsIds -",
+          response.status,
+          response.statusText,
+          await response.text(),
+        ); // Handle API errors
     }
+  } catch (e) {
+    console.log("api.getDatasetItemsIds -", e); // Handle other errors
   }
   return datasetItemsIds;
 }

--- a/ui/components/core/src/lib/types/dataset/datasetTypes.ts
+++ b/ui/components/core/src/lib/types/dataset/datasetTypes.ts
@@ -143,6 +143,7 @@ const datasetBrowserSchema = z
     table_data: tableDataSchema,
     pagination: paginationInfoSchema,
     semantic_search: z.array(z.string()),
+    item_ids: z.array(z.string()),
     isErrored: z.optional(z.boolean()),
   })
   .strict();
@@ -154,6 +155,7 @@ export class DatasetBrowser implements DatasetBrowserType {
   table_data: TableData;
   pagination: PaginationInfo;
   semantic_search: Array<string>;
+  item_ids: Array<string>;
   isErrored?: boolean;
 
   constructor(obj: DatasetBrowserType) {
@@ -163,6 +165,7 @@ export class DatasetBrowser implements DatasetBrowserType {
     this.table_data = obj.table_data;
     this.pagination = obj.pagination;
     this.semantic_search = obj.semantic_search;
+    this.item_ids = obj.item_ids;
     this.isErrored = obj.isErrored;
   }
 }


### PR DESCRIPTION
## Issue

Semantic search request a search at least two times for each search. Also, order is not respected when navigating

Fixes #562 

## Description

- Rework of reactive logic to avoid searching twice
- send and retrieve complete list of ids to have consistent order
- get list of ids when not using browser (if user open on a datasetItem directly, or refresh)
