### PR TITLE
ensure visibilty of input points

### DIFF
--- a/ui/components/canvas2d/src/Canvas2D.svelte
+++ b/ui/components/canvas2d/src/Canvas2D.svelte
@@ -1157,6 +1157,7 @@ License: CECILL-C
       input_point.on("dragend", () => dragInputPointEnd());
       const inputGroup: Konva.Group = viewLayer.findOne("#input");
       inputGroup.add(input_point);
+      inputGroup.moveToTop();  //ensure input points stay over other groups
       highlightInputPoint(input_point, viewRef.name);
       lastInputViewRef = viewRef;
       await updateCurrentMask(viewRef);


### PR DESCRIPTION
## Issue

In some conditions with Interactive Segmentation (mainly on video when using Tracking with "Validate before tracking" mode, but not always restricted to this mode), input points are not shown on screen.

## Description

It seems to be linked to the way images are loaded in canvas2D (2 layers that are swapped, to avoid flickering), as the "input" group is sometimes under (z-order) the currently shown image. 
Fix: ensure correct z-order by putting input group to top whenever a new input point is drawn.

