### PR TITLE
fix ids order

### DIFF
--- a/pixano/app/routers/browser.py
+++ b/pixano/app/routers/browser.py
@@ -75,14 +75,13 @@ async def get_browser(
         except DatasetAccessError as e:
             raise HTTPException(status_code=400, detail=str(e))
     else:
-        item_rows = get_rows(
-            dataset=dataset, table=table_item, limit=limit, skip=skip, where=where, sortcol=sortcol, order=order
-        )
-        if where is not None:
-            full_item_rows = get_rows(dataset=dataset, table=table_item, where=where)
+        if where is not None or sortcol is not None:
+            full_item_rows = get_rows(dataset=dataset, table=table_item, where=where, sortcol=sortcol, order=order)
+            item_rows = full_item_rows[skip : skip + limit]
             list_ids = [item.id for item in full_item_rows]
         else:
-            list_ids = dataset.get_all_ids(sortcol=sortcol, order=order)
+            item_rows = get_rows(dataset=dataset, table=table_item, limit=limit, skip=skip)
+            list_ids = dataset.get_all_ids()
 
     item_ids = [item.id for item in item_rows]
     item_first_media: dict[str, dict] = {}

--- a/pixano/datasets/queries/table.py
+++ b/pixano/datasets/queries/table.py
@@ -213,10 +213,6 @@ class TableQueryBuilder:
         # This is because Lance does not support order_by
         # Also DuckDB is less memory efficient than Lance
         # ###################
-        # Now we always use use duckdb because we always order by "created_at" when there is no specified order
-        if self._order_by == [] and "created_at" in columns:
-            self._order_by = ["created_at"]
-            self._descending = [False]
         # if order_by is a count computed column, we need a join on local count table
         count_table = None
         if len(self._order_by) == 1 and self._order_by not in columns and self._order_by[0].startswith("#"):

--- a/pixano/datasets/queries/table.py
+++ b/pixano/datasets/queries/table.py
@@ -213,9 +213,13 @@ class TableQueryBuilder:
         # This is because Lance does not support order_by
         # Also DuckDB is less memory efficient than Lance
         # ###################
+
+        # protection against not allowed columns
+        self._order_by = [order for order in self._order_by if order in columns or order.startswith("#")]
+
         # if order_by is a count computed column, we need a join on local count table
         count_table = None
-        if len(self._order_by) == 1 and self._order_by not in columns and self._order_by[0].startswith("#"):
+        if len(self._order_by) == 1 and self._order_by[0] not in columns and self._order_by[0].startswith("#"):
             # get lancedb connection, to check if #column is an existing table
             db = lancedb.connect(self.table._conn.uri)
             count_name = self._order_by[0][1:]

--- a/pixano/datasets/queries/table.py
+++ b/pixano/datasets/queries/table.py
@@ -215,7 +215,7 @@ class TableQueryBuilder:
         # ###################
 
         # protection against not allowed columns
-        self._order_by = [order for order in self._order_by if order in columns or order.startswith("#")]
+        self._order_by = [order for order in self._order_by if order.split(".")[0] in columns or order.startswith("#")]
 
         # if order_by is a count computed column, we need a join on local count table
         count_table = None

--- a/ui/apps/pixano/src/lib/stores/datasetStores.ts
+++ b/ui/apps/pixano/src/lib/stores/datasetStores.ts
@@ -18,6 +18,7 @@ import type { DatasetTableStore } from "../types/pixanoTypes";
 export const defaultDatasetTableValues: DatasetTableStore = {
   currentPage: DEFAULT_DATASET_TABLE_PAGE,
   pageSize: DEFAULT_DATASET_TABLE_SIZE,
+  sort: { col: "created_at", order: "asc" },
 };
 
 // Exports


### PR DESCRIPTION
## Issue

With the default "created_at" sort, there was an order mismatch between the 20 rows displayed in Explorer, and the full list of ids (used to get index of item in current selection/filter/search, acces previous/next, etc.)

a test made to choose how to retrieve this full list was made BEFORE we replace "no sort" by default "created_at", so the list of ids was not sorted....

## Description

Fixed

Note: Except for rare case (after a refresh on a datasetItem page), we will probably always use the sorted version now.
