### PR TITLE
add timeout to pixano inference connect

### DIFF
--- a/ui/components/core/src/api/inference/isInferenceApiHealthy.ts
+++ b/ui/components/core/src/api/inference/isInferenceApiHealthy.ts
@@ -12,13 +12,13 @@ export async function isInferenceApiHealthy(url: string): Promise<boolean> {
         "Content-Type": "application/json",
       },
       method: "POST",
+      signal: AbortSignal.timeout(4000),
     });
 
     if (!response.ok) {
+      // console.log("api.inferenceConnect -", response.status, response.statusText);
       return false;
     }
-
-    // console.log("api.inferenceConnect -", response.status, response.statusText);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Issue

If for some reason internet connection is broken, inference/connect fetch would hang for default timeout (depending on browser, could take some time)

## Description

Set a shorter timeout (4sec) (this is a fast request on pixano-inference server side)
