### PR TITLE
remove fixed version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "opencv-python >= 4.7.0, < 5.0.0",
   "pandas >= 1.5.0, < 3.0.0",
   "Pillow >= 9.4.0, < 11.0.0",
-  "pixano-inference",
+  "pixano-inference ~= 0.5.6",
   "polars > 1.7.0, < 2.0.0",
   "pycocotools >= 2.0.0, < 3.0.0",
   "pydantic >= 2.9.0, < 3.0.0",


### PR DESCRIPTION
## Issue

Fixed pixano_inference dependency

## Description

As Pixano Inference is part of Pixano products, we assume to always use latest version