### PR TITLE
sort by columns

### DIFF
--- a/pixano/app/routers/browser.py
+++ b/pixano/app/routers/browser.py
@@ -29,6 +29,8 @@ async def get_browser(
     query: str = "",
     embedding_table: str = "",
     where: str | None = None,
+    sortcol: str | None = None,
+    order: str | None = None,
 ) -> DatasetBrowser:  # type: ignore
     """Load dataset items for the explorer page.
 
@@ -40,6 +42,8 @@ async def get_browser(
         query: Text query for semantic search.
         embedding_table: Table name for embeddings.
         where: Where clause.
+        sortcol: column to order by
+        order: sort order (asc or desc)
 
     Returns:
         Dataset explorer page.
@@ -71,7 +75,9 @@ async def get_browser(
         except DatasetAccessError as e:
             raise HTTPException(status_code=400, detail=str(e))
     else:
-        item_rows = get_rows(dataset=dataset, table=table_item, limit=limit, skip=skip, where=where)
+        item_rows = get_rows(
+            dataset=dataset, table=table_item, limit=limit, skip=skip, where=where, sortcol=sortcol, order=order
+        )
         if where is not None:
             full_item_rows = get_rows(dataset=dataset, table=table_item, where=where)
             list_ids = [item.id for item in full_item_rows]

--- a/pixano/app/routers/utils.py
+++ b/pixano/app/routers/utils.py
@@ -100,6 +100,8 @@ def get_rows(
     item_ids: list[str] | None = None,
     limit: int | None = None,
     skip: int = 0,
+    sortcol: str | None = None,
+    order: str | None = None,
 ) -> list[BaseSchema]:
     """Get rows from a table.
 
@@ -113,12 +115,23 @@ def get_rows(
         item_ids: Item IDs of the rows.
         limit: Limit number of rows.
         skip: Skip number of rows.
+        sortcol: column to order by
+        order: sort order (asc or desc)
 
     Returns:
         List of rows.
     """
     try:
-        rows = dataset.get_data(table_name=table, where=where, ids=ids, limit=limit, skip=skip, item_ids=item_ids)
+        rows = dataset.get_data(
+            table_name=table,
+            where=where,
+            ids=ids,
+            limit=limit,
+            skip=skip,
+            item_ids=item_ids,
+            sortcol=sortcol,
+            order=order,
+        )
     except DatasetPaginationError as err:
         raise HTTPException(status_code=400, detail="Invalid query parameters. " + str(err))
     except DatasetAccessError as err:

--- a/pixano/datasets/dataset.py
+++ b/pixano/datasets/dataset.py
@@ -344,6 +344,8 @@ class Dataset:
         skip: int = 0,
         where: str | None = None,
         item_ids: list[str] | None = None,
+        sortcol: str | None = None,
+        order: str | None = None,
     ) -> list[BaseSchema]: ...
     @overload
     def get_data(
@@ -354,6 +356,8 @@ class Dataset:
         skip: int = 0,
         where: str | None = None,
         item_ids: None = None,
+        sortcol: str | None = None,
+        order: str | None = None,
     ) -> BaseSchema | None: ...
 
     def get_data(
@@ -364,6 +368,8 @@ class Dataset:
         skip: int = 0,
         where: str | None = None,
         item_ids: list[str] | None = None,
+        sortcol: str | None = None,
+        order: str | None = None,
     ) -> list[BaseSchema] | BaseSchema | None:
         """Read data from a table.
 
@@ -376,6 +382,8 @@ class Dataset:
             limit: Amount of items to read. If not set, will default to table size.
             skip: The number of data to skip.
             item_ids: Item ids to read.
+            sortcol: column to order by
+            order: sort order (asc or desc)
 
         Returns:
             List of values.
@@ -413,6 +421,8 @@ class Dataset:
                 else:
                     where = f"item_ref.id IN {sql_item_ids}"
                 query = TableQueryBuilder(table).where(where).limit(limit).offset(skip)
+            if sortcol is not None and order is not None:
+                query = query.order_by(sortcol, order == "desc")
         else:
             sql_ids = to_sql_list(ids)
             if where is not None:

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -107,6 +107,7 @@ License: CECILL-C
     {:else if !selectedDataset.isErrored}
       <Table
         items={selectedDataset.table_data}
+        disableSort={searchInput !== ""}
         on:selectItem={(event) => handleSelectItem(event.detail)}
         on:colsort={(event) => handleColSort(event.detail)}
       />

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -63,6 +63,29 @@ License: CECILL-C
       where,
     }));
   }
+
+  function handleColSort(colsorts: { id: string; order: string }[]) {
+    if (colsorts.length === 0) {
+      //reset sort
+      datasetTableStore.update((value) => {
+        value = {
+          ...value,
+          currentPage: 1, //reset page (?)
+        };
+        delete value.sort;
+        return value;
+      });
+    } else if (colsorts.length === 1) {
+      const { id, order } = colsorts[0];
+      datasetTableStore.update((value) => ({
+        ...value,
+        currentPage: 1, //reset page (?)
+        sort: { col: id, order },
+      }));
+    } else {
+      console.error("ERROR: MultiSort on columns is not managed nor allowed");
+    }
+  }
 </script>
 
 <div class="w-full px-20 bg-slate-50 flex flex-col text-slate-800 min-h-[calc(100vh-80px)]">
