### PR TITLE
order by created_at

### DIFF
--- a/pixano/datasets/queries/table.py
+++ b/pixano/datasets/queries/table.py
@@ -204,48 +204,53 @@ class TableQueryBuilder:
         else:
             columns = self._columns
 
+        # #### DISABLED ######
         # If order_by
         #   build the query directly using DuckDB
         # Else
         #   build the query using Lance
         # This is because Lance does not support order_by
         # Also DuckDB is less memory efficient than Lance
+        # ###################
+        # Now we always use use duckdb because we always order by "created_at" when there is no specified order
+        if self._order_by == [] and "created_at" in columns:
+            self._order_by = ["created_at"]
+            self._descending = [False]
+
+        arrow_table = self.table.to_arrow()  # noqa: F841
+
+        def duckdb_format_column(column):
+            if "." in column:
+                struct, property = column.split(".")
+                return f"{struct}['{property}']"
+            return column
+
+        formatted_columns = [duckdb_format_column(col) for col in columns]  # format columns to handle struct columns
+        SQL_QUERY = f"SELECT {', '.join(formatted_columns)} FROM arrow_table"
+        if self._where is not None:
+            SQL_QUERY += f" WHERE {self._where}"
         if self._order_by != []:
-            arrow_table = self.table.to_lance()  # noqa: F841
+            SQL_QUERY += " ORDER BY "
+            SQL_QUERY += ", ".join(
+                [f"{col} {'DESC' if desc else 'ASC'}" for col, desc in zip(self._order_by, self._descending)]
+            )
+        if self._limit is not None:
+            SQL_QUERY += f" LIMIT {self._limit}"
+        if self._offset is not None:
+            SQL_QUERY += f" OFFSET {self._offset}"
 
-            def duckdb_format_column(column):
-                if "." in column:
-                    struct, property = column.split(".")
-                    return f"{struct}['{property}']"
-                return column
-
-            formatted_columns = [
-                duckdb_format_column(col) for col in columns
-            ]  # format columns to handle struct columns
-            SQL_QUERY = f"SELECT {', '.join(formatted_columns)} FROM arrow_table"
-            if self._where is not None:
-                SQL_QUERY += f" WHERE {self._where}"
-            if self._order_by != []:
-                SQL_QUERY += " ORDER BY "
-                SQL_QUERY += ", ".join(
-                    [f"{col} {'DESC' if desc else 'ASC'}" for col, desc in zip(self._order_by, self._descending)]
-                )
-            if self._limit is not None:
-                SQL_QUERY += f" LIMIT {self._limit}"
-            if self._offset is not None:
-                SQL_QUERY += f" OFFSET {self._offset}"
-
-            arrow_results: pa.Table = duckdb.query(SQL_QUERY).to_arrow_table()
-            arrow_results = arrow_results.rename_columns(columns)  # rename columns to match the requested columns
-            return arrow_results
-        else:
-            limit = self.table.count_rows() if self._limit is None else self._limit
-            query = self.table.search(None).select(columns).limit(limit)
-            if self._where is not None:
-                query = query.where(self._where)
-            if self._offset is not None:
-                query = query.offset(self._offset)
-            return query.to_arrow()
+        arrow_results: pa.Table = duckdb.query(SQL_QUERY).to_arrow_table()
+        arrow_results = arrow_results.rename_columns(columns)  # rename columns to match the requested columns
+        return arrow_results
+        # OLD Keep as reference for when lance will support ORDER BY
+        # else:
+        #     limit = self.table.count_rows() if self._limit is None else self._limit
+        #     query = self.table.search(None).select(columns).limit(limit)
+        #     if self._where is not None:
+        #         query = query.where(self._where)
+        #     if self._offset is not None:
+        #         query = query.offset(self._offset)
+        #     return query.to_arrow()
 
     def to_pandas(self) -> pd.DataFrame:
         """Builds the query and returns the result as a pandas DataFrame.

--- a/ui/components/core/src/api/getBrowser.ts
+++ b/ui/components/core/src/api/getBrowser.ts
@@ -18,11 +18,11 @@ export async function getBrowser(
 
   let query_qparams = "";
   if (query && query.model !== "" && query.search !== "") {
-    query_qparams = `&query=${query.search}&embedding_table=${query.model}`;
+    query_qparams = `&query=${encodeURIComponent(query.search)}&embedding_table=${query.model}`;
   }
   let where_qparams = "";
   if (where && where !== "") {
-    where_qparams = `&where=${where}`;
+    where_qparams = `&where=${encodeURIComponent(where)}`;
   }
   try {
     const response = await fetch(


### PR DESCRIPTION
## Issue

When updating some item feature, the updated rows become last.

We want to preserve order, so we order by date (using "created_at", the most reliable one as it should follow build order)

## Description

When no order is specified, always use order by 'created_at' (except if this column doesn't exist, for some old datasets)

Note: as lancedb search() doesn't support "order_by", we now use mostly duckdb sql search.


Also, bugfix in front (missing encodeURI for search filter)