### PR TITLE
add unsubscribers

### DIFF
--- a/ui/apps/pixano/src/components/dataset/DatasetPagination.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetPagination.svelte
@@ -6,6 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
+
   import type { DatasetBrowser } from "@pixano/core/src";
   import {
     svg_first_page,
@@ -28,10 +30,12 @@ License: CECILL-C
   let currentPage: number;
   let pageSize: number;
 
-  datasetTableStore.subscribe((value) => {
+  const unsubscribeDatasetTableStore = datasetTableStore.subscribe((value) => {
     currentPage = value?.currentPage || DEFAULT_DATASET_TABLE_PAGE;
     pageSize = value?.pageSize || DEFAULT_DATASET_TABLE_SIZE;
   });
+
+  onDestroy(unsubscribeDatasetTableStore);
 
   function handleGoToFirstPage() {
     if (currentPage > 1) {

--- a/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/DatasetHeader.svelte
@@ -6,6 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
+
   import { ConfirmModal, IconButton, PrimaryButton } from "@pixano/core/src";
   import pixanoLogo from "@pixano/core/src/assets/pixano.png";
 
@@ -32,14 +34,22 @@ License: CECILL-C
 
   const DATASET_ITEM_ROUTE = `/[dataset]/dataset/[itemId]`;
 
-  saveCurrentItemStore.subscribe((value) => (canSaveCurrentItem = value.canSave));
+  const unsubscribeSaveCurrentItemStore = saveCurrentItemStore.subscribe(
+    (value) => (canSaveCurrentItem = value.canSave),
+  );
 
-  isLoadingNewItemStore.subscribe((value) => {
+  const unsubscribeisLoadingNewItemStore = isLoadingNewItemStore.subscribe((value) => {
     isLoading = value;
   });
 
-  $: page.subscribe((value) => {
+  $: unsubscribePage = page.subscribe((value) => {
     currentItemId = value.params.itemId;
+  });
+
+  onDestroy(() => {
+    unsubscribeSaveCurrentItemStore();
+    unsubscribeisLoadingNewItemStore();
+    unsubscribePage();
   });
 
   const getDatasetItemDisplayCount = () => {

--- a/ui/apps/pixano/src/lib/stores/datasetStores.ts
+++ b/ui/apps/pixano/src/lib/stores/datasetStores.ts
@@ -23,7 +23,7 @@ export const defaultDatasetTableValues: DatasetTableStore = {
 // Exports
 export const currentDatasetStore = writable<DatasetInfo>();
 export const datasetSchema = writable<DatasetSchema>();
-export const datasetsStore = writable<DatasetInfo[]>();
+export const datasetsStore = writable<DatasetInfo[]>([]);
 export const modelsStore = writable<string[]>([]);
 export const isLocalSegmentationModel = writable<boolean>(false);
 export const sourcesStore = writable<Source[]>([]);

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
   import { api, cn } from "@pixano/core/src";
 
@@ -48,7 +48,7 @@ License: CECILL-C
   // Get all the ids of the items of the selected dataset
   $: void getCurrentDatasetItemsIds(currentDatasetId); //void here to avoid .then/.catch. But maybe we could manage error ?
 
-  datasetTableStore.subscribe((value) => {
+  const unsubscribeDatasetTableStore = datasetTableStore.subscribe((value) => {
     if (value.where != undefined) {
       datasetTotalItemsCount.set($datasetItemIds.length);
     }
@@ -65,7 +65,7 @@ License: CECILL-C
     }
   };
 
-  $: page.subscribe((value) => {
+  $: unsubscribePage = page.subscribe((value) => {
     currentDatasetId = value.params.dataset;
     // if currentDatasetStore is not set yet (happens from a refresh on a datasetItem page), set it now
     if (currentDatasetId && $currentDatasetStore == null) {
@@ -76,13 +76,17 @@ License: CECILL-C
     }
   });
 
-  $: {
-    currentDatasetStore.subscribe((currentDataset) => {
-      if (currentDataset) {
-        datasetTableStore.set(defaultDatasetTableValues);
-      }
-    });
-  }
+  $: unsubscribeCurrentDatasetStore = currentDatasetStore.subscribe((currentDataset) => {
+    if (currentDataset) {
+      datasetTableStore.set(defaultDatasetTableValues);
+    }
+  });
+
+  onDestroy(() => {
+    unsubscribeDatasetTableStore();
+    unsubscribePage();
+    unsubscribeCurrentDatasetStore();
+  });
 </script>
 
 <svelte:head>

--- a/ui/apps/pixano/src/routes/+page.svelte
+++ b/ui/apps/pixano/src/routes/+page.svelte
@@ -6,18 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import type { DatasetInfo } from "@pixano/core/src";
-
   import DatasetsLibrary from "../components/library/DatasetsLibrary.svelte";
   import { datasetsStore } from "../lib/stores/datasetStores";
-
-  let datasets: Array<DatasetInfo>;
-
-  datasetsStore.subscribe((value) => {
-    if (value) {
-      datasets = value;
-    }
-  });
 </script>
 
-<DatasetsLibrary {datasets} />
+<DatasetsLibrary datasets={$datasetsStore} />

--- a/ui/apps/pixano/src/routes/[dataset]/dashboard/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dashboard/+page.svelte
@@ -6,44 +6,12 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { onDestroy } from "svelte";
-
-  import type { DatasetInfo } from "@pixano/core/src";
-
   import Dashboard from "../../../components/dashboard/Dashboard.svelte";
   import { currentDatasetStore } from "$lib/stores/datasetStores";
-
-  let selectedDataset: DatasetInfo;
-
-  $: getDatasetInfo = currentDatasetStore.subscribe(
-    (datasetInfo) => (selectedDataset = datasetInfo),
-  );
-
-  onDestroy(() => {
-    getDatasetInfo();
-  });
-
-  //import { afterUpdate } from "svelte";
-
-  // get stats if not already loaded, and allow stats on page refresh
-
-  //TMP: disabled, need a rework following python refactor
-
-  // afterUpdate(async () => {
-  //   if (selectedDataset && selectedDataset.stats == undefined) {
-  //     const completedDatasetwithStats = await api.getDataset(selectedDataset.id);
-  //     if (
-  //       completedDatasetwithStats.stats !== undefined &&
-  //       completedDatasetwithStats.stats?.length > 0
-  //     ) {
-  //       selectedDataset.stats = completedDatasetwithStats.stats;
-  //     }
-  //   }
-  // });
 </script>
 
-{#if selectedDataset}
+{#if $currentDatasetStore}
   <div class="pt-20 h-1 min-h-screen">
-    <Dashboard {selectedDataset} />
+    <Dashboard selectedDataset={$currentDatasetStore} />
   </div>
 {/if}

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/+page.svelte
@@ -18,18 +18,15 @@ License: CECILL-C
   import { page } from "$app/stores";
   import { datasetItemIds, datasetTableStore } from "$lib/stores/datasetStores";
 
-  let selectedDatasetId: string;
   let selectedDataset: DatasetBrowser;
   let showNoRowModal = false;
-
-  $: page.subscribe((value) => (selectedDatasetId = value.params.dataset));
 
   let unsubscribe2datasetTableStore: Unsubscriber;
   onMount(() => {
     unsubscribe2datasetTableStore = datasetTableStore.subscribe((pagination) => {
-      if (selectedDatasetId) {
+      if ($page.params.dataset) {
         getBrowser(
-          selectedDatasetId,
+          $page.params.dataset,
           pagination.currentPage,
           pagination.pageSize,
           pagination.query,

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/[itemId]/+page.svelte
@@ -6,6 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
+
   import {
     api,
     BaseSchema,
@@ -35,7 +37,6 @@ License: CECILL-C
 
   let selectedItem: DatasetItem;
   let selectedDataset: DatasetInfo;
-  let models: Array<string>;
   let currentDatasetId: string;
   let currentItemId: string;
   let isLoadingNewItem: boolean = false;
@@ -44,11 +45,7 @@ License: CECILL-C
   let noItemFound: boolean = false;
   let featureValues: FeaturesValues = { main: {}, objects: {} };
 
-  modelsStore.subscribe((value) => {
-    models = value;
-  });
-
-  saveCurrentItemStore.subscribe((value) => {
+  const unsubscribeSaveCurrentItemStore = saveCurrentItemStore.subscribe((value) => {
     canSaveCurrentItem = value.canSave;
     shouldSaveCurrentItem = value.shouldSave;
   });
@@ -195,12 +192,12 @@ License: CECILL-C
       .catch((err) => console.error(err));
   };
 
-  page.subscribe((value) => {
+  const unsubscribePage = page.subscribe((value) => {
     currentDatasetId = value.params.dataset;
     currentItemId = value.params.itemId;
   });
 
-  datasetsStore.subscribe((value) => {
+  const unsubscribeDatasetsStore = datasetsStore.subscribe((value) => {
     const foundDataset = value?.find((dataset) => dataset.id === currentDatasetId);
     if (foundDataset) {
       selectedDataset = foundDataset;
@@ -218,8 +215,15 @@ License: CECILL-C
     }
   }
 
-  $: isLoadingNewItemStore.subscribe((value) => {
+  $: unsubscibeIsLoadingNewItemStore = isLoadingNewItemStore.subscribe((value) => {
     isLoadingNewItem = value;
+  });
+
+  onDestroy(() => {
+    unsubscribeDatasetsStore();
+    unsubscribePage();
+    unsubscribeSaveCurrentItemStore();
+    unsubscibeIsLoadingNewItemStore();
   });
 
   function reduceByTypeAndGroupAndTable(
@@ -324,7 +328,7 @@ License: CECILL-C
 {#if selectedItem && selectedDataset}
   <DatasetItemWorkspace
     {selectedItem}
-    {models}
+    models={$modelsStore}
     {featureValues}
     {handleSaveItem}
     isLoading={isLoadingNewItem}

--- a/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
+++ b/ui/components/datasetItemWorkspace/src/DatasetItemWorkspace.svelte
@@ -29,6 +29,8 @@ License: CECILL-C
 
   import "./index.css";
 
+  import { onDestroy } from "svelte";
+
   import { getTopEntity } from "./lib/api/objectsApi";
   import { sortByFrameIndex } from "./lib/api/videoApi";
   import {
@@ -169,7 +171,11 @@ License: CECILL-C
     saveData.set([]);
   };
 
-  canSave.subscribe((value) => (canSaveCurrentItem = value));
+  const unsubscribeCanSave = canSave.subscribe((value) => (canSaveCurrentItem = value));
+
+  onDestroy(() => {
+    unsubscribeCanSave();
+  });
 
   $: if (selectedItem) {
     newShape.update((old) => ({ ...old, status: "none" }));

--- a/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/DatasetItemViewer/DatasetItemViewer.svelte
@@ -7,6 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { Loader2Icon } from "lucide-svelte";
+  import { onDestroy } from "svelte";
 
   import {
     api,
@@ -47,9 +48,11 @@ License: CECILL-C
 
   let modelWorking: boolean = false;
 
-  modelsUiStore.subscribe(() => {
+  const unsubscribeModelsUiStore = modelsUiStore.subscribe(() => {
     if (selectedItem) loadViewEmbeddings();
   });
+
+  onDestroy(unsubscribeModelsUiStore);
 
   const pixanoInferenceSegmentation = async (
     viewRef: Reference,

--- a/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Features/CreateFeatureInputs.svelte
@@ -6,6 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
+
   import { BaseSchema, type ItemFeature } from "@pixano/core";
   import { Checkbox, Combobox, Input } from "@pixano/core/src";
 
@@ -33,12 +35,14 @@ License: CECILL-C
   export let baseSchema: BaseSchema;
   let objectValidationSchema: CreateObjectSchema;
 
-  datasetSchema.subscribe((schema) => {
+  const unsubscribeDatasetSchema = datasetSchema.subscribe((schema) => {
     ({ schema: objectValidationSchema, inputs: formInputs } = getValidationSchemaAndFormInputs(
       schema,
       baseSchema,
     ));
   });
+
+  onDestroy(unsubscribeDatasetSchema);
 
   const handleInputChange = (
     value: string | number | boolean,

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/ObjectCard.svelte
@@ -7,6 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { ChevronRight, Eye, EyeOff, ListPlus, ListX, Pencil, Trash2 } from "lucide-svelte";
+  import { onDestroy } from "svelte";
   import { derived } from "svelte/store";
 
   import { TextSpansContent, Thumbnail } from "@pixano/canvas2d";
@@ -161,7 +162,7 @@ License: CECILL-C
     },
   );
 
-  annotations.subscribe(() => {
+  const unsubscribeAnnotations = annotations.subscribe(() => {
     highlightState = "all";
     for (const ann of entity.ui.childs ?? []) {
       if (ann.ui.displayControl.highlighted === "self") {
@@ -303,7 +304,12 @@ License: CECILL-C
       }
     }
   };
-  entities.subscribe(() => setThumbnails());
+  const unsubscribeEntities = entities.subscribe(() => setThumbnails());
+
+  onDestroy(() => {
+    unsubscribeAnnotations();
+    unsubscribeEntities();
+  });
 </script>
 
 <article

--- a/ui/components/datasetItemWorkspace/src/components/Inspector/OptionsAndFilters.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Inspector/OptionsAndFilters.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   // Imports
 
   import { CircleSlash2 } from "lucide-svelte";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onDestroy } from "svelte";
 
   import {
     Annotation,
@@ -89,7 +89,7 @@ License: CECILL-C
     return nonFeatsFields;
   };
 
-  datasetSchema.subscribe((schema) => {
+  const unsubscribeDatasetSchema = datasetSchema.subscribe((schema) => {
     tableColumns = [];
     for (const table of schema.groups["entities"]) {
       if (
@@ -149,6 +149,10 @@ License: CECILL-C
       value: "",
     } as ObjectsFilter;
     entityFilters.set([structuredClone(defaultFilter)]);
+  });
+
+  onDestroy(() => {
+    unsubscribeDatasetSchema();
   });
 
   const handleAddFilter = (logicOperator: LogicOperator) => {

--- a/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/LoadModelModal.svelte
@@ -6,6 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
   import { derived } from "svelte/store";
 
   import {
@@ -40,13 +41,15 @@ License: CECILL-C
     return [...withSam, ...withoutSam];
   });
 
-  modelsUiStore.subscribe((store) => {
+  const unsubscribeModelsUiStore = modelsUiStore.subscribe((store) => {
     currentModalOpen = store.currentModalOpen;
     selectedModelName =
       store.selectedModelName !== "" ? store.selectedModelName : selectedModelName;
     selectedTableName =
       store.selectedTableName !== "" ? store.selectedTableName : selectedTableName;
   });
+
+  onDestroy(unsubscribeModelsUiStore);
 
   const getViewEmbeddings = () => {
     modelsUiStore.update((store) => ({

--- a/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/PreAnnotation/PreAnnotation.svelte
@@ -7,6 +7,7 @@ License: CECILL-C
 <script lang="ts">
   // Imports
   import { BoxSelectIcon, Check, Filter } from "lucide-svelte";
+  import { onDestroy } from "svelte";
 
   import { Annotation, cn, IconButton, PrimaryButton, SliderWithValue, Switch } from "@pixano/core";
   import * as Tooltip from "@pixano/core/src/components/ui/tooltip";
@@ -35,7 +36,7 @@ License: CECILL-C
   $: objectToAnnotate = filteredObjectsToAnnotate[0];
   $: color = $colorScale[1](objectToAnnotate?.id || "");
 
-  annotations.subscribe((objects) => {
+  const unsubscribeAnnotations = annotations.subscribe((objects) => {
     objectsToAnnotate = getObjectsToPreAnnotate(objects);
     filteredObjectsToAnnotate = sortAndFilterObjectsToAnnotate(
       objectsToAnnotate,
@@ -43,6 +44,8 @@ License: CECILL-C
       $currentFrameIndex,
     );
   });
+
+  onDestroy(unsubscribeAnnotations);
 
   $: {
     if ($preAnnotationIsActive && objectsToAnnotate.length === 0) {
@@ -57,7 +60,7 @@ License: CECILL-C
   }
 
   const onAcceptItem = () => {
-    objectToAnnotate.review_state = "accepted";
+    objectToAnnotate.ui.review_state = "accepted";
     objectToAnnotate.ui.displayControl.highlighted = "none";
 
     annotations.update((objects) => [
@@ -145,10 +148,11 @@ License: CECILL-C
           {#key objectToAnnotate.id}
             <CreateFeatureInputs
               bind:isFormValid
-              initialValues={objectToAnnotate.features}
               bind:objectProperties
               isAutofocusEnabled={false}
+              baseSchema={objectToAnnotate.table_info.base_schema}
             />
+            <!-- initialValues={objectToAnnotate.features}  // need rework/rethink -->
           {/key}
         </div>
         <div class="flex gap-4 mt-4 justify-center sticky bottom-0 pb-2 left-[50%] bg-white">

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar.svelte
@@ -16,7 +16,7 @@ License: CECILL-C
     Wand2Icon,
     X,
   } from "lucide-svelte";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import type { SelectionTool } from "@pixano/core";
@@ -85,13 +85,15 @@ License: CECILL-C
     modelsUiStore.update((store) => ({ ...store, currentModalOpen: "selectModel" }));
   };
 
-  interactiveSegmenterModel.subscribe((segmenter) => {
+  const unsubscribeInteractiveSegmenterModel = interactiveSegmenterModel.subscribe((segmenter) => {
     if (segmenter) {
       addSmartPointTool.postProcessor = segmenter;
       removeSmartPointTool.postProcessor = segmenter;
       smartRectangleTool.postProcessor = segmenter;
     }
   });
+
+  onDestroy(unsubscribeInteractiveSegmenterModel);
 
   onMount(() => {
     if ($selectedTool === undefined) selectedTool.set(panTool);

--- a/ui/components/datasetItemWorkspace/src/components/Toolbar/KeyPointsSelectionTool.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/Toolbar/KeyPointsSelectionTool.svelte
@@ -6,6 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
+
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import { cn, IconButton, type SelectionTool, type Vertex } from "@pixano/core/src";
   import keypoints_icon from "@pixano/core/src/assets/lucide_keypoints_icon.svg";
@@ -30,13 +32,15 @@ License: CECILL-C
     newShape.set({ status: "none" });
   };
 
-  selectedTool.subscribe((tool) => {
+  const unsubscribeSelectedTool = selectedTool.subscribe((tool) => {
     if (tool?.type !== ToolType.Keypoint) {
       selectedKeypointsTemplate.set(null);
     } else {
       selectedKeypointsTemplate.set(templates[0].template_id);
     }
   });
+
+  onDestroy(unsubscribeSelectedTool);
 </script>
 
 <div

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/ObjectTrack.svelte
@@ -6,6 +6,8 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
+  import { onDestroy } from "svelte";
+
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import type {
     KeypointsTemplate,
@@ -77,7 +79,7 @@ License: CECILL-C
     ) as Tracklet[];
   }
 
-  annotations.subscribe(() => {
+  const unsubscribeAnnotations = annotations.subscribe(() => {
     highlightState = "all";
     for (const ann of track.ui.childs ?? []) {
       if (ann.ui.displayControl.highlighted === "self") {
@@ -89,6 +91,8 @@ License: CECILL-C
       }
     }
   });
+
+  onDestroy(unsubscribeAnnotations);
 
   const moveCursorToPosition = (clientX: number) => {
     const newPosition = objectTimeTrack.getBoundingClientRect();

--- a/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
+++ b/ui/components/datasetItemWorkspace/src/components/VideoPlayer/VideoInspector.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
   import { ToolType } from "@pixano/canvas2d/src/tools";
   import { BBox, Entity, SliderRoot, type KeypointsTemplate } from "@pixano/core";
@@ -30,9 +30,11 @@ License: CECILL-C
   export let keypoints: KeypointsTemplate[];
 
   let tracks: Entity[] = [];
-  entities.subscribe((entities) => {
+  const unsubscribeEntities = entities.subscribe((entities) => {
     tracks = entities.filter((entity) => entity.is_track).sort(sortEntities);
   });
+
+  onDestroy(unsubscribeEntities);
 
   onMount(() => {
     videoControls.update((old) => ({ ...old, isLoaded: true }));


### PR DESCRIPTION
## Issue

After using Pixano for some time (navigating through several datasetItems and datasets), we can see in logs that some things that should be unique are run several times. 

## Description

A potential origin of this behaviour could be because pixano front doesn't usually unsubscribe, though there is a consequent number of subscribe in front code.

By adding all unsubscribers (called in "onDestroy"), we hope ths could resolve the issue.

WIP ...still under testing...

Note: 
In SceneInspector - line 48 :  $: mediaViews.subscribe(...);
This one cause a bug if unsubscribed... need further investigation...
