### PR TITLE
TextSpan section as table + abort on fetch items_info

### DIFF
--- a/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetPreviewCard.svelte
@@ -6,7 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher, onDestroy, onMount } from "svelte";
 
   import { api, WorkspaceType, type DatasetInfo } from "@pixano/core/src";
   import pixanoLogo from "@pixano/core/src/assets/pixano.png";
@@ -16,6 +16,7 @@ License: CECILL-C
   export let dataset: DatasetInfo;
 
   let additionalInfo: string | undefined = undefined;
+  const controller = new AbortController();
 
   const dispatch = createEventDispatcher();
 
@@ -39,11 +40,13 @@ License: CECILL-C
         return "Undefined";
     }
   }
+
   onMount(() => {
     //get dataset infos to put in tooltip
     api
-      .getItemsInfo(dataset.id)
+      .getItemsInfo(dataset.id, { signal: controller.signal })
       .then((infos) => {
+        if (controller.signal.aborted) return;
         let maxNumViews = 0;
         let entitiesCounts = 0;
         let annCounts: Record<string, number> = {};
@@ -71,6 +74,10 @@ License: CECILL-C
       .catch((err) => {
         console.log("Error collecting additionnal dataset infos", err);
       });
+  });
+
+  onDestroy(() => {
+    controller.abort("aborted");
   });
 </script>
 

--- a/ui/apps/pixano/src/components/layout/MainHeader.svelte
+++ b/ui/apps/pixano/src/components/layout/MainHeader.svelte
@@ -10,12 +10,13 @@ License: CECILL-C
   import pixanoLogoWhite from "@pixano/core/src/assets/pixano_white.png";
   import { svg_search } from "@pixano/core/src/icons";
 
-  import { datasetsStore } from "$lib/stores/datasetStores";
+  import { datasetFilter, datasetsStore } from "$lib/stores/datasetStores";
 
   export let datasets: Array<DatasetInfo>;
 
   const handleSearch = (e: Event) => {
     const target = e.currentTarget as HTMLInputElement;
+    datasetFilter.set(target.value);
     datasetsStore.update((value = []) =>
       value.map((dataset) => ({
         ...dataset,
@@ -58,6 +59,7 @@ License: CECILL-C
               class="h-10 pl-10 pr-4 rounded border border-primary-foreground bg-primary-foreground
               text-white placeholder-white font-medium focus:outline-none"
               on:input={handleSearch}
+              value={$datasetFilter}
             />
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/ui/apps/pixano/src/lib/stores/datasetStores.ts
+++ b/ui/apps/pixano/src/lib/stores/datasetStores.ts
@@ -24,6 +24,7 @@ export const defaultDatasetTableValues: DatasetTableStore = {
 export const currentDatasetStore = writable<DatasetInfo>();
 export const datasetSchema = writable<DatasetSchema>();
 export const datasetsStore = writable<DatasetInfo[]>();
+export const datasetFilter = writable<string>("");
 export const modelsStore = writable<string[]>([]);
 export const isLocalSegmentationModel = writable<boolean>(false);
 export const sourcesStore = writable<Source[]>([]);

--- a/ui/components/canvas2d/src/components/TextSpansContent.svelte
+++ b/ui/components/canvas2d/src/components/TextSpansContent.svelte
@@ -5,37 +5,74 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
+  import { onMount } from "svelte";
+
   import { BaseSchema, TextSpan, type Annotation } from "@pixano/core";
   import { DISPLAY_MENTION_FEATURES } from "@pixano/dataset-item-workspace/src/lib/settings/defaultFeatures";
 
   export let annotations: Annotation[] | undefined;
 
-  const uniqueMentions = (): [string, string][] => {
-    const mentions: [string, string][] = [];
-    const textSpans = annotations?.filter((ann) => ann.is_type(BaseSchema.TextSpan)) ?? [];
-    (textSpans as TextSpan[]).forEach((tspan) => {
-      let mention_label: string = "mention";
-      for (const feat of DISPLAY_MENTION_FEATURES) {
-        if (feat in tspan.data && typeof tspan.data[feat] === "string") {
-          mention_label = tspan.data[feat];
-          break;
+  let col_names: string[] = [];
+  let mentionRows: { [key: string]: string | undefined }[] = [];
+
+  onMount(() => {
+    const textSpans =
+      (annotations?.filter((ann) => ann.is_type(BaseSchema.TextSpan)) as TextSpan[]) ?? [];
+    // get used fields
+    const foundFields = new Set<string>();
+    for (const tspan of textSpans) {
+      for (const field of DISPLAY_MENTION_FEATURES) {
+        const val = tspan.data[field];
+        if (typeof val === "string") {
+          foundFields.add(field);
         }
       }
-      if (!mentions.find(([ml, m]) => ml === mention_label && m === tspan.data.mention))
-        mentions.push([mention_label, tspan.data.mention]);
+    }
+    // force "mention"
+    foundFields.add("mention");
+    // filter col_names
+    col_names = DISPLAY_MENTION_FEATURES.filter((f) => foundFields.has(f));
+    // build rows
+    const rawRows = textSpans.map((tspan) => {
+      const row: { [key: string]: string | undefined } = {};
+      for (const field of col_names) {
+        const val = tspan.data[field];
+        row[field] = typeof val === "string" ? val : undefined;
+      }
+      return row;
     });
-    return Array.from(mentions.values());
-  };
-
-  const mentions = uniqueMentions();
+    // deduplicate
+    const seen = new Set<string>();
+    mentionRows = rawRows.filter((row) => {
+      const key = JSON.stringify(row);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  });
 </script>
 
-{#if annotations?.some((ann) => ann.is_type(BaseSchema.TextSpan))}
-  <p class="font-medium mt-4">Text spans</p>
-  <div class="grid gap-x-4 gap-y-2 grid-cols-[150px_auto] mt-2 pr-4 justify-between">
-    {#each mentions as [mention_label, mention]}
-      <p class="font-medium ml-4">{mention_label}</p>
-      <p>{mention}</p>
-    {/each}
+{#if mentionRows.length > 0}
+  <div class="mt-4 mr-4">
+    <p class="font-medium mb-2">Text spans</p>
+
+    <table class="table-auto border-collapse w-full text-sm">
+      <thead class="bg-gray-100">
+        <tr>
+          {#each col_names as col}
+            <th class="border px-2 py-1 text-left">{col}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each mentionRows as row}
+          <tr>
+            {#each col_names as col}
+              <td class="border px-2 py-1">{row[col] ?? ""}</td>
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
   </div>
 {/if}

--- a/ui/components/core/src/api/getItemsInfo.ts
+++ b/ui/components/core/src/api/getItemsInfo.ts
@@ -6,11 +6,17 @@ License: CECILL-C
 
 import type { DatasetMoreInfo } from "../lib/types/dataset/DatasetMoreInfo";
 
-export async function getItemsInfo(datasetId: string): Promise<Array<DatasetMoreInfo>> {
+export async function getItemsInfo(
+  datasetId: string,
+  options?: { signal?: AbortSignal },
+): Promise<Array<DatasetMoreInfo>> {
   let infos: Array<DatasetMoreInfo>;
 
   try {
-    const response = await fetch(`/items_info/${datasetId}/`);
+    const response = await fetch(`/items_info/${datasetId}/`, {
+      method: "GET",
+      signal: options?.signal,
+    });
     if (response.ok) {
       infos = (await response.json()) as Array<DatasetMoreInfo>;
     } else {
@@ -24,7 +30,7 @@ export async function getItemsInfo(datasetId: string): Promise<Array<DatasetMore
     }
   } catch (e) {
     infos = [];
-    console.log("api.getItemsInfo -", e);
+    if (!(typeof e === "string" && e === "aborted")) console.log("api.getItemsInfo -", e);
   }
 
   return infos;

--- a/ui/components/datasetItemWorkspace/src/lib/settings/defaultFeatures.ts
+++ b/ui/components/datasetItemWorkspace/src/lib/settings/defaultFeatures.ts
@@ -6,8 +6,8 @@ License: CECILL-C
 
 import type { Entity, ItemFeature } from "@pixano/core";
 
-// TextSpan features to use (value) instead of "mention", in this order
-export const DISPLAY_MENTION_FEATURES = ["role"];
+// TextSpan features to display in table of TextSpan section, in this order
+export const DISPLAY_MENTION_FEATURES = ["role", "concept", "mention"];
 
 // default entity features used to display tooltip, in this order
 const DEFAULT_FEATURES = ["name", "category", "category_name"];


### PR DESCRIPTION
## Issue

1. TextSpan section on ObjectCard is not so clear, and we could need more details than "role" (need to add "concept")
2. items_info (for DatasetLibrary preview cards tooltip) could delay model loading if dataset clicked before all fetches done.

## Description

1. Use an HTML table for display, for more clarity and display of column names
2. use fetch AbortSignal to cancel ongoing fetches when leaving Dataset Library page.