@@ -85,6 +108,7 @@ License: CECILL-C
       <Table
         items={selectedDataset.table_data}
         on:selectItem={(event) => handleSelectItem(event.detail)}
+        on:colsort={(event) => handleColSort(event.detail)}
       />
     {:else}
       <div

--- a/ui/apps/pixano/src/lib/types/pixanoTypes.ts
+++ b/ui/apps/pixano/src/lib/types/pixanoTypes.ts
@@ -12,4 +12,8 @@ export type DatasetTableStore = {
     search: string;
   };
   where?: string;
+  sort?: {
+    col: string;
+    order: string;
+  };
 };

--- a/ui/apps/pixano/src/routes/[dataset]/dataset/+page.svelte
+++ b/ui/apps/pixano/src/routes/[dataset]/dataset/+page.svelte
@@ -69,6 +69,7 @@ License: CECILL-C
           pagination.pageSize,
           pagination.query,
           pagination.where,
+          pagination.sort,
         )
           .then((datasetItems) => {
             if (datasetItems.id) {

--- a/ui/components/core/src/api/getBrowser.ts
+++ b/ui/components/core/src/api/getBrowser.ts
@@ -12,6 +12,7 @@ export async function getBrowser(
   size: number = 100,
   query: Record<string, string> | undefined,
   where: string | undefined,
+  sort: { col: string; order: string } | undefined,
 ): Promise<DatasetBrowser> {
   let datasetItems: DatasetBrowser;
   let datasetItems_raw: DatasetBrowserType;
@@ -24,9 +25,13 @@ export async function getBrowser(
   if (where && where !== "") {
     where_qparams = `&where=${encodeURIComponent(where)}`;
   }
+  let sort_qparams = "";
+  if (sort && sort.col !== "" && ["asc", "desc"].includes(sort.order)) {
+    sort_qparams = `&sortcol=${encodeURIComponent(sort.col)}&order=${sort.order}`;
+  }
   try {
     const response = await fetch(
-      `/browser/${datasetId}?skip=${(page - 1) * size}&limit=${size}${query_qparams}${where_qparams}`,
+      `/browser/${datasetId}?skip=${(page - 1) * size}&limit=${size}${query_qparams}${where_qparams}${sort_qparams}`,
     );
     if (response.ok) {
       datasetItems_raw = (await response.json()) as DatasetBrowserType;

--- a/ui/components/table/src/Table.svelte
+++ b/ui/components/table/src/Table.svelte
@@ -23,6 +23,7 @@ License: CECILL-C
 
   // Exports
   export let items: TableData;
+  export let disableSort = false;
 
   // Add data into a writable store, reactive to items
   const data = writable(items.rows);
@@ -58,7 +59,7 @@ License: CECILL-C
           sort:
             col.type === "image" || col.name.startsWith(COUNTS_COLUMNS_PREFIX)
               ? { disable: true }
-              : {},
+              : { disable: false },
         },
       }),
     );
@@ -78,8 +79,9 @@ License: CECILL-C
     table.createViewModel(columns);
 
   const { sortKeys } = pluginStates.sort;
-  const handleSort = (props) => {
-    if (!props.sort.disable) {
+  const handleSort = (props, cell) => {
+    const isColDisabled = cell?.state?.columns[cell?.colstart].plugins?.sort?.disable === true;
+    if (!isColDisabled && !disableSort) {
       // note1: we use this function instead of subscribing to sortKeys
       // to avoid dispatching on page mount
       // note2: disabling no-unsafe-call because props is a svelte-headless-table
@@ -181,15 +183,19 @@ License: CECILL-C
               <Subscribe props={cell.props()} let:props attrs={cell.attrs()} let:attrs>
                 <th
                   {...attrs}
-                  on:click={() => handleSort(props)}
+                  on:click={() => handleSort(props, cell)}
                   class="relative py-4 px-2 font-semibold"
                 >
-                  <Render of={cell.render()} />
-                  {#if props.sort.order === "asc"}
-                    ⬇️
-                  {:else if props.sort.order === "desc"}
-                    ⬆️
-                  {/if}
+                  <span class="whitespace-nowrap flex items-center gap-1 justify-center">
+                    <Render of={cell.render()} />
+                    {#if !disableSort}
+                      {#if props.sort.order === "asc"}
+                        ⬇️
+                      {:else if props.sort.order === "desc"}
+                        ⬆️
+                      {/if}
+                    {/if}
+                  </span>
                 </th>
               </Subscribe>
             {/each}


### PR DESCRIPTION
## Description

In explorer, add the ability to sort columns (ascending or descending order)
Some columns are not sortable (like images, and counts -- that's sad for theses, but the information is not directly on the item table...)

For a future PR, we could eventually join a "count table" (in memory) to allows count sorting (and also filter)