### PR TITLE
minor improvement/bugfixes on ObjectCard

### DIFF
--- a/ui/components/canvas2d/src/components/TextSpansContent.svelte
+++ b/ui/components/canvas2d/src/components/TextSpansContent.svelte
@@ -25,7 +25,7 @@ License: CECILL-C
   <p class="font-medium mt-4">Text spans</p>
   <div class="grid gap-x-4 gap-y-2 grid-cols-[150px_auto] mt-2 pr-4">
     {#each mentions as mention}
-      <p class="font-medium">mention</p>
+      <p class="font-medium ml-4">mention</p>
       <p>{mention}</p>
     {/each}
   </div>

--- a/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
@@ -25,28 +25,30 @@ License: CECILL-C
 </script>
 
 {#each features as feature}
-  <div class="flex w-full gap-4 mt-2 px-4">
+  <div class="flex w-full gap-4 mt-2 px-4 justify-between items-center">
     {#if isEditing || feature.value !== undefined}
-      <p class="flex items-center">
+      <p class="flex items-center" title={feature.obj.id}>
         {feature.label.replace("_", " ")}
       </p>
     {/if}
-    {#if feature.type === "bool" && (feature.value !== undefined || isEditing)}
-      <Checkbox
-        checked={!!feature.value}
-        disabled={!isEditing}
-        handleClick={(checked) => saveInputChange(checked, feature.name, feature.obj)}
-      />
-    {/if}
-    {#if feature.type === "list"}
-      <ListFeature
-        {isEditing}
-        handleInputChange={(value, name) => saveInputChange(value, name, feature.obj)}
-        listFeature={{ value: feature.value, name: feature.name, options: feature.options }}
-      />
-    {/if}
-    {#if feature.type === "str" || feature.type === "int" || feature.type === "float"}
-      <FeatureTextInput {featureClass} {feature} {saveInputChange} {isEditing} />
-    {/if}
+    <div class="flex items-center justify-end">
+      {#if feature.type === "bool" && (feature.value !== undefined || isEditing)}
+        <Checkbox
+          checked={!!feature.value}
+          disabled={!isEditing}
+          handleClick={(checked) => saveInputChange(checked, feature.name, feature.obj)}
+        />
+      {/if}
+      {#if feature.type === "list"}
+        <ListFeature
+          {isEditing}
+          handleInputChange={(value, name) => saveInputChange(value, name, feature.obj)}
+          listFeature={{ value: feature.value, name: feature.name, options: feature.options }}
+        />
+      {/if}
+      {#if feature.type === "str" || feature.type === "int" || feature.type === "float"}
+        <FeatureTextInput {featureClass} {feature} {saveInputChange} {isEditing} />
+      {/if}
+    </div>
   </div>
 {/each}

--- a/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/UpdateFeatureInputs.svelte
@@ -31,7 +31,7 @@ License: CECILL-C
         {feature.label.replace("_", " ")}
       </p>
     {/if}
-    <div class="flex items-center justify-end">
+    <div class="flex items-center justify-end overflow-hidden">
       {#if feature.type === "bool" && (feature.value !== undefined || isEditing)}
         <Checkbox
           checked={!!feature.value}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ChildCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ChildCard.svelte
@@ -40,6 +40,7 @@ License: CECILL-C
     current_itemBBoxes,
     current_itemKeypoints,
     current_itemMasks,
+    interpolate,
     mediaViews,
     selectedTool,
   } from "../../lib/stores/datasetItemWorkspaceStores";
@@ -64,7 +65,7 @@ License: CECILL-C
   let childVisible = true;
   $: if ($annotations) childEditing = child.ui.displayControl.editing;
   $: if ($annotations) childVisible = !child.ui.displayControl.hidden;
-  $: if ($annotations || child) buildCurrentTrackletChildList();
+  $: if ($annotations || child || $interpolate) buildCurrentTrackletChildList();
 
   const buildCurrentTrackletChildList = () => {
     if (child.is_type(BaseSchema.Tracklet)) {

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ChildCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ChildCard.svelte
@@ -61,7 +61,9 @@ License: CECILL-C
   let currentTrackletChilds: { trackletChild: Annotation; displayName: string }[] = [];
 
   let childEditing = false;
+  let childVisible = true;
   $: if ($annotations) childEditing = child.ui.displayControl.editing;
+  $: if ($annotations) childVisible = !child.ui.displayControl.hidden;
   $: if ($annotations || child) buildCurrentTrackletChildList();
 
   const buildCurrentTrackletChildList = () => {
@@ -110,10 +112,10 @@ License: CECILL-C
 <div class="flex justify-between bg-transparent border-transparent">
   <div class="flex-[1_1_auto] flex items-center overflow-hidden min-w-0">
     <IconButton
-      on:click={() => handleSetDisplayControl("hidden", !child.ui.displayControl.hidden, child)}
-      tooltipContent={!child.ui.displayControl.hidden ? "Hide" : "Show"}
+      on:click={() => handleSetDisplayControl("hidden", childVisible, child)}
+      tooltipContent={childVisible ? "Hide" : "Show"}
     >
-      {#if !child.ui.displayControl.hidden}
+      {#if childVisible}
         <Eye class="h-4" />
       {:else}
         <EyeOff class="h-4" />
@@ -142,13 +144,15 @@ License: CECILL-C
   </div>
   <div class="flex-shrink-0 flex items-center justify-end">
     {#if $selectedTool.type !== ToolType.Fusion}
-      <IconButton
-        tooltipContent="Edit object"
-        selected={childEditing}
-        on:click={() => onEditIconClick(child)}
-      >
-        <Pencil class="h-4" />
-      </IconButton>
+      {#if !child.is_type(BaseSchema.TextSpan)}
+        <IconButton
+          tooltipContent="Edit object"
+          selected={childEditing}
+          on:click={() => onEditIconClick(child)}
+        >
+          <Pencil class="h-4" />
+        </IconButton>
+      {/if}
       <IconButton
         tooltipContent="Relink object"
         selected={showRelink}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/InspectorInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/InspectorInspector.svelte
@@ -29,7 +29,11 @@ License: CECILL-C
         <Tabs.Trigger value="objects">Objects</Tabs.Trigger>
         <Tabs.Trigger value="scene">Scene</Tabs.Trigger>
       </Tabs.List>
-      <Tabs.Content value="objects" class="h-full overflow-y-auto scroll-smooth">
+      <Tabs.Content
+        value="objects"
+        class="h-full overflow-y-auto scroll-smooth"
+        id="card-object-container"
+      >
         {#if isLoading}
           <div class="p-4 flex flex-col gap-4">
             <Skeleton class="h-8 w-full" />

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -56,7 +56,7 @@ License: CECILL-C
   let showIcons: boolean = false;
   let highlightState: string = "all";
   let isVisible: boolean = true;
-
+  let childsPanelOpen = true;
   let hiddenTrack = entity.is_track ? entity.ui.displayControl.hidden : false;
 
   let displayName: string;
@@ -121,12 +121,17 @@ License: CECILL-C
       //let anns_features: Record<string, Feature[]> = {};
       let feats: Record<string, Feature[]> = {};
       let child_anns: Annotation[] = [];
-      if ($currentFrameIndex !== null) {
-        child_anns = entity.ui.childs!.filter(
-          (ann) => !ann.is_type(BaseSchema.Tracklet) && ann.ui.frame_index! === $currentFrameIndex,
-        );
+      if (entity.is_track) {
+        if ($currentFrameIndex !== null) {
+          child_anns = entity.ui.childs!.filter(
+            (ann) =>
+              !ann.is_type(BaseSchema.Tracklet) && ann.ui.frame_index! === $currentFrameIndex,
+          );
+        } else {
+          child_anns = entity.ui.childs!.filter((ann) => !ann.is_type(BaseSchema.Tracklet));
+        }
       } else {
-        child_anns = entity.ui.childs!.filter((ann) => !ann.is_type(BaseSchema.Tracklet));
+        child_anns = entity.ui.childs!;
       }
       for (const ann of child_anns) {
         if (ann.data.entity_ref.id !== entity.id && !(ann.data.entity_ref.id in feats)) {
@@ -399,33 +404,49 @@ License: CECILL-C
               {saveInputChange}
             />
           </div>
-          <p class="font-medium">Objects ({allowableChilds.length})</p>
-          <div class="flex flex-col">
-            {#if entity.ui.childs?.some((ann) => ann.ui.datasetItemType === WorkspaceType.VIDEO)}
-              <p class="text-center italic">
-                {allowedChilds.length > 0 ? allowedChilds.length : "No"}
-                object{allowedChilds.length === 1 ? "" : "s"}
-                visible on frame {$currentFrameIndex}
-              </p>
-            {/if}
-            {#each allowedChilds as child}
-              <ChildCard {entity} {child} {handleSetDisplayControl} {onEditIconClick} />
-            {/each}
+          <div class="flex justify-between items-center">
+            <p class="font-medium">Objects ({allowableChilds.length})</p>
+            <IconButton
+              on:click={() => (childsPanelOpen = !childsPanelOpen)}
+              tooltipContent={childsPanelOpen ? "Hide objects" : "Show objects"}
+            >
+              <ChevronRight
+                class={cn("transition", { "rotate-90": childsPanelOpen })}
+                strokeWidth={1}
+              />
+            </IconButton>
           </div>
-          <p class="font-medium">Thumbnails</p>
-          {#each thumbnails as thumbnail}
-            <Thumbnail
-              imageDimension={thumbnail.baseImageDimensions}
-              coords={thumbnail.coords}
-              imageUrl={`/${thumbnail.uri}`}
-              minSide={150}
-              maxWidth={200}
-              maxHeight={200}
-            />
-            {#if Object.keys($mediaViews).length > 1}
-              <span class="text-center italic">{thumbnail.view}</span>
-            {/if}
-          {/each}
+
+          {#if childsPanelOpen}
+            <div class="flex flex-col">
+              {#if entity.ui.childs?.some((ann) => ann.ui.datasetItemType === WorkspaceType.VIDEO)}
+                <p class="text-center italic">
+                  {allowedChilds.length > 0 ? allowedChilds.length : "No"}
+                  object{allowedChilds.length === 1 ? "" : "s"}
+                  visible on frame {$currentFrameIndex}
+                </p>
+              {/if}
+              {#each allowedChilds as child}
+                <ChildCard {entity} {child} {handleSetDisplayControl} {onEditIconClick} />
+              {/each}
+            </div>
+          {/if}
+          {#if thumbnails.length > 0}
+            <p class="font-medium">Thumbnails</p>
+            {#each thumbnails as thumbnail}
+              <Thumbnail
+                imageDimension={thumbnail.baseImageDimensions}
+                coords={thumbnail.coords}
+                imageUrl={`/${thumbnail.uri}`}
+                minSide={150}
+                maxWidth={200}
+                maxHeight={200}
+              />
+              {#if Object.keys($mediaViews).length > 1}
+                <span class="text-center italic">{thumbnail.view}</span>
+              {/if}
+            {/each}
+          {/if}
           <TextSpansContent annotations={entity.ui.childs} />
         </div>
       </div>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -64,8 +64,8 @@ License: CECILL-C
     const displayFeat = getDefaultDisplayFeat(entity);
     displayName = displayFeat ? `${displayFeat} (${entity.id})` : entity.id;
   }
-
   $: color = $colorScale[1](entity.id);
+  $: entity.ui.displayControl.open = highlightState === "self";
 
   const isAllowedChild = (child: Annotation): boolean => {
     if (child.ui.datasetItemType !== WorkspaceType.VIDEO) return true;

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -57,6 +57,7 @@ License: CECILL-C
   let highlightState: string = "all";
   let isVisible: boolean = true;
   let childsPanelOpen = true;
+  let thumbnailsPanelOpen = false;
   let hiddenTrack = entity.is_track ? entity.ui.displayControl.hidden : false;
 
   let displayName: string;
@@ -433,20 +434,33 @@ License: CECILL-C
             </div>
           {/if}
           {#if thumbnails.length > 0}
-            <p class="font-medium">Thumbnails</p>
-            {#each thumbnails as thumbnail}
-              <Thumbnail
-                imageDimension={thumbnail.baseImageDimensions}
-                coords={thumbnail.coords}
-                imageUrl={`/${thumbnail.uri}`}
-                minSide={150}
-                maxWidth={200}
-                maxHeight={200}
-              />
-              {#if Object.keys($mediaViews).length > 1}
-                <span class="text-center italic">{thumbnail.view}</span>
-              {/if}
-            {/each}
+            <div class="flex justify-between items-center">
+              <p class="font-medium">Thumbnails</p>
+              <IconButton
+                on:click={() => (thumbnailsPanelOpen = !thumbnailsPanelOpen)}
+                tooltipContent={thumbnailsPanelOpen ? "Hide thumbnails" : "Show thumbnails"}
+              >
+                <ChevronRight
+                  class={cn("transition", { "rotate-90": thumbnailsPanelOpen })}
+                  strokeWidth={1}
+                />
+              </IconButton>
+            </div>
+            {#if thumbnailsPanelOpen}
+              {#each thumbnails as thumbnail}
+                <Thumbnail
+                  imageDimension={thumbnail.baseImageDimensions}
+                  coords={thumbnail.coords}
+                  imageUrl={`/${thumbnail.uri}`}
+                  minSide={150}
+                  maxWidth={200}
+                  maxHeight={200}
+                />
+                {#if Object.keys($mediaViews).length > 1}
+                  <span class="text-center italic">{thumbnail.view}</span>
+                {/if}
+              {/each}
+            {/if}
           {/if}
           <TextSpansContent annotations={entity.ui.childs} />
         </div>

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -343,12 +343,10 @@ License: CECILL-C
     <div
       class={cn(
         "flex-shrink-0 flex items-center justify-end",
-        showIcons || entity.ui.displayControl.editing
+        showIcons
           ? entity.is_track
-            ? $selectedTool.type !== ToolType.Fusion
-              ? "basis-[160px]"
-              : "basis-[120px]"
-            : "basis-[120px]"
+            ? "basis-[120px]"
+            : "basis-[80px]"
           : entity.is_track && hiddenTrack
             ? "basis-[80px]"
             : "basis-[40px]",
@@ -356,15 +354,6 @@ License: CECILL-C
       style="min-width: 40px;"
     >
       {#if showIcons || entity.ui.displayControl.editing}
-        {#if $selectedTool.type !== ToolType.Fusion}
-          <IconButton
-            tooltipContent="Edit object"
-            selected={entity.ui.displayControl.editing}
-            on:click={() => onEditIconClick()}
-          >
-            <Pencil class="h-4" />
-          </IconButton>
-        {/if}
         <IconButton tooltipContent="Delete object" redconfirm on:click={() => deleteObject(entity)}>
           <Trash2 class="h-4" />
         </IconButton>
@@ -396,7 +385,19 @@ License: CECILL-C
       >
         <div class="flex flex-col gap-2">
           <div class="w-full block">
-            <p class="font-medium">Features</p>
+            <div class="flex justify-between items-center">
+              <p class="font-medium">Features</p>
+              {#if $selectedTool.type !== ToolType.Fusion}
+                <IconButton
+                  tooltipContent="Edit object"
+                  selected={entity.ui.displayControl.editing}
+                  on:click={() => onEditIconClick()}
+                >
+                  <Pencil class="h-4" />
+                </IconButton>
+              {/if}
+            </div>
+
             <UpdateFeatureInputs
               featureClass="objects"
               features={$features}

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsModelSection.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsModelSection.svelte
@@ -80,7 +80,7 @@ License: CECILL-C
     </IconButton>
     <h3 class="uppercase font-medium grow">{sectionTitle}</h3>
     <IconButton
-      tooltipContent={"Filters: confidence, interpolation"}
+      tooltipContent={"Generic options"}
       selected={showFilters}
       on:click={() => (showFilters = !showFilters)}
     >
@@ -90,7 +90,7 @@ License: CECILL-C
     <p>{numberOfItem}</p>
   </div>
   {#if showFilters}
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-2 border-2 rounded-md border-primary p-2">
       <span>Confidence threshold</span>
       <SliderWithValue
         bind:value={confidenceThreshold}
@@ -99,7 +99,7 @@ License: CECILL-C
         max={1}
         step={0.01}
       />
-      <div class="ml-4 flex gap-4 items-center">
+      <div class="flex gap-4 items-center">
         <Checkbox
           handleClick={() => {
             $interpolate = !$interpolate;

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsModelSection.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectsModelSection.svelte
@@ -10,12 +10,12 @@ License: CECILL-C
   import { onMount } from "svelte";
   import { derived } from "svelte/store";
 
-  import { BaseSchema, BBox, IconButton, Source } from "@pixano/core/src";
+  import { BaseSchema, BBox, Checkbox, IconButton, Source } from "@pixano/core/src";
   import SliderWithValue from "@pixano/core/src/components/ui/slider/SliderWithValue.svelte";
 
   import { toggleObjectDisplayControl } from "../../lib/api/objectsApi";
   import { GROUND_TRUTH, OTHER } from "../../lib/constants";
-  import { annotations } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { annotations, interpolate } from "../../lib/stores/datasetItemWorkspaceStores";
 
   export let source: Source | undefined;
   export let numberOfItem: number;
@@ -80,7 +80,7 @@ License: CECILL-C
     </IconButton>
     <h3 class="uppercase font-medium grow">{sectionTitle}</h3>
     <IconButton
-      tooltipContent={"Filter: confidence"}
+      tooltipContent={"Filters: confidence, interpolation"}
       selected={showFilters}
       on:click={() => (showFilters = !showFilters)}
     >
@@ -90,7 +90,7 @@ License: CECILL-C
     <p>{numberOfItem}</p>
   </div>
   {#if showFilters}
-    <div>
+    <div class="flex flex-col gap-2">
       <span>Confidence threshold</span>
       <SliderWithValue
         bind:value={confidenceThreshold}
@@ -99,6 +99,15 @@ License: CECILL-C
         max={1}
         step={0.01}
       />
+      <div class="ml-4 flex gap-4 items-center">
+        <Checkbox
+          handleClick={() => {
+            $interpolate = !$interpolate;
+          }}
+          checked={$interpolate}
+        />
+        <span>Interpolate</span>
+      </div>
     </div>
   {/if}
   <div class="p-2 pt-0 max-h-full">

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -54,7 +54,6 @@ License: CECILL-C
   export let onAddKeyItemClick: (event: MouseEvent) => void;
   export let onSplitTrackletClick: () => void;
   export let onDeleteTrackletClick: () => void;
-  //export let onRelinkTrackletClick: () => void;
   export let findNeighborItems: (tracklet: Tracklet, frameIndex: number) => [number, number];
   export let moveCursorToPosition: (clientX: number) => void;
   export let resetTool: () => void;

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -312,17 +312,19 @@ License: CECILL-C
     />
   </ContextMenu.Trigger>
   <ContextMenu.Content>
-    {#if canAddKeyFrame}
-      <ContextMenu.Item on:click={(event) => onAddKeyItemClick(event)}>
-        Add a point at frame {$currentFrameIndex}
-      </ContextMenu.Item>
-    {/if}
-    {#if canSplit}
-      <ContextMenu.Item on:click={onSplitTrackletClick}>
-        Split tracklet after frame {$currentFrameIndex}
-      </ContextMenu.Item>
-    {/if}
-    {#if $selectedTool.type !== ToolType.Fusion}
+    {#if $selectedTool.type === ToolType.Fusion}
+      <ContextMenu.Item>Context options disabled while in association mode</ContextMenu.Item>
+    {:else}
+      {#if canAddKeyFrame}
+        <ContextMenu.Item on:click={(event) => onAddKeyItemClick(event)}>
+          Add a point at frame {$currentFrameIndex}
+        </ContextMenu.Item>
+      {/if}
+      {#if canSplit}
+        <ContextMenu.Item on:click={onSplitTrackletClick}>
+          Split tracklet after frame {$currentFrameIndex}
+        </ContextMenu.Item>
+      {/if}
       {#if leftTracklet}
         <ContextMenu.Item on:click={() => onGlueTrackletClick("left")}>
           Glue to left
@@ -334,20 +336,20 @@ License: CECILL-C
         </ContextMenu.Item>
       {/if}
       <ContextMenu.Item on:click={onRelinkTrackletClick}>Relink tracklet</ContextMenu.Item>
-    {/if}
-    <ContextMenu.Item on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
-    {#if showRelink}
-      <div class="flex flex-row gap-4 items-center mr-4">
-        <RelinkAnnotation
-          bind:selectedEntityId
-          bind:mustMerge
-          bind:overlapTargetId
-          baseSchema={tracklet.table_info.base_schema}
-          viewRef={tracklet.data.view_ref}
-          {tracklet}
-        />
-        <Button class="text-white mt-4" on:click={handleRelink}>OK</Button>
-      </div>
+      <ContextMenu.Item on:click={onDeleteTrackletClick}>Delete tracklet</ContextMenu.Item>
+      {#if showRelink}
+        <div class="flex flex-row gap-4 items-center mr-4">
+          <RelinkAnnotation
+            bind:selectedEntityId
+            bind:mustMerge
+            bind:overlapTargetId
+            baseSchema={tracklet.table_info.base_schema}
+            viewRef={tracklet.data.view_ref}
+            {tracklet}
+          />
+          <Button class="text-white mt-4" on:click={handleRelink}>OK</Button>
+        </div>
+      {/if}
     {/if}
   </ContextMenu.Content>
 </ContextMenu.Root>

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTracklet.svelte
@@ -64,12 +64,13 @@ License: CECILL-C
   let mustMerge: boolean = false;
   let overlapTargetId: string = "";
 
+  const tracklet_margin = 0.3;
   const getLeft = (tracklet: Tracklet) => {
-    let start = Math.max(0, tracklet.data.start_timestep - 0.5);
+    let start = Math.max(0, tracklet.data.start_timestep - tracklet_margin);
     return (start / ($lastFrameIndex + 1)) * 100;
   };
   const getRight = (tracklet: Tracklet) => {
-    let end = Math.max(tracklet.data.start_timestep, tracklet.data.end_timestep) + 0.5;
+    let end = Math.max(tracklet.data.start_timestep, tracklet.data.end_timestep) + tracklet_margin;
     return (end / ($lastFrameIndex + 1)) * 100;
   };
   const getHeight = (views: MView) => 80 / Object.keys(views).length;

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -137,7 +137,10 @@ License: CECILL-C
   </ContextMenu.Trigger>
   <ContextMenu.Content>
     {#if tracklet.ui.childs?.length > 2}
-      <ContextMenu.Item on:click={() => onDeleteItemClick(tracklet, itemFrameIndex)}>
+      <ContextMenu.Item
+        on:click={() => onDeleteItemClick(tracklet, itemFrameIndex)}
+        title="Remove all shapes under this key. For selective delete, use Objects panel."
+      >
         Remove item
       </ContextMenu.Item>
     {/if}

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/TrackletKeyItem.svelte
@@ -6,13 +6,12 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import type { SaveItem, TrackletItem } from "@pixano/core";
-  import { BaseSchema, cn, ContextMenu, Tracklet } from "@pixano/core";
+  import type { TrackletItem } from "@pixano/core";
+  import { cn, ContextMenu, Tracklet } from "@pixano/core";
 
-  import { sourcesStore } from "../../../../../apps/pixano/src/lib/stores/datasetStores";
   import { isLuminanceHigh } from "../../../../core/src/lib/utils/colorUtils";
-  import { addOrUpdateSaveItem, getPixanoSource } from "../../lib/api/objectsApi";
-  import { annotations, entities, saveData } from "../../lib/stores/datasetItemWorkspaceStores";
+  import { onDeleteItemClick } from "../../lib/api/objectsApi";
+  import { annotations } from "../../lib/stores/datasetItemWorkspaceStores";
   import { currentFrameIndex, lastFrameIndex } from "../../lib/stores/videoViewerStores";
 
   export let trackId: string;
@@ -51,68 +50,6 @@ License: CECILL-C
     );
     isItemBeingEdited = currentObjectsBeingEdited.length === 1;
   }
-
-  const onDeleteItemClick = () => {
-    const anns_to_del = tracklet.ui.childs.filter((ann) => ann.ui.frame_index === itemFrameIndex);
-    if (!anns_to_del) return;
-    const anns_to_del_ids = anns_to_del.map((ann) => ann.id);
-    if (tracklet.ui.childs.length <= 2) {
-      console.error("Deleting one of 2 last item of tracklet, it should not happen.");
-      return;
-    }
-    let changed_tracklet = false;
-    annotations.update((anns) =>
-      anns
-        .map((ann) => {
-          if (ann.id === tracklet.id && ann.is_type(BaseSchema.Tracklet)) {
-            (ann as Tracklet).ui.childs = (ann as Tracklet).ui.childs.filter(
-              (fann) => !anns_to_del_ids.includes(fann.id),
-            );
-            //if ann_to_del first/last of tracklet, need to "resize" (childs should be sorted)
-            if (itemFrameIndex === tracklet.data.start_timestep) {
-              (ann as Tracklet).data.start_timestep = (
-                ann as Tracklet
-              ).ui.childs[0].ui.frame_index!;
-              changed_tracklet = true;
-            }
-            if (itemFrameIndex === tracklet.data.end_timestep) {
-              (ann as Tracklet).data.end_timestep = (ann as Tracklet).ui.childs[
-                (ann as Tracklet).ui.childs.length - 1
-              ].ui.frame_index!;
-              changed_tracklet = true;
-            }
-          }
-          return ann;
-        })
-        .filter((ann) => !anns_to_del_ids.includes(ann.id)),
-    );
-    entities.update((ents) =>
-      ents.map((ent) => {
-        if (ent.is_track && ent.id === tracklet.data.entity_ref.id) {
-          ent.ui.childs = ent.ui.childs?.filter((ann) => !anns_to_del_ids.includes(ann.id));
-        }
-        return ent;
-      }),
-    );
-
-    for (const ann_to_del of anns_to_del) {
-      const save_del_ann: SaveItem = {
-        change_type: "delete",
-        object: ann_to_del,
-      };
-      saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_del_ann));
-    }
-
-    if (changed_tracklet) {
-      const pixSource = getPixanoSource(sourcesStore);
-      tracklet.data.source_ref = { id: pixSource.id, name: pixSource.table_info.name };
-      const save_upd_tracklet: SaveItem = {
-        change_type: "update",
-        object: tracklet,
-      };
-      saveData.update((current_sd) => addOrUpdateSaveItem(current_sd, save_upd_tracklet));
-    }
-  };
 
   export const getKeyItemLeftPosition = (frameIndex: number) => {
     const itemFrameIndex = frameIndex > $lastFrameIndex ? $lastFrameIndex : frameIndex;
@@ -200,7 +137,9 @@ License: CECILL-C
   </ContextMenu.Trigger>
   <ContextMenu.Content>
     {#if tracklet.ui.childs?.length > 2}
-      <ContextMenu.Item on:click={() => onDeleteItemClick()}>Remove item</ContextMenu.Item>
+      <ContextMenu.Item on:click={() => onDeleteItemClick(tracklet, itemFrameIndex)}>
+        Remove item
+      </ContextMenu.Item>
     {/if}
     {#if !isItemBeingEdited}
       <ContextMenu.Item

--- a/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/scrollIntoView.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/api/objectsApi/scrollIntoView.ts
@@ -6,9 +6,28 @@ License: CECILL-C
 
 export const scrollIntoView = (entity_id: string) => {
   const cardElement = document.querySelector(`#card-object-${entity_id}`);
-  if (cardElement) {
-    cardElement.scrollIntoView({ block: "center" });
-  }
+  const scrollContainer = document.querySelector("#card-object-container") as HTMLElement;
+
+  if (!cardElement || !scrollContainer) return;
+
+  // Wait for layout to stabilize before scrolling
+  let attempts = 0;
+  const maxAttempts = 10;
+
+  const tryScroll = () => {
+    const cardRect = cardElement.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const scrollOffset = cardRect.top - containerRect.top;
+
+    // Check if card is already aligned; if not, scroll
+    if (Math.abs(scrollOffset) > 1 && attempts < maxAttempts) {
+      scrollContainer.scrollBy({ top: scrollOffset, behavior: "smooth" });
+      attempts++;
+      requestAnimationFrame(tryScroll);
+    }
+  };
+  requestAnimationFrame(tryScroll);
+
   const trackElement = document
     .querySelector(`#video-object-${entity_id}`)
     ?.getElementsByClassName("video-tracklet");

--- a/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/stores/datasetItemWorkspaceStores.ts
@@ -77,6 +77,9 @@ export const selectedKeypointsTemplate = writable<KeypointsTemplate["template_id
 
 export const saveData = writable<SaveItem[]>([]);
 export const canSave = derived(saveData, ($saveData) => $saveData.length > 0);
+
+export const interpolate = writable<boolean>(true);
+
 type ColorScale = [Array<string>, (id: string) => string];
 
 const initialColorScale: ColorScale = [[], utils.ordinalColorScale([])];
@@ -168,8 +171,8 @@ export const conversations = derived(entities, ($entities) => {
 });
 
 export const current_itemBBoxes = derived(
-  [itemBboxes, currentFrameIndex, tracklets, mediaViews],
-  ([$itemBboxes, $currentFrameIndex, $tracklets, $mediaViews]) => {
+  [itemBboxes, currentFrameIndex, tracklets, mediaViews, interpolate],
+  ([$itemBboxes, $currentFrameIndex, $tracklets, $mediaViews, $interpolate]) => {
     const current_bboxes_and_interpolated: BBox[] = [];
     const current_tracklets = $tracklets.filter(
       (tracklet) =>
@@ -183,7 +186,7 @@ export const current_itemBBoxes = derived(
       const bbox_childs = $itemBboxes.filter((bbox) => bbox_childs_ids.has(bbox.id));
       const box = bbox_childs.find((box) => box.ui.frame_index === $currentFrameIndex);
       if (box) current_bboxes_and_interpolated.push(box);
-      else if (bbox_childs.length > 1) {
+      else if (bbox_childs.length > 1 && $interpolate) {
         const sample_bbox = bbox_childs[0];
         const view_id = ($mediaViews[sample_bbox.data.view_ref.name] as SequenceFrame[])[
           $currentFrameIndex
@@ -197,8 +200,8 @@ export const current_itemBBoxes = derived(
 );
 
 export const current_itemKeypoints = derived(
-  [itemKeypoints, currentFrameIndex, tracklets, mediaViews],
-  ([$itemKeypoints, $currentFrameIndex, $tracklets, $mediaViews]) => {
+  [itemKeypoints, currentFrameIndex, tracklets, mediaViews, interpolate],
+  ([$itemKeypoints, $currentFrameIndex, $tracklets, $mediaViews, $interpolate]) => {
     const current_kpts_and_interpolated: KeypointsTemplate[] = [];
     const current_tracklets = $tracklets.filter(
       (tracklet) =>
@@ -212,7 +215,7 @@ export const current_itemKeypoints = derived(
       const kpt_childs = $itemKeypoints.filter((kpt) => kpt_childs_ids.has(kpt.id));
       const kpt = kpt_childs.find((kpt) => kpt.ui!.frame_index === $currentFrameIndex);
       if (kpt) current_kpts_and_interpolated.push(kpt);
-      else if (kpt_childs.length > 1) {
+      else if (kpt_childs.length > 1 && $interpolate) {
         const sample_kpt = kpt_childs[0];
         const view_id = ($mediaViews[sample_kpt.viewRef!.name] as SequenceFrame[])[
           $currentFrameIndex


### PR DESCRIPTION
## Issue

Several bugfixes and enhancement on ObjectCard, ChilCard and VideoInspector.

Fixes #459 #513 #536 #552

## Description

Bugfixes:
- [x] visibility icon in ChildCard was not reactive
- [x] annotations features were not displayed if not in video mode.
- [x] scrollIntoView (after highlighting) was not really right -- now the selected object is always on top of scroll view

Enhancements:
- [x] some minor layout adjustement (margins, justify, tooltips...)
- [x] allow to open/close ChildCards panel (default: open).
- [x] allow to open/close Thumbnails panel (default: closed).
- [x] remove edit icon for text span (not editable).
- [x] Features value now right justified.
- [x] move Object edit icon to Features line.
- [x] move Tracklet (in ChildCard) edit icon to tracklet childs.
- [x] add delete for tracklet childs
- [x] disallow tracklet context menu options (add, split, glue, relink, delete) while in association mode (to prevent unmanaged side effects)
- [x] open objectCard when object selected (highlighted) -- also close others.
- [x] adjust tracklet margin (previous margin make a splitted tracklet too close from next one if on next frame)
- [x] add a tooltip on context menu Delete for KeyItem to warn that it will delete all shapes (BBox, Mask, Keypoints) under this keyItem
- [x] add a flag in "Filters" to set bbox & keypoints interpolation ON/OFF
- [x] put a border on "Filters" for readability / design / style