### PR TITLE
feat(front): Improve navigation keyboard shortcuts

### DIFF
--- a/ui/apps/pixano/src/components/layout/DatasetItemHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetItemHeader.svelte
@@ -42,7 +42,7 @@ License: CECILL-C
           break;
         case "ArrowLeft":
         case "KeyA":
-      await goToNeighborItem("previous");
+          await goToNeighborItem("previous");
           break;
       }
     }
@@ -64,13 +64,13 @@ License: CECILL-C
       {currentItemId}
       <IconButton
         on:click={() => goToNeighborItem("previous")}
-        tooltipContent="Previous item (shift + left arrow)"
+        tooltipContent="Previous item (Shift + Left / Shift + A or Q)"
       >
         <ArrowLeft />
       </IconButton>
       <IconButton
         on:click={() => goToNeighborItem("next")}
-        tooltipContent="Next item (shift + right arrow)"
+        tooltipContent="Next item (Shift + Right / Shift + D)"
       >
         <ArrowRight />
       </IconButton>

--- a/ui/apps/pixano/src/components/layout/DatasetItemHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetItemHeader.svelte
@@ -34,10 +34,17 @@ License: CECILL-C
       event.stopPropagation();
       return;
     }
-    if (event.shiftKey && event.key === "ArrowLeft") {
+    if (event.shiftKey) {
+      switch (event.code) {
+        case "ArrowRight":
+        case "KeyD":
+          await goToNeighborItem("next");
+          break;
+        case "ArrowLeft":
+        case "KeyA":
       await goToNeighborItem("previous");
-    } else if (event.shiftKey && event.key === "ArrowRight") {
-      await goToNeighborItem("next");
+          break;
+      }
     }
     return event.key;
   };

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
@@ -89,17 +89,19 @@ License: CECILL-C
       return; // Ignore shortcut when typing text
     }
 
-    switch (event.key) {
-      case " ":
+    switch (event.code) {
+      case "Space":
         if (event.repeat) break;
         event.preventDefault();
         onPlayClick();
         break;
       case "ArrowRight":
+      case "KeyD":
         if (event.shiftKey) break;
         onPlayStepClick();
         break;
       case "ArrowLeft":
+      case "KeyA":
         if (event.shiftKey) break;
         onPlayStepBackClick();
         break;

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoControls.svelte
@@ -122,13 +122,13 @@ License: CECILL-C
     {/if}
   </button>
   <button
-    title="One step backward (left arrow)"
+    title="Previous frame (Left / A or Q)"
     on:click={onPlayStepBackClick}
     class="text-primary"
   >
     <StepBack />
   </button>
-  <button title="One step forward (right arrow)" on:click={onPlayStepClick} class="text-primary">
+  <button title="Next frame (Right / D)" on:click={onPlayStepClick} class="text-primary">
     <StepForward />
   </button>
   <p>


### PR DESCRIPTION
## Description

* Since a lot of annotation actions in Pixano involve using the mouse in the right hand, add the option to navigate video frames with the left hand (WASD/ZQSD) rather than just with the right hand (Arrow keys)
* Replace `event.code` instead of `event.key` to be able to use the same physical keys regardless of keyboard layout (QWERTY, AZERTY, or other)