### PR TITLE
bigger default text panels widths

### DIFF
--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/EntityLinkingViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/EntityLinkingViewer.svelte
@@ -63,7 +63,7 @@ License: CECILL-C
   let loaded: boolean = false; // Loading status of images per view
 
   // utility vars for resizing with slide bar
-  let entityLinkingAreaWidth = 300; //default width
+  let entityLinkingAreaWidth = 700; //default width
   let expanding = false;
 
   /**

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VqaViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/VqaViewer.svelte
@@ -69,7 +69,7 @@ License: CECILL-C
   ) => Promise<Mask | undefined>;
 
   // utility vars for resizing with slide bar
-  let vqaAreaMaxWidth = 450; //default width
+  let vqaAreaMaxWidth = 500; //default width
   const minVqaAreaWidth = 260; //minimum width for VqaArea (less may hide some elements)
   let expanding = false;
 


### PR DESCRIPTION
## Issue

Default width for text panels in Entity Linking and VQA workspaces are too small.

## Description

Make them bigger