### PR TITLE
feat: 3D bbox editing with rotation rings and resize arrows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage/
 
 # AI assistants
 CLAUDE.md
+.claude/
 
 # Docs
 site

--- a/ui/apps/web/src/lib/annotations/__tests__/buildPayloads.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/buildPayloads.test.ts
@@ -18,7 +18,6 @@ const CTX = {
   datasetId: "ds-1",
   recordId: "rec-1",
   viewId: "view-1",
-  viewName: "image",
 };
 
 describe("buildBBoxCreate", () => {

--- a/ui/apps/web/src/lib/annotations/__tests__/coordinateTransforms.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/coordinateTransforms.test.ts
@@ -1,0 +1,177 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import * as THREE from "three";
+
+import {
+  bboxTransform,
+  lanceRotationToThree,
+  lanceToThree,
+  threeBoxToLanceXYZWHD,
+  threeQuaternionToLanceRotation,
+} from "../coordinateTransforms";
+import type { LocalBBox3D } from "$lib/api/annotations";
+
+// ─── lanceToThree ─────────────────────────────────────────────────────────────
+
+describe("lanceToThree", () => {
+  it("maps x unchanged, z to Three.js y, and negates y to Three.js z", () => {
+    expect(lanceToThree(1, 2, 3)).toEqual([1, 3, -2]);
+  });
+
+  it("maps origin to origin", () => {
+    const [x, y, z] = lanceToThree(0, 0, 0);
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(0);
+    expect(z).toBeCloseTo(0);
+  });
+
+  it("handles negative coordinates", () => {
+    expect(lanceToThree(-1, -2, -3)).toEqual([-1, -3, 2]);
+  });
+});
+
+// ─── lanceRotationToThree ─────────────────────────────────────────────────────
+
+describe("lanceRotationToThree", () => {
+  it("returns identity quaternion for undefined rotation", () => {
+    const q = lanceRotationToThree(undefined);
+    expect(q.x).toBeCloseTo(0);
+    expect(q.y).toBeCloseTo(0);
+    expect(q.z).toBeCloseTo(0);
+    expect(q.w).toBeCloseTo(1);
+  });
+
+  it("returns identity quaternion for the identity matrix", () => {
+    const q = lanceRotationToThree([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    expect(q.x).toBeCloseTo(0);
+    expect(q.y).toBeCloseTo(0);
+    expect(q.z).toBeCloseTo(0);
+    expect(q.w).toBeCloseTo(1);
+  });
+
+  it("maps a 90° Lance Z rotation to a 90° Three.js Y rotation", () => {
+    // Lance Z is Three.js Y, so a rotation about Lance Z must become a rotation about Three.js Y.
+    // 90° CCW about Z in Lance: [[0,-1,0],[1,0,0],[0,0,1]] → flat [0,-1,0, 1,0,0, 0,0,1]
+    const q = lanceRotationToThree([0, -1, 0, 1, 0, 0, 0, 0, 1]);
+    const HALF_SQRT2 = Math.SQRT2 / 2;
+    expect(q.x).toBeCloseTo(0);
+    expect(q.y).toBeCloseTo(HALF_SQRT2);
+    expect(q.z).toBeCloseTo(0);
+    expect(q.w).toBeCloseTo(HALF_SQRT2);
+  });
+});
+
+// ─── bboxTransform ────────────────────────────────────────────────────────────
+
+function makeBbox(overrides: Partial<LocalBBox3D>): LocalBBox3D {
+  return {
+    id: "bbox-1",
+    record_id: "rec-1",
+    entity_id: "ent-1",
+    view_id: "view-1",
+    coords: [0, 0, 0, 1, 1, 1],
+    format: "xyzwhd",
+    rotation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    is_normalized: false,
+    ...overrides,
+  };
+}
+
+describe("bboxTransform — xyzwhd", () => {
+  it("converts the center position via lanceToThree", () => {
+    const bbox = makeBbox({ coords: [1, 2, 3, 4, 5, 6], format: "xyzwhd" });
+    const { position } = bboxTransform(bbox);
+    expect(position).toEqual([1, 3, -2]);
+  });
+
+  it("passes w/h/d extents through unchanged as Three.js size", () => {
+    const bbox = makeBbox({ coords: [0, 0, 0, 4, 5, 6], format: "xyzwhd" });
+    const { size } = bboxTransform(bbox);
+    expect(size).toEqual([4, 5, 6]);
+  });
+});
+
+describe("bboxTransform — xyzxyz", () => {
+  it("computes the center from the two corners", () => {
+    const bbox = makeBbox({ coords: [0, 0, 0, 2, 4, 6], format: "xyzxyz" });
+    const { position } = bboxTransform(bbox);
+    // Lance center: (1, 2, 3) → lanceToThree → [1, 3, -2]
+    expect(position).toEqual([1, 3, -2]);
+  });
+
+  it("applies the Lance→Three axis swap to extents: [sx, sz, sy]", () => {
+    // coords: x span=2, y span=4, z span=6
+    // Three.js size: [Lance X-ext, Lance Z-ext, Lance Y-ext] = [2, 6, 4]
+    const bbox = makeBbox({ coords: [0, 0, 0, 2, 4, 6], format: "xyzxyz" });
+    const { size } = bboxTransform(bbox);
+    expect(size).toEqual([2, 6, 4]);
+  });
+
+  it("handles inverted corner ordering", () => {
+    const bbox = makeBbox({ coords: [2, 4, 6, 0, 0, 0], format: "xyzxyz" });
+    const { size } = bboxTransform(bbox);
+    expect(size).toEqual([2, 6, 4]);
+  });
+});
+
+// ─── threeQuaternionToLanceRotation ──────────────────────────────────────────
+
+describe("threeQuaternionToLanceRotation", () => {
+  it("returns identity matrix for identity quaternion", () => {
+    const rot = threeQuaternionToLanceRotation(new THREE.Quaternion());
+    const identity = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    for (let i = 0; i < 9; i++) expect(rot[i]).toBeCloseTo(identity[i]);
+  });
+
+  it("round-trips with lanceRotationToThree for a 90° Z rotation", () => {
+    // The 90° CCW about Lance Z matrix, in row-major:
+    const lanceRot = [0, -1, 0, 1, 0, 0, 0, 0, 1];
+    const q = lanceRotationToThree(lanceRot);
+    const recovered = threeQuaternionToLanceRotation(q);
+    for (let i = 0; i < 9; i++) expect(recovered[i]).toBeCloseTo(lanceRot[i]);
+  });
+
+  it("identity quaternion round-trips through lanceRotationToThree", () => {
+    const q = new THREE.Quaternion();
+    const rot = threeQuaternionToLanceRotation(q);
+    const q2 = lanceRotationToThree(rot);
+    expect(q2.x).toBeCloseTo(0);
+    expect(q2.y).toBeCloseTo(0);
+    expect(q2.z).toBeCloseTo(0);
+    expect(q2.w).toBeCloseTo(1);
+  });
+});
+
+// ─── threeBoxToLanceXYZWHD ───────────────────────────────────────────────────
+
+describe("threeBoxToLanceXYZWHD", () => {
+  it("inverts lanceToThree for the center: [tx, -tz, ty]", () => {
+    // lanceToThree(1, 2, 3) = [1, 3, -2] → inverse must recover (1, 2, 3)
+    const [lx, ly, lz] = threeBoxToLanceXYZWHD([1, 3, -2], [1, 1, 1]);
+    expect(lx).toBeCloseTo(1);
+    expect(ly).toBeCloseTo(2);
+    expect(lz).toBeCloseTo(3);
+  });
+
+  it("passes size through unchanged as Lance w/h/d", () => {
+    const coords = threeBoxToLanceXYZWHD([0, 0, 0], [4, 5, 6]);
+    expect(coords[3]).toBeCloseTo(4); // w
+    expect(coords[4]).toBeCloseTo(5); // h
+    expect(coords[5]).toBeCloseTo(6); // d
+  });
+
+  it("round-trips with bboxTransform xyzwhd", () => {
+    // bboxTransform(xyzwhd) maps Lance center → Three.js position and passes size through.
+    // threeBoxToLanceXYZWHD must recover the original Lance coords exactly.
+    const bbox = makeBbox({ coords: [1, 2, 3, 4, 5, 6], format: "xyzwhd" });
+    const { position, size } = bboxTransform(bbox);
+    const recovered = threeBoxToLanceXYZWHD(position, size);
+    expect(recovered).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});

--- a/ui/apps/web/src/lib/annotations/__tests__/pointCloudParser.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/pointCloudParser.test.ts
@@ -1,0 +1,113 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import { parsePointCloud } from "../pointCloudParser";
+
+// Build a raw binary buffer from an array of Lance [x, y, z] points.
+// The format is 5 floats per point: [x, y, z, intensity(=0), unused(=0)].
+function buildBuffer(points: [number, number, number][]): ArrayBuffer {
+  const data = new Float32Array(points.length * 5);
+  for (let i = 0; i < points.length; i++) {
+    data[i * 5] = points[i][0];
+    data[i * 5 + 1] = points[i][1];
+    data[i * 5 + 2] = points[i][2];
+  }
+  return data.buffer;
+}
+
+// ─── Empty buffer ─────────────────────────────────────────────────────────────
+
+describe("parsePointCloud — empty buffer", () => {
+  it("returns empty position and color arrays", () => {
+    const { positions, colors } = parsePointCloud(new ArrayBuffer(0));
+    expect(positions.length).toBe(0);
+    expect(colors.length).toBe(0);
+  });
+
+  it("returns zero bounds", () => {
+    const { bounds } = parsePointCloud(new ArrayBuffer(0));
+    expect(bounds).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0, minZ: 0, maxZ: 0 });
+  });
+});
+
+// ─── Coordinate transform ─────────────────────────────────────────────────────
+
+describe("parsePointCloud — Lance→Three.js coordinate transform", () => {
+  it("maps [lx, ly, lz] to Three.js [lx, lz, -ly]", () => {
+    const { positions } = parsePointCloud(buildBuffer([[1, 2, 3]]));
+    expect(positions[0]).toBeCloseTo(1); // Three.js X = Lance X
+    expect(positions[1]).toBeCloseTo(3); // Three.js Y = Lance Z
+    expect(positions[2]).toBeCloseTo(-2); // Three.js Z = -Lance Y
+  });
+
+  it("handles negative coordinates", () => {
+    const { positions } = parsePointCloud(buildBuffer([[-1, -2, -3]]));
+    expect(positions[0]).toBeCloseTo(-1);
+    expect(positions[1]).toBeCloseTo(-3);
+    expect(positions[2]).toBeCloseTo(2);
+  });
+});
+
+// ─── Elevation colors ─────────────────────────────────────────────────────────
+
+describe("parsePointCloud — elevation colors", () => {
+  it("assigns R=0 to the lowest Lance Z point", () => {
+    // Point A at Lance Z=0 (minimum elevation): t=0, R=0
+    const { colors } = parsePointCloud(buildBuffer([[0, 0, 0], [0, 0, 10]]));
+    expect(colors[0]).toBeCloseTo(0); // R of point A
+  });
+
+  it("assigns R=1 to the highest Lance Z point", () => {
+    // Point B at Lance Z=10 (maximum elevation): t=1, R=1
+    const { colors } = parsePointCloud(buildBuffer([[0, 0, 0], [0, 0, 10]]));
+    expect(colors[3]).toBeCloseTo(1); // R of point B
+  });
+
+  it("assigns stable colors when all points share the same elevation", () => {
+    // Single elevation: lanceZRange falls back to 1, t=0 for all points
+    const { colors } = parsePointCloud(buildBuffer([[0, 0, 5], [1, 0, 5]]));
+    expect(colors[0]).toBeCloseTo(0); // R: t=0
+    expect(colors[1]).toBeCloseTo(0.4); // G: GREEN_MIN + 0 * GREEN_RANGE = 0.4
+    expect(colors[2]).toBeCloseTo(1.0); // B: 1 - 0 * BLUE_DECAY = 1
+  });
+
+  it("colors are interpolated for a mid-elevation point", () => {
+    // Three points: Z=0, Z=5, Z=10 → t=0, 0.5, 1
+    const { colors } = parsePointCloud(buildBuffer([[0, 0, 0], [0, 0, 5], [0, 0, 10]]));
+    expect(colors[3]).toBeCloseTo(0.5); // R of mid point
+    expect(colors[4]).toBeCloseTo(0.4 + 0.5 * 0.4); // G
+    expect(colors[5]).toBeCloseTo(1 - 0.5 * 0.5); // B
+  });
+});
+
+// ─── Bounding box ─────────────────────────────────────────────────────────────
+
+describe("parsePointCloud — Three.js bounding box", () => {
+  it("computes the correct bounds from two opposite points", () => {
+    // Lance (-1,-2,-3) → Three.js (-1,-3, 2)
+    // Lance ( 1, 2, 3) → Three.js ( 1, 3,-2)
+    const { bounds } = parsePointCloud(buildBuffer([[-1, -2, -3], [1, 2, 3]]));
+    expect(bounds.minX).toBeCloseTo(-1);
+    expect(bounds.maxX).toBeCloseTo(1);
+    expect(bounds.minY).toBeCloseTo(-3);
+    expect(bounds.maxY).toBeCloseTo(3);
+    expect(bounds.minZ).toBeCloseTo(-2);
+    expect(bounds.maxZ).toBeCloseTo(2);
+  });
+
+  it("returns degenerate bounds for a single point", () => {
+    const { bounds } = parsePointCloud(buildBuffer([[2, 4, 6]]));
+    // Three.js: [2, 6, -4]
+    expect(bounds.minX).toBeCloseTo(2);
+    expect(bounds.maxX).toBeCloseTo(2);
+    expect(bounds.minY).toBeCloseTo(6);
+    expect(bounds.maxY).toBeCloseTo(6);
+    expect(bounds.minZ).toBeCloseTo(-4);
+    expect(bounds.maxZ).toBeCloseTo(-4);
+  });
+});

--- a/ui/apps/web/src/lib/annotations/buildPayloads.ts
+++ b/ui/apps/web/src/lib/annotations/buildPayloads.ts
@@ -28,7 +28,6 @@ export interface BuildContext {
   datasetId: string;
   recordId: string;
   viewId: string;
-  viewName: string;
 }
 
 export interface BuildBBoxResult {
@@ -135,6 +134,76 @@ export function buildBBoxUpdate(
     confidence: 1,
     ...DEFAULT_SOURCE,
   };
+}
+
+/**
+ * Build the (entity, bbox3d) create mutation pair for a new 3D box annotation.
+ * Coordinates are in Lance/backend space (xyzwhd, Z-up). Rotation defaults to
+ * identity — axis-aligned boxes only for now.
+ */
+export const DEFAULT_3D_ROTATION = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+export function buildBBox3DUpdate(
+  ctx: BuildContext,
+  bboxId: string,
+  entityId: string,
+  coordsLance: [number, number, number, number, number, number],
+  rotation?: number[],
+): Record<string, unknown> {
+  return {
+    id: bboxId,
+    record_id: ctx.recordId,
+    entity_id: entityId,
+    view_id: ctx.viewId,
+    coords: Array.from(coordsLance),
+    format: "xyzwhd",
+    rotation: rotation ?? DEFAULT_3D_ROTATION,
+    is_normalized: false,
+    confidence: 1,
+    ...DEFAULT_SOURCE,
+  };
+}
+
+export function buildBBox3DCreate(
+  ctx: BuildContext,
+  coordsLance: [number, number, number, number, number, number],
+  opts: { widgetId?: string; localBBoxId?: string; entityId?: string; bboxId?: string; rotation?: number[] } = {},
+): BuildBBoxResult {
+  const entityId = opts.entityId ?? generateShortId();
+  const bboxId = opts.bboxId ?? generateShortId();
+
+  const entityBody: Record<string, unknown> = {
+    id: entityId,
+    record_id: ctx.recordId,
+    parent_id: "",
+  };
+
+  const bboxBody: Record<string, unknown> = {
+    ...buildBBox3DUpdate(ctx, bboxId, entityId, coordsLance, opts.rotation),
+    frame_id: ctx.viewId,
+    frame_index: -1,
+    tracklet_id: "",
+    entity_dynamic_state_id: "",
+  };
+
+  const mutations: ResourceMutation[] = [
+    {
+      op: "create",
+      resource: "entities",
+      body: entityBody,
+      widgetId: opts.widgetId,
+      localBBoxId: opts.localBBoxId,
+    },
+    {
+      op: "create",
+      resource: "bbox3ds",
+      body: bboxBody,
+      widgetId: opts.widgetId,
+      localBBoxId: opts.localBBoxId,
+    },
+  ];
+
+  return { entityId, bboxId, mutations };
 }
 
 /**

--- a/ui/apps/web/src/lib/annotations/coordinateTransforms.ts
+++ b/ui/apps/web/src/lib/annotations/coordinateTransforms.ts
@@ -1,0 +1,92 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import * as THREE from "three";
+
+import type { LocalBBox3D } from "$lib/api/annotations";
+
+// S maps Lance coords → Three.js coords: lanceToThree(x,y,z) = [x, z, -y].
+// Correct change of basis for rotation matrices: R_three = S * R_lance * S⁻¹ = S * R_lance * Sᵀ
+const _S = new THREE.Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
+const _ST = new THREE.Matrix4().copy(_S).transpose();
+
+export function lanceToThree(x: number, y: number, z: number): [number, number, number] {
+  return [x, z, -y];
+}
+
+export function lanceRotationToThree(rotation: number[] | undefined): THREE.Quaternion {
+  const m = new THREE.Matrix4();
+  if (rotation && rotation.length === 9) {
+    const r = rotation;
+    m.set(r[0], r[1], r[2], 0, r[3], r[4], r[5], 0, r[6], r[7], r[8], 0, 0, 0, 0, 1);
+  }
+  const composed = new THREE.Matrix4().multiplyMatrices(_S, m).multiply(_ST);
+  return new THREE.Quaternion().setFromRotationMatrix(composed);
+}
+
+export function bboxTransform(bbox: LocalBBox3D): {
+  position: [number, number, number];
+  size: [number, number, number];
+  quaternion: THREE.Quaternion;
+} {
+  const c = bbox.coords;
+  if (bbox.format === "xyzxyz") {
+    const cx = (c[0] + c[3]) / 2;
+    const cy = (c[1] + c[4]) / 2;
+    const cz = (c[2] + c[5]) / 2;
+    const sx = Math.abs(c[3] - c[0]);
+    const sy = Math.abs(c[4] - c[1]);
+    const sz = Math.abs(c[5] - c[2]);
+    return {
+      position: lanceToThree(cx, cy, cz),
+      // Lance extents: sx=X, sy=Y, sz=Z. Three.js axes: X=LanceX, Y=LanceZ, Z=LanceY.
+      size: [sx, sz, sy],
+      quaternion: lanceRotationToThree(bbox.rotation),
+    };
+  }
+  // xyzwhd: center (x,y,z) + extents (w,h,d) where h=LanceZ-extent = Three.js Y-extent.
+  return {
+    position: lanceToThree(c[0], c[1], c[2]),
+    size: [c[3], c[4], c[5]],
+    quaternion: lanceRotationToThree(bbox.rotation),
+  };
+}
+
+/**
+ * Converts a Three.js quaternion back to a Lance 3×3 rotation matrix (row-major).
+ *
+ * lanceRotationToThree applies R_three = S * R_lance * S^T.
+ * The inverse is:            R_lance = S^T * R_three * S
+ *
+ * where S is the Lance→Three axis-swap matrix:
+ *   lanceToThree(x,y,z) = [x, z, -y]
+ *   S = [[1,0,0],[0,0,1],[0,-1,0]]
+ */
+export function threeQuaternionToLanceRotation(q: THREE.Quaternion): number[] {
+  const R_three = new THREE.Matrix4().makeRotationFromQuaternion(q);
+  const R_lance = new THREE.Matrix4().multiplyMatrices(_ST, R_three).multiply(_S);
+  const e = R_lance.elements; // Three.js stores elements column-major
+  return [e[0], e[4], e[8], e[1], e[5], e[9], e[2], e[6], e[10]];
+}
+
+/**
+ * Inverse of bboxTransform's xyzwhd path: converts a Three.js preview center
+ * and size back to Lance xyzwhd coordinates for storage.
+ *
+ * lanceToThree(lx, ly, lz) = [lx, lz, -ly]
+ * Inverse:  lx = three.x,  ly = -three.z,  lz = three.y
+ *
+ * Size mapping (xyzwhd, no axis swap):
+ *   w = Three.js X-extent,  h = Three.js Y-extent,  d = Three.js Z-extent
+ */
+export function threeBoxToLanceXYZWHD(
+  center: [number, number, number],
+  size: [number, number, number],
+): [number, number, number, number, number, number] {
+  const [tx, ty, tz] = center;
+  const [w, h, d] = size;
+  return [tx, -tz, ty, w, h, d];
+}

--- a/ui/apps/web/src/lib/annotations/pointCloudParser.ts
+++ b/ui/apps/web/src/lib/annotations/pointCloudParser.ts
@@ -1,0 +1,101 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+// Binary format: [X, Y, Z, intensity, unused] — only XYZ (indices 0–2) are used.
+const POINT_STRIDE = 5;
+
+// Elevation colorization: hue shifts from blue (low) to red (high) with a
+// fixed green channel to keep points visible against dark backgrounds.
+const ELEVATION_COLOR_GREEN_MIN = 0.4;
+const ELEVATION_COLOR_GREEN_RANGE = 0.4;
+const ELEVATION_COLOR_BLUE_DECAY = 0.5;
+
+export interface ParsedPointCloud {
+  /** Three.js XYZ positions, length = pointCount × 3. */
+  positions: Float32Array;
+  /** RGB colors in [0, 1] derived from elevation, length = pointCount × 3. */
+  colors: Float32Array;
+  /** Axis-aligned bounding box in Three.js space. */
+  bounds: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    minZ: number;
+    maxZ: number;
+  };
+}
+
+/**
+ * Parses a raw Lance point-cloud binary buffer into Three.js-space positions,
+ * elevation-based colors, and a bounding box — ready for WebGL upload.
+ *
+ * Two-pass algorithm:
+ *   Pass 1 — find the Lance Z range needed for elevation colorization.
+ *   Pass 2 — apply the Lance→Three.js axis swap, assign colors, track bounds.
+ */
+export function parsePointCloud(buffer: ArrayBuffer): ParsedPointCloud {
+  const floats = new Float32Array(buffer);
+  const pointCount = Math.floor(floats.length / POINT_STRIDE);
+
+  const positions = new Float32Array(pointCount * 3);
+  const colors = new Float32Array(pointCount * 3);
+
+  if (pointCount === 0) {
+    return {
+      positions,
+      colors,
+      bounds: { minX: 0, maxX: 0, minY: 0, maxY: 0, minZ: 0, maxZ: 0 },
+    };
+  }
+
+  // Pass 1: determine Lance Z range for elevation normalization.
+  let minLanceZ = Infinity;
+  let maxLanceZ = -Infinity;
+  for (let i = 0; i < pointCount; i++) {
+    const lz = floats[i * POINT_STRIDE + 2];
+    if (lz < minLanceZ) minLanceZ = lz;
+    if (lz > maxLanceZ) maxLanceZ = lz;
+  }
+  const lanceZRange = maxLanceZ - minLanceZ || 1;
+
+  // Pass 2: transform coordinates (lanceToThree: [lx, lz, -ly]),
+  //         assign elevation colors, and accumulate Three.js bounds.
+  let minX = Infinity,
+    maxX = -Infinity;
+  let minY = Infinity,
+    maxY = -Infinity;
+  let minZ = Infinity,
+    maxZ = -Infinity;
+
+  for (let i = 0; i < pointCount; i++) {
+    const lx = floats[i * POINT_STRIDE];
+    const ly = floats[i * POINT_STRIDE + 1];
+    const lz = floats[i * POINT_STRIDE + 2];
+
+    const tx = lx;
+    const ty = lz;
+    const tz = -ly;
+
+    positions[i * 3] = tx;
+    positions[i * 3 + 1] = ty;
+    positions[i * 3 + 2] = tz;
+
+    const t = (lz - minLanceZ) / lanceZRange;
+    colors[i * 3] = t;
+    colors[i * 3 + 1] = ELEVATION_COLOR_GREEN_MIN + t * ELEVATION_COLOR_GREEN_RANGE;
+    colors[i * 3 + 2] = 1 - t * ELEVATION_COLOR_BLUE_DECAY;
+
+    if (tx < minX) minX = tx;
+    if (tx > maxX) maxX = tx;
+    if (ty < minY) minY = ty;
+    if (ty > maxY) maxY = ty;
+    if (tz < minZ) minZ = tz;
+    if (tz > maxZ) maxZ = tz;
+  }
+
+  return { positions, colors, bounds: { minX, maxX, minY, maxY, minZ, maxZ } };
+}

--- a/ui/apps/web/src/lib/annotations/types.ts
+++ b/ui/apps/web/src/lib/annotations/types.ts
@@ -83,13 +83,35 @@ export interface ImageWidgetStorage {
 }
 
 /**
+ * In-flight 3D box before the backend POST succeeds.
+ */
+export interface DraftBBox3D {
+  id: string;
+  entityId: string;
+  coordsLance: [number, number, number, number, number, number];
+  /** Lance 3×3 rotation matrix (row-major). Omitted means identity. */
+  rotation?: number[];
+  persisted: boolean;
+  entity?: Record<string, unknown>;
+}
+
+/**
+ * Mutable per-instance storage for the point-cloud widget.
+ */
+export interface PointCloudWidgetStorage {
+  mode: "navigate" | "draw-bbox3d";
+  drafts: DraftBBox3D[];
+  [key: string]: unknown;
+}
+
+/**
  * A pending mutation to be flushed to the backend by WorkspaceManager.flushSave.
  * Modeled after pixano's ResourceMutation in apps/pixano/src/lib/api/resourcePayloads.ts.
  */
 export type ResourceMutation =
   | {
       op: "create";
-      resource: "entities" | "bboxes";
+      resource: string;
       body: Record<string, unknown>;
       /** Widget this mutation belongs to; used to flip `persisted` after success. */
       widgetId?: string;
@@ -98,7 +120,7 @@ export type ResourceMutation =
     }
   | {
       op: "update";
-      resource: "bboxes";
+      resource: string;
       id: string;
       body: Record<string, unknown>;
       widgetId?: string;
@@ -106,7 +128,7 @@ export type ResourceMutation =
     }
   | {
       op: "delete";
-      resource: "bboxes" | "entities";
+      resource: string;
       id: string;
       widgetId?: string;
       localBBoxId?: string;

--- a/ui/apps/web/src/lib/api/__tests__/annotations.test.ts
+++ b/ui/apps/web/src/lib/api/__tests__/annotations.test.ts
@@ -8,14 +8,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "../apiClient";
 import {
-  createBBox,
+  createAnnotation,
   createEntity,
-  deleteBBox,
+  deleteAnnotation,
   deleteEntity,
   listBBox3Ds,
   listBBoxes,
   listEntities,
-  updateBBox,
+  updateAnnotation,
 } from "../annotations";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -202,13 +202,13 @@ describe("createEntity", () => {
   });
 });
 
-// ─── createBBox ──────────────────────────────────────────────────────────────
+// ─── createAnnotation ────────────────────────────────────────────────────────
 
-describe("createBBox", () => {
-  it("POSTs to bboxes endpoint", async () => {
+describe("createAnnotation", () => {
+  it("POSTs to the given resource endpoint", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(okJson({ id: "new-b" }));
 
-    await createBBox(DS, { entity_id: "e1" });
+    await createAnnotation(DS, "bboxes", { entity_id: "e1" });
 
     const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
     expect(url).toBe(`/datasets/${DS}/bboxes`);
@@ -216,40 +216,39 @@ describe("createBBox", () => {
   });
 });
 
-// ─── updateBBox ──────────────────────────────────────────────────────────────
+// ─── updateAnnotation ────────────────────────────────────────────────────────
 
-describe("updateBBox", () => {
-  it("PUTs to bboxes/:id and strips the id field from the body", async () => {
+describe("updateAnnotation", () => {
+  it("PUTs to resource/:id and strips the id field from the body", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(okJson({ id: "b1", coords: [0, 0, 0.5, 0.5] }));
 
-    await updateBBox(DS, "b1", { id: "b1", coords: [0, 0, 0.5, 0.5] });
+    await updateAnnotation(DS, "bboxes", "b1", { id: "b1", coords: [0, 0, 0.5, 0.5] });
 
     const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
     expect(url).toBe(`/datasets/${DS}/bboxes/b1`);
     expect(init.method).toBe("PUT");
-    // id must be stripped from the patch body
     const sent = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(sent).not.toHaveProperty("id");
     expect(sent).toMatchObject({ coords: [0, 0, 0.5, 0.5] });
   });
 
-  it("URL-encodes the bbox id", async () => {
+  it("URL-encodes the annotation id", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(okJson({}));
 
-    await updateBBox(DS, "a/b c", {});
+    await updateAnnotation(DS, "bboxes", "a/b c", {});
 
     const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
     expect(url).toContain("a%2Fb%20c");
   });
 });
 
-// ─── deleteBBox ──────────────────────────────────────────────────────────────
+// ─── deleteAnnotation ────────────────────────────────────────────────────────
 
-describe("deleteBBox", () => {
-  it("DELETEs the bbox by id", async () => {
+describe("deleteAnnotation", () => {
+  it("DELETEs the annotation by resource and id", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
 
-    await deleteBBox(DS, "b1");
+    await deleteAnnotation(DS, "bboxes", "b1");
 
     const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
     expect(url).toBe(`/datasets/${DS}/bboxes/b1`);
@@ -258,12 +257,12 @@ describe("deleteBBox", () => {
 
   it("does not throw on 404 (already deleted)", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }));
-    await expect(deleteBBox(DS, "gone")).resolves.toBeUndefined();
+    await expect(deleteAnnotation(DS, "bboxes", "gone")).resolves.toBeUndefined();
   });
 
   it("throws on unexpected non-404 error", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 500, statusText: "Internal Server Error" }));
-    await expect(deleteBBox(DS, "b1")).rejects.toThrow("deleteBBox failed with 500");
+    await expect(deleteAnnotation(DS, "bboxes", "b1")).rejects.toThrow("deleteAnnotation(bboxes) failed with 500");
   });
 });
 

--- a/ui/apps/web/src/lib/api/annotations.ts
+++ b/ui/apps/web/src/lib/api/annotations.ts
@@ -168,41 +168,47 @@ export function createEntity(
   );
 }
 
-export function createBBox(
+export async function deleteEntity(datasetId: string, id: string): Promise<void> {
+  const res = await fetch(resourceUrl(datasetId, "entities", id), { method: "DELETE" });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`deleteEntity failed with ${res.status} ${res.statusText}`);
+  }
+}
+
+export function createAnnotation(
   datasetId: string,
+  resource: string,
   body: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   return requestJson<Record<string, unknown>>(
-    resourceUrl(datasetId, "bboxes"),
+    resourceUrl(datasetId, resource),
     { headers: JSON_HEADERS, method: "POST", body: JSON.stringify(body) },
-    "createBBox",
+    `createAnnotation(${resource})`,
   );
 }
 
-export function updateBBox(
+export function updateAnnotation(
   datasetId: string,
+  resource: string,
   id: string,
   body: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const { id: _ignored, ...patch } = body;
   void _ignored;
   return requestJson<Record<string, unknown>>(
-    resourceUrl(datasetId, "bboxes", id),
+    resourceUrl(datasetId, resource, id),
     { headers: JSON_HEADERS, method: "PUT", body: JSON.stringify(patch) },
-    "updateBBox",
+    `updateAnnotation(${resource})`,
   );
 }
 
-export async function deleteBBox(datasetId: string, id: string): Promise<void> {
-  const res = await fetch(resourceUrl(datasetId, "bboxes", id), { method: "DELETE" });
+export async function deleteAnnotation(
+  datasetId: string,
+  resource: string,
+  id: string,
+): Promise<void> {
+  const res = await fetch(resourceUrl(datasetId, resource, id), { method: "DELETE" });
   if (!res.ok && res.status !== 404) {
-    throw new Error(`deleteBBox failed with ${res.status} ${res.statusText}`);
-  }
-}
-
-export async function deleteEntity(datasetId: string, id: string): Promise<void> {
-  const res = await fetch(resourceUrl(datasetId, "entities", id), { method: "DELETE" });
-  if (!res.ok && res.status !== 404) {
-    throw new Error(`deleteEntity failed with ${res.status} ${res.statusText}`);
+    throw new Error(`deleteAnnotation(${resource}) failed with ${res.status} ${res.statusText}`);
   }
 }

--- a/ui/apps/web/src/lib/components/widgets/ImageWidget.svelte
+++ b/ui/apps/web/src/lib/components/widgets/ImageWidget.svelte
@@ -292,7 +292,6 @@ License: CECILL-C
         datasetId: imgOptions.datasetId,
         recordId: imgOptions.recordId,
         viewId: imgOptions.viewId,
-        viewName: imgOptions.viewName,
       };
       const body = buildBBoxUpdate(ctx, bbox.id, bbox.entityId, coordsNorm);
       const existing = manager.pendingMutations.find(
@@ -439,7 +438,6 @@ License: CECILL-C
         datasetId: imgOptions.datasetId,
         recordId: imgOptions.recordId,
         viewId: imgOptions.viewId,
-        viewName: imgOptions.viewName,
       },
       coordsNorm,
       { widgetId: stableWidgetId, localBBoxId: localId },

--- a/ui/apps/web/src/lib/components/widgets/PointCloudScene.svelte
+++ b/ui/apps/web/src/lib/components/widgets/PointCloudScene.svelte
@@ -5,20 +5,59 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { T } from "@threlte/core";
+  import { T, useThrelte } from "@threlte/core";
   import { HTML, OrbitControls } from "@threlte/extras";
   import { onMount } from "svelte";
   import * as THREE from "three";
 
+  import { bboxTransform, threeBoxToLanceXYZWHD, threeQuaternionToLanceRotation } from "$lib/annotations/coordinateTransforms";
+  import { parsePointCloud } from "$lib/annotations/pointCloudParser";
   import { pickEntityLabel } from "$lib/annotations/types";
   import type { LocalBBox3D } from "$lib/api/annotations";
+  import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
   interface Props {
     pointCloudUrl?: string;
     bboxes3d?: LocalBBox3D[];
+    drawMode?: boolean;
+    cameraMode?: "orbit" | "first-person";
+    /**
+     * Fired when the user clicks to lock the height (transitions to "confirming"),
+     * and again after each drag-move when in "moving" phase.
+     * Parent stores the coords to show Save/Cancel UI.
+     */
+    onReadyToConfirm?: (coords: [number, number, number, number, number, number], rotation?: number[], editingId?: string) => void;
+    /**
+     * Fired when drawing is cancelled (Escape key, mode turned off, external reset).
+     */
+    onDrawCanceled?: () => void;
+    /**
+     * Fired when the point cloud fails to load. Parent is responsible for
+     * surfacing the message to the user.
+     */
+    onLoadError?: (message: string) => void;
+    /**
+     * Parent increments this to force-reset the FSM (Cancel button).
+     */
+    externalReset?: number;
+    /** Whether to show and enable the rotation gizmo rings. */
+    showRings?: boolean;
+    /** Whether to show and enable the resize arrow gizmos. */
+    showArrows?: boolean;
   }
 
-  let { pointCloudUrl, bboxes3d = [] }: Props = $props();
+  let {
+    pointCloudUrl,
+    bboxes3d = [],
+    drawMode = false,
+    cameraMode = "orbit",
+    onReadyToConfirm,
+    onDrawCanceled,
+    onLoadError,
+    externalReset = 0,
+    showRings = true,
+    showArrows = true,
+  }: Props = $props();
 
   let positions = $state<Float32Array>(new Float32Array(0));
   let colors = $state<Float32Array>(new Float32Array(0));
@@ -27,30 +66,290 @@ License: CECILL-C
   let cameraPosition = $state<[number, number, number]>([30, 20, 30]);
   let cameraTarget = $state<[number, number, number]>([0, 0, 0]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let controlsRef = $state<any>(null);
+  let controlsRef = $state<ThreeOrbitControls | null>(null);
+
+  // Floor Y in Three.js space — updated after point cloud loads; used for ground raycasting
+  let floorY = $state(0);
+
+  const CAMERA_DISTANCE_FACTOR = 1.2;
+  const CAMERA_HEIGHT_FACTOR = 0.5;
+  const ORBIT_DAMPING_FACTOR = 0.07;
+  const AMBIENT_LIGHT_INTENSITY = 0.6;
+  const POINT_RENDER_SIZE = 0.05;
+  const BOX_LINE_WIDTH = 2;
+  const BOX_COLOR_PERSISTED = "#22d3ee";
+  const BOX_COLOR_PREVIEW = "#f59e0b";
+  const GRID_SIZE = 100;
+  const GRID_DIVISIONS = 50;
+  const GRID_COLOR_CENTER = "#333333";
+  const GRID_COLOR_LINES = "#222222";
+
+  const MIN_FOOTPRINT_SIZE = 0.05;
+  const MIN_BOX_HEIGHT = 0.05;
+  const MIN_GEOMETRY_SIZE = 0.01;
+  const HEIGHT_DRAG_SCALE_PER_PX = 0.01;
+  const HEIGHT_MINIMUM_FROM_FOOTPRINT_RATIO = 0.1;
+  const WHEEL_LINE_HEIGHT_PX = 40;
+  const FETCH_TIMEOUT_MS = 30_000;
+
+  // Reused across every pointermove — avoids per-event allocations in hot paths
+  const _screenNdc = new THREE.Vector2();
+  const _screenRay = new THREE.Raycaster();
+  const _groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  const _screenGroundHit = new THREE.Vector3();
+
+  // Scratch objects for the draw-event $effect (raycast + drag handlers)
+  const _raycastNdc = new THREE.Vector2();
+  const _raycastRay = new THREE.Raycaster();
+  // Unit vectors for ring-plane normals and rotation axes (index = axis: 0=X, 1=Y, 2=Z)
+  const _AXIS_UNIT_VECS = [
+    new THREE.Vector3(1, 0, 0),
+    new THREE.Vector3(0, 1, 0),
+    new THREE.Vector3(0, 0, 1),
+  ] as const;
+  // computeRingAngle scratch
+  const _ringCenter = new THREE.Vector3();
+  const _ringPlane = new THREE.Plane();
+  const _ringHit = new THREE.Vector3();
+  // rotating-phase scratch
+  const _rotDeltaQ = new THREE.Quaternion();
+  // resizing-face-phase scratch
+  const _resizeF = new THREE.Vector3();
+  const _resizePlaneNormal = new THREE.Vector3();
+  const _resizeDragPlane = new THREE.Plane();
+  const _resizeHitPt = new THREE.Vector3();
+  // arrow-gizmos $derived scratch — hoisted to avoid per-derivation allocations
+  const _arrowWorldDir = new THREE.Vector3();
+  const _arrowFaceCenter = new THREE.Vector3();
+  const _arrowPos = new THREE.Vector3();
+  const _arrowRotQuat = new THREE.Quaternion();
+  // Pre-allocated Mesh objects for raycasting — geometry is swapped in the $effects below.
+  // Avoids allocating up to 10 Mesh objects per pointermove during the confirming phase.
+  const _raycastBoxMesh = new THREE.Mesh();
+  const _raycastRingMeshes = [new THREE.Mesh(), new THREE.Mesh(), new THREE.Mesh()];
+  const _raycastArrowMesh = new THREE.Mesh();
+
+  // ─── Draw FSM ─────────────────────────────────────────────────────────────────
+  // idle → drawing-base → drawing-height → confirming ↔ moving | resizing-face
+
+  type DrawPhase = "idle" | "drawing-base" | "drawing-height" | "confirming" | "moving" | "resizing-face" | "rotating";
+  let drawPhase = $state<DrawPhase>("idle");
+  let baseCornerA = $state<THREE.Vector3 | null>(null);
+  let baseCornerB = $state<THREE.Vector3 | null>(null);
+  let boxHeight = $state(0);
+  let heightDragStartScreenY = $state(0);
+  let previewVisible = $state(false);
+  let previewCenter = $state<[number, number, number]>([0, 0, 0]);
+  let previewSize = $state<[number, number, number]>([0.01, 0.01, 0.01]);
+
+  // Pre-built geometries for the preview box — recreated only when previewSize changes.
+  // Box is kept alive for raycasting; EdgesGeometry is used for rendering.
+  let previewEdgesGeometry = $state<THREE.EdgesGeometry | null>(null);
+  let _raycastBoxGeom = $state<THREE.BoxGeometry | null>(null);
+  $effect(() => {
+    const [w, h, d] = previewSize;
+    const box = new THREE.BoxGeometry(w, h, d);
+    const edges = new THREE.EdgesGeometry(box);
+    previewEdgesGeometry = edges;
+    _raycastBoxGeom = box;
+    _raycastBoxMesh.geometry = box;
+    return () => { edges.dispose(); box.dispose(); };
+  });
+
+  // Current rotation of the preview box (Three.js world space)
+  let previewQuaternion = $state(new THREE.Quaternion());
+
+  // Id of the existing box being edited; null when drawing a new box
+  let editingBoxId = $state<string | null>(null);
+
+  const activeDragging = $derived(
+    drawPhase === "drawing-base" ||
+    drawPhase === "drawing-height" ||
+    drawPhase === "moving" ||
+    drawPhase === "resizing-face" ||
+    drawPhase === "rotating"
+  );
+
+  // Gizmo rings — radius = bounding sphere * padding
+  const GIZMO_RING_PADDING = 1.2;
+  const GIZMO_TUBE_FRACTION = 0.0225;
+  let gizmoRingRadius = $derived(
+    Math.hypot(previewSize[0], previewSize[1], previewSize[2]) / 2 * GIZMO_RING_PADDING,
+  );
+  let gizmoTubeRadius = $derived(gizmoRingRadius * GIZMO_TUBE_FRACTION);
+
+  // Ring definitions: euler so each ring lies in the correct plane, plus render color.
+  // Axis 0=X (YZ plane), 1=Y (XZ plane), 2=Z (XY plane).
+  const RING_DEFS = [
+    { color: "#ef4444", euler: new THREE.Euler(0, Math.PI / 2, 0) },
+    { color: "#22c55e", euler: new THREE.Euler(Math.PI / 2, 0, 0) },
+    { color: "#3b82f6", euler: new THREE.Euler(0, 0, 0) },
+  ] as const;
+  // Component indices [a, b] for Math.atan2(d.component_a, d.component_b) per axis.
+  const RING_ATAN_AXES = [[2, 1], [2, 0], [1, 0]] as const;
+
+  // Resize arrows — shaft + arrowhead per face, matching ring colour scheme (X=red, Y=green, Z=blue)
+  const GIZMO_ARROW_HEIGHT_FRACTION = 0.50;
+  const GIZMO_ARROW_RADIUS_FRACTION = 0.09;
+  const GIZMO_ARROW_GAP_FRACTION = 0.04;
+  const GIZMO_ARROW_HEAD_FRACTION = 0.42;   // fraction of total height that is the cone head
+  const GIZMO_ARROW_SHAFT_RADIUS_FRACTION = 0.30; // shaft radius as fraction of head radius
+  const arrowHeight = $derived(gizmoRingRadius * GIZMO_ARROW_HEIGHT_FRACTION);
+  const arrowRadius = $derived(gizmoRingRadius * GIZMO_ARROW_RADIUS_FRACTION);
+  const arrowHeadLength = $derived(arrowHeight * GIZMO_ARROW_HEAD_FRACTION);
+  const arrowShaftLength = $derived(arrowHeight * (1 - GIZMO_ARROW_HEAD_FRACTION));
+  const arrowShaftRadius = $derived(arrowRadius * GIZMO_ARROW_SHAFT_RADIUS_FRACTION);
+  // Local Y offsets within the arrow group (group origin = center of full arrow)
+  const arrowShaftOffsetY = $derived(-arrowHeight * GIZMO_ARROW_HEAD_FRACTION / 2);
+  const arrowHeadOffsetY = $derived(arrowHeight * (1 - GIZMO_ARROW_HEAD_FRACTION) / 2);
+  // Precomputed per-frame data for each of the 6 face arrows.
+  // Directions are computed in local box space then rotated by previewQuaternion so
+  // the cones always point perpendicular to their actual face regardless of rotation.
+  const _ARROW_UP = new THREE.Vector3(0, 1, 0);
+  const _ARROW_DEFS = [
+    { id: "+x", localDir: new THREE.Vector3( 1,  0,  0), color: "#ef4444", axis: 0 as const, sign:  1 as const },
+    { id: "-x", localDir: new THREE.Vector3(-1,  0,  0), color: "#ef4444", axis: 0 as const, sign: -1 as const },
+    { id: "+y", localDir: new THREE.Vector3( 0,  1,  0), color: "#22c55e", axis: 1 as const, sign:  1 as const },
+    { id: "-y", localDir: new THREE.Vector3( 0, -1,  0), color: "#22c55e", axis: 1 as const, sign: -1 as const },
+    { id: "+z", localDir: new THREE.Vector3( 0,  0,  1), color: "#3b82f6", axis: 2 as const, sign:  1 as const },
+    { id: "-z", localDir: new THREE.Vector3( 0,  0, -1), color: "#3b82f6", axis: 2 as const, sign: -1 as const },
+  ] as const;
+  const arrowGizmos = $derived(
+    (() => {
+      const gap = gizmoRingRadius * GIZMO_ARROW_GAP_FRACTION;
+      const hs = gap + arrowHeight / 2;
+      return _ARROW_DEFS.map((def) => {
+        const halfSize = previewSize[def.axis] / 2;
+        _arrowWorldDir.copy(def.localDir).applyQuaternion(previewQuaternion).normalize();
+        _arrowFaceCenter.set(...previewCenter).addScaledVector(_arrowWorldDir, halfSize);
+        _arrowPos.copy(_arrowFaceCenter).addScaledVector(_arrowWorldDir, hs);
+        _arrowRotQuat.setFromUnitVectors(_ARROW_UP, _arrowWorldDir);
+        return {
+          id: def.id,
+          pos: [_arrowPos.x, _arrowPos.y, _arrowPos.z] as [number, number, number],
+          quat: [_arrowRotQuat.x, _arrowRotQuat.y, _arrowRotQuat.z, _arrowRotQuat.w] as [number, number, number, number],
+          color: def.color,
+          axis: def.axis,
+          sign: def.sign,
+        };
+      });
+    })()
+  );
+
+  // Raycast geometries for rings and arrows — cached and rebuilt only when gizmo dimensions
+  // change, avoiding geometry allocation on every pointermove during confirming phase.
+  let _raycastRingGeoms = $state<THREE.TorusGeometry[] | null>(null);
+  $effect(() => {
+    const r = gizmoRingRadius;
+    const tube = gizmoTubeRadius;
+    const geoms = [0, 1, 2].map(() => new THREE.TorusGeometry(r, tube, 6, 64));
+    _raycastRingGeoms = geoms;
+    geoms.forEach((g, i) => (_raycastRingMeshes[i].geometry = g));
+    return () => geoms.forEach((g) => g.dispose());
+  });
+
+  let _raycastArrowGeom = $state<THREE.CylinderGeometry | null>(null);
+  $effect(() => {
+    const geom = new THREE.CylinderGeometry(arrowRadius, arrowRadius, arrowHeight, 8);
+    _raycastArrowGeom = geom;
+    _raycastArrowMesh.geometry = geom;
+    return () => geom.dispose();
+  });
+
+  // Move phase
+  let moveStartGround: THREE.Vector3 | null = null;
+  let moveStartCenter: [number, number, number] = [0, 0, 0];
+
+  // Resize-face phase — which face is being dragged and its initial geometry
+  let resizeAxis: 0 | 1 | 2 = 1;
+  let resizeStartCenter: [number, number, number] = [0, 0, 0];
+  let resizeStartSize: [number, number, number] = [0.01, 0.01, 0.01];
+  // World-space face normal and face center snapshotted at drag start — per-drag state, not permanent scratch.
+  let _resizeWorldDir = new THREE.Vector3(0, 1, 0);
+  let _resizeStartFaceCenter = new THREE.Vector3();
+
+  // Rotating phase — which ring axis is being dragged
+  let rotAxis: 0 | 1 | 2 = 1;
+  let rotStartAngle = 0;
+  let rotStartQuaternion = new THREE.Quaternion();
+
+  const { camera } = useThrelte();
+
+  // ─── OrbitControls configuration (single source of truth) ───────────────────
+  // Drives all OrbitControls properties reactively based on cameraMode and
+  // drawPhase. Custom handlers below add only what OrbitControls can't do alone.
 
   $effect(() => {
     const ref = controlsRef;
     if (!ref) return;
 
-    const SENSITIVITY = 0.003;
+    if (cameraMode === "orbit") {
+      // Orbit mode: left-drag = orbit, right-drag = pan, scroll = zoom.
+      // These are Three.js OrbitControls defaults and work reliably across platforms.
+      ref.enableRotate = !activeDragging;
+      ref.enableZoom = !activeDragging;
+      ref.enablePan = !activeDragging;
+      ref.screenSpacePanning = true;
+      ref.mouseButtons = activeDragging
+        ? { LEFT: null, MIDDLE: null, RIGHT: null }
+        : { LEFT: THREE.MOUSE.ROTATE, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN };
+    } else {
+      // First-person mode: OrbitControls handles left-pan only. Right-drag and
+      // scroll are managed by the custom first-person effect below.
+      ref.enableRotate = false;
+      ref.enableZoom = false;
+      ref.enablePan = !activeDragging;
+      ref.screenSpacePanning = false;
+      ref.mouseButtons = activeDragging
+        ? { LEFT: null, MIDDLE: null, RIGHT: null }
+        : { LEFT: THREE.MOUSE.PAN, MIDDLE: null, RIGHT: null };
+    }
+  });
+
+  // ─── Orbit mode: sync cameraTarget for the draw-phase overlay ───────────────────
+
+  $effect(() => {
+    const ref = controlsRef;
+    if (!ref || cameraMode !== "orbit") return;
+
+    const onChange = () => {
+      cameraTarget = [ref.target.x, ref.target.y, ref.target.z];
+    };
+    ref.addEventListener("change", onChange);
+
+    return () => {
+      ref.removeEventListener("change", onChange);
+    };
+  });
+
+  // ─── First-person mode: right-drag = look-around, scroll = fly-through ────────
+
+  $effect(() => {
+    const ref = controlsRef;
+    if (!ref || cameraMode !== "first-person") return;
+
+    const ROTATION_SENSITIVITY = 0.003;
     const FLY_SPEED = 0.05;
     let isRightDragging = false;
     let lastX = 0;
     let lastY = 0;
 
+    const _worldUp = new THREE.Vector3(0, 1, 0);
+    const _localRight = new THREE.Vector3(1, 0, 0);
+    const _forward = new THREE.Vector3();
+    const _flyDir = new THREE.Vector3();
+
     const onContextMenu = (e: MouseEvent) => e.preventDefault();
 
-    const onMouseDown = (e: MouseEvent) => {
-      if (e.button === 2) {
-        isRightDragging = true;
-        lastX = e.clientX;
-        lastY = e.clientY;
-      }
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 2) return;
+      if (activeDragging) return;
+      isRightDragging = true;
+      lastX = e.clientX;
+      lastY = e.clientY;
     };
 
-    const onMouseMove = (e: MouseEvent) => {
+    const onPointerMove = (e: PointerEvent) => {
       if (!isRightDragging) return;
       const dx = e.clientX - lastX;
       const dy = e.clientY - lastY;
@@ -58,183 +357,551 @@ License: CECILL-C
       lastY = e.clientY;
 
       const cam = ref.object as THREE.PerspectiveCamera;
-      cam.rotateOnWorldAxis(new THREE.Vector3(0, 1, 0), -dx * SENSITIVITY);
-      cam.rotateOnAxis(new THREE.Vector3(1, 0, 0), -dy * SENSITIVITY);
+      cam.rotateOnWorldAxis(_worldUp, -dx * ROTATION_SENSITIVITY);
+      cam.rotateOnAxis(_localRight, -dy * ROTATION_SENSITIVITY);
 
       const dist = cam.position.distanceTo(ref.target);
-      const dir = new THREE.Vector3(0, 0, -1).applyQuaternion(cam.quaternion);
-      ref.target.copy(cam.position).addScaledVector(dir, dist);
+      _forward.set(0, 0, -1).applyQuaternion(cam.quaternion);
+      ref.target.copy(cam.position).addScaledVector(_forward, dist);
       cameraTarget = [ref.target.x, ref.target.y, ref.target.z];
       ref.update();
     };
 
-    const onMouseUp = (e: MouseEvent) => {
+    const onPointerUp = (e: PointerEvent) => {
       if (e.button === 2) isRightDragging = false;
     };
+
+    // Sync cameraTarget when OrbitControls left-pan moves the camera
+    const onChange = () => {
+      cameraTarget = [ref.target.x, ref.target.y, ref.target.z];
+    };
+    ref.addEventListener("change", onChange);
 
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
       const cam = ref.object as THREE.PerspectiveCamera;
-      const dir = new THREE.Vector3();
-      cam.getWorldDirection(dir);
-      const move = dir.multiplyScalar(-e.deltaY * FLY_SPEED);
-      cam.position.add(move);
-      ref.target.add(move);
+      cam.getWorldDirection(_flyDir);
+      const delta = e.deltaMode === 1 ? e.deltaY * WHEEL_LINE_HEIGHT_PX : e.deltaY;
+      cam.position.addScaledVector(_flyDir, -delta * FLY_SPEED);
+      ref.target.addScaledVector(_flyDir, -delta * FLY_SPEED);
       cameraTarget = [ref.target.x, ref.target.y, ref.target.z];
       ref.update();
     };
 
     ref.domElement.addEventListener("contextmenu", onContextMenu);
-    ref.domElement.addEventListener("mousedown", onMouseDown);
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
+    ref.domElement.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
     ref.domElement.addEventListener("wheel", onWheel, { passive: false });
 
     return () => {
       ref.domElement.removeEventListener("contextmenu", onContextMenu);
-      ref.domElement.removeEventListener("mousedown", onMouseDown);
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
+      ref.domElement.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
       ref.domElement.removeEventListener("wheel", onWheel);
+      ref.removeEventListener("change", onChange);
     };
   });
 
-  function lanceToThree(x: number, y: number, z: number): [number, number, number] {
-    return [x, z, -y];
-  }
+  // ─── Draw-mode pointer events ────────────────────────────────────────────────
+  // All three handlers live on window (capture) so stopPropagation prevents the event
+  // from reaching OrbitControls on the canvas element. onPointerDown guards with
+  // el.contains(target) so toolbar and overlay clicks are never intercepted.
 
-  function bboxTransform(bbox: LocalBBox3D): {
-    position: [number, number, number];
-    size: [number, number, number];
-    quaternion: THREE.Quaternion;
-  } {
-    const c = bbox.coords;
-    if (bbox.format === "xyzxyz") {
-      const cx = (c[0] + c[3]) / 2;
-      const cy = (c[1] + c[4]) / 2;
-      const cz = (c[2] + c[5]) / 2;
-      const sx = Math.abs(c[3] - c[0]);
-      const sy = Math.abs(c[4] - c[1]);
-      const sz = Math.abs(c[5] - c[2]);
-      return {
-        position: lanceToThree(cx, cy, cz),
-        size: [sx, sy, sz],
-        quaternion: lanceRotationToThree(bbox.rotation),
-      };
+  $effect(() => {
+    const ref = controlsRef;
+    if (!ref) return;
+    void drawMode; // reactive dependency: re-run (and reset cursor) when mode toggles
+
+    const el: HTMLElement = ref.domElement;
+
+    function setupRay(clientX: number, clientY: number): void {
+      const rect = el.getBoundingClientRect();
+      _raycastNdc.set(
+        ((clientX - rect.left) / rect.width) * 2 - 1,
+        -((clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      _raycastRay.setFromCamera(_raycastNdc, camera.current);
     }
-    return {
-      position: lanceToThree(c[0], c[1], c[2]),
-      size: [c[3], c[4], c[5]],
-      quaternion: lanceRotationToThree(bbox.rotation),
+
+    function raycastBox(clientX: number, clientY: number): THREE.Intersection | null {
+      if (!previewVisible || !_raycastBoxGeom) return null;
+      setupRay(clientX, clientY);
+      _raycastBoxMesh.position.set(...previewCenter);
+      _raycastBoxMesh.quaternion.copy(previewQuaternion);
+      _raycastBoxMesh.updateMatrixWorld(true);
+      const hits = _raycastRay.intersectObject(_raycastBoxMesh);
+      return hits.length > 0 ? hits[0] : null;
+    }
+
+    function raycastRings(clientX: number, clientY: number): { axis: 0 | 1 | 2 } | null {
+      if (!previewVisible || !showRings || !_raycastRingGeoms) return null;
+      setupRay(clientX, clientY);
+      for (let axis = 0; axis < 3; axis++) {
+        const mesh = _raycastRingMeshes[axis];
+        mesh.position.set(...previewCenter);
+        mesh.setRotationFromEuler(RING_DEFS[axis as 0 | 1 | 2].euler);
+        mesh.updateMatrixWorld(true);
+        const hits = _raycastRay.intersectObject(mesh);
+        if (hits.length > 0) return { axis: axis as 0 | 1 | 2 };
+      }
+      return null;
+    }
+
+    // Raycasts against all rendered boxes and returns the closest one hit.
+    // Used in navigate mode to let the user click an existing box to edit it.
+    function raycastExistingBoxes(clientX: number, clientY: number): LocalBBox3D | null {
+      setupRay(clientX, clientY);
+      let closestDist = Infinity;
+      let closestBox: LocalBBox3D | null = null;
+      for (const bbox of bboxes3d) {
+        if (bbox.id === editingBoxId) continue;
+        const t = bboxTransform(bbox);
+        const geom = new THREE.BoxGeometry(t.size[0], t.size[1], t.size[2]);
+        const mesh = new THREE.Mesh(geom);
+        mesh.position.set(t.position[0], t.position[1], t.position[2]);
+        mesh.quaternion.copy(t.quaternion);
+        mesh.updateMatrixWorld(true);
+        const hits = _raycastRay.intersectObject(mesh);
+        geom.dispose();
+        if (hits.length > 0 && hits[0].distance < closestDist) {
+          closestDist = hits[0].distance;
+          closestBox = bbox;
+        }
+      }
+      return closestBox;
+    }
+
+    // Returns the signed angle (atan2) of the mouse ray's intersection with the
+    // ring plane, measured from the ring center in the ring's two tangent axes.
+    function computeRingAngle(clientX: number, clientY: number, axis: 0 | 1 | 2): number | null {
+      setupRay(clientX, clientY);
+      const normal = _AXIS_UNIT_VECS[axis];
+      _ringCenter.set(...previewCenter);
+      _ringPlane.set(normal, -_ringCenter.dot(normal));
+      if (!_raycastRay.ray.intersectPlane(_ringPlane, _ringHit)) return null;
+      const d = _ringHit.sub(_ringCenter);
+      const [a, b] = RING_ATAN_AXES[axis];
+      return Math.atan2(d.getComponent(a), d.getComponent(b));
+    }
+
+    function raycastArrows(clientX: number, clientY: number) {
+      if (!previewVisible || !showArrows || !_raycastArrowGeom) return null;
+      setupRay(clientX, clientY);
+      for (const arrow of arrowGizmos) {
+        _raycastArrowMesh.position.set(arrow.pos[0], arrow.pos[1], arrow.pos[2]);
+        _raycastArrowMesh.quaternion.set(arrow.quat[0], arrow.quat[1], arrow.quat[2], arrow.quat[3]);
+        _raycastArrowMesh.updateMatrixWorld(true);
+        const hits = _raycastRay.intersectObject(_raycastArrowMesh);
+        if (hits.length > 0) return arrow;
+      }
+      return null;
+    }
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      // Only handle events that target the canvas — toolbar and overlay clicks must pass through.
+      if (!el.contains(e.target as Node)) return;
+
+      if (drawPhase === "idle") {
+        if (drawMode) {
+          const hit = screenToGround(e.clientX, e.clientY, el);
+          if (!hit) return;
+          e.stopPropagation();
+          e.preventDefault();
+          baseCornerA = hit.clone();
+          baseCornerB = hit.clone();
+          previewVisible = true;
+          boxHeight = 0;
+          drawPhase = "drawing-base";
+        } else {
+          const hit = raycastExistingBoxes(e.clientX, e.clientY);
+          if (!hit) return;
+          e.stopPropagation();
+          e.preventDefault();
+          startEditingBox(hit);
+        }
+      } else if (drawPhase === "drawing-height") {
+        e.stopPropagation();
+        e.preventDefault();
+        if (boxHeight < MIN_BOX_HEIGHT) { resetDraw(); return; }
+        fireReadyToConfirm();
+        drawPhase = "confirming";
+      } else if (drawPhase === "confirming") {
+        // Rings take priority — they live outside the box so there's no overlap,
+        // but checking first keeps the intent unambiguous.
+        const ringHit = raycastRings(e.clientX, e.clientY);
+        if (ringHit) {
+          e.stopPropagation();
+          e.preventDefault();
+          rotAxis = ringHit.axis;
+          rotStartAngle = computeRingAngle(e.clientX, e.clientY, ringHit.axis) ?? 0;
+          rotStartQuaternion = previewQuaternion.clone();
+          drawPhase = "rotating";
+          return;
+        }
+        const arrowHit = raycastArrows(e.clientX, e.clientY);
+        if (arrowHit) {
+          e.stopPropagation();
+          e.preventDefault();
+          resizeAxis = arrowHit.axis as 0 | 1 | 2;
+          resizeStartCenter = [...previewCenter];
+          resizeStartSize = [...previewSize];
+          // Snapshot the world-space face normal (local axis rotated by box quaternion)
+          // and the face center so onPointerMove can project onto the correct plane.
+          _resizeWorldDir.set(0, 0, 0).setComponent(arrowHit.axis, arrowHit.sign);
+          _resizeWorldDir.applyQuaternion(previewQuaternion).normalize();
+          _resizeStartFaceCenter.fromArray(previewCenter).addScaledVector(
+            _resizeWorldDir, previewSize[arrowHit.axis] / 2,
+          );
+          drawPhase = "resizing-face";
+          return;
+        }
+        const boxHit = raycastBox(e.clientX, e.clientY);
+        if (!boxHit) {
+          // In navigate mode, clicking another existing box switches to editing it
+          if (!drawMode) {
+            const existingHit = raycastExistingBoxes(e.clientX, e.clientY);
+            if (existingHit) {
+              e.stopPropagation();
+              e.preventDefault();
+              startEditingBox(existingHit);
+              return;
+            }
+          }
+          return; // empty space — let OrbitControls orbit
+        }
+        e.stopPropagation();
+        e.preventDefault();
+        // Box click always translates — resize is only via face arrows
+        const ground = screenToGround(e.clientX, e.clientY, el);
+        if (!ground) return;
+        moveStartGround = ground.clone();
+        moveStartCenter = [...previewCenter];
+        drawPhase = "moving";
+      }
     };
-  }
 
-  function lanceRotationToThree(rotation: number[] | undefined): THREE.Quaternion {
-    const m = new THREE.Matrix4();
-    if (rotation && rotation.length === 9) {
-      const r = rotation;
-      m.set(r[0], r[1], r[2], 0, r[3], r[4], r[5], 0, r[6], r[7], r[8], 0, 0, 0, 0, 1);
+    const onPointerMove = (e: PointerEvent) => {
+      if (drawPhase === "drawing-base") {
+        e.stopPropagation();
+        const hit = screenToGround(e.clientX, e.clientY, el);
+        if (hit) { baseCornerB = hit.clone(); updatePreviewFootprint(); }
+      } else if (drawPhase === "drawing-height") {
+        e.stopPropagation();
+        boxHeight = computeBoxHeight(e.clientY);
+        updatePreviewHeight();
+      } else if (drawPhase === "rotating") {
+        e.stopPropagation();
+        const angle = computeRingAngle(e.clientX, e.clientY, rotAxis);
+        if (angle === null) return;
+        const delta = angle - rotStartAngle;
+        _rotDeltaQ.setFromAxisAngle(_AXIS_UNIT_VECS[rotAxis], delta);
+        previewQuaternion = new THREE.Quaternion().multiplyQuaternions(_rotDeltaQ, rotStartQuaternion);
+      } else if (drawPhase === "moving") {
+        e.stopPropagation();
+        const hit = screenToGround(e.clientX, e.clientY, el);
+        if (hit && moveStartGround) {
+          const dx = hit.x - moveStartGround.x;
+          const dz = hit.z - moveStartGround.z;
+          previewCenter = [moveStartCenter[0] + dx, previewCenter[1], moveStartCenter[2] + dz];
+        }
+      } else if (drawPhase === "resizing-face") {
+        e.stopPropagation();
+        // Project the mouse ray onto the best-visible plane that contains the face
+        // normal. The plane normal is the component of the camera-forward direction
+        // that is perpendicular to the drag axis — this maximises drag sensitivity
+        // regardless of how the box is rotated.
+        const C = _resizeWorldDir;
+        camera.current.getWorldDirection(_resizeF);
+        _resizePlaneNormal.copy(_resizeF).addScaledVector(C, -_resizeF.dot(C));
+        if (_resizePlaneNormal.lengthSq() < 1e-6) {
+          // Camera nearly parallel to face normal — use world Y (or X for vertical arrows)
+          _resizePlaneNormal.set(Math.abs(C.y) > 0.99 ? 1 : 0, Math.abs(C.y) > 0.99 ? 0 : 1, 0);
+        }
+        _resizePlaneNormal.normalize();
+        _resizeDragPlane.setFromNormalAndCoplanarPoint(_resizePlaneNormal, _resizeStartFaceCenter);
+        setupRay(e.clientX, e.clientY);
+        if (!_raycastRay.ray.intersectPlane(_resizeDragPlane, _resizeHitPt)) return;
+        // Signed displacement along the face normal (positive = extruding outward)
+        const drag = _resizeHitPt.sub(_resizeStartFaceCenter).dot(C);
+        const newSize = [...resizeStartSize] as [number, number, number];
+        const newCenter = [...resizeStartCenter] as [number, number, number];
+        newSize[resizeAxis] = Math.max(MIN_GEOMETRY_SIZE, resizeStartSize[resizeAxis] + drag);
+        newCenter[0] = resizeStartCenter[0] + C.x * drag / 2;
+        newCenter[1] = resizeStartCenter[1] + C.y * drag / 2;
+        newCenter[2] = resizeStartCenter[2] + C.z * drag / 2;
+        previewSize = newSize;
+        previewCenter = newCenter;
+      } else if (drawPhase === "confirming") {
+        if (raycastRings(e.clientX, e.clientY)) {
+          el.style.cursor = "grab";
+        } else {
+          const ah = raycastArrows(e.clientX, e.clientY);
+          if (ah) {
+            el.style.cursor = ah.axis === 1 ? "ns-resize" : ah.axis === 0 ? "ew-resize" : "nesw-resize";
+          } else {
+            el.style.cursor = raycastBox(e.clientX, e.clientY) ? "grab" : drawMode ? "crosshair" : "default";
+          }
+        }
+      } else {
+        el.style.cursor = drawMode ? "crosshair" : "default";
+      }
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      // No el.contains guard — drag operations must commit even when the pointer is
+      // released outside the canvas. drawPhase is the only gate needed because only
+      // onPointerDown (which does guard with el.contains) can enter an active phase.
+      if (drawPhase === "drawing-base") {
+        const footprint = Math.hypot(
+          (baseCornerB?.x ?? 0) - (baseCornerA?.x ?? 0),
+          (baseCornerB?.z ?? 0) - (baseCornerA?.z ?? 0),
+        );
+        if (footprint < MIN_FOOTPRINT_SIZE) { resetDraw(); return; }
+        heightDragStartScreenY = e.clientY;
+        drawPhase = "drawing-height";
+      } else if (drawPhase === "rotating") {
+        drawPhase = "confirming";
+        fireReadyToConfirm();
+      } else if (drawPhase === "moving") {
+        drawPhase = "confirming";
+        fireReadyToConfirm();
+      } else if (drawPhase === "resizing-face") {
+        drawPhase = "confirming";
+        fireReadyToConfirm();
+      }
+    };
+
+    window.addEventListener("pointerdown", onPointerDown, { capture: true });
+    window.addEventListener("pointermove", onPointerMove, { capture: true });
+    window.addEventListener("pointerup", onPointerUp, { capture: true });
+
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, { capture: true });
+      window.removeEventListener("pointermove", onPointerMove, { capture: true });
+      window.removeEventListener("pointerup", onPointerUp, { capture: true });
+      el.style.cursor = "";
+    };
+  });
+
+  // Cancel in-flight draw or edit when the mode toggles in either direction.
+  // The early return before reading drawPhase is intentional: it prevents
+  // drawPhase from becoming a reactive dependency, avoiding an immediate
+  // resetDraw() when drawPhase transitions out of idle during a draw.
+  let _prevDrawMode = false;
+  $effect(() => {
+    const mode = drawMode;
+    if (mode === _prevDrawMode) return;
+    _prevDrawMode = mode;
+    if (drawPhase !== "idle") resetDraw();
+  });
+
+  // React to parent requesting a reset (Cancel button in DOM overlay)
+  let prevExternalReset = 0;
+  $effect(() => {
+    if (externalReset > prevExternalReset) {
+      prevExternalReset = externalReset;
+      resetDraw();
     }
-    const S = new THREE.Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
-    const composed = new THREE.Matrix4().multiplyMatrices(S, m);
-    return new THREE.Quaternion().setFromRotationMatrix(composed);
+  });
+
+  // ─── Draw helpers ─────────────────────────────────────────────────────────────
+
+  function screenToGround(
+    clientX: number,
+    clientY: number,
+    domEl: HTMLElement,
+    y = floorY,
+  ): THREE.Vector3 | null {
+    const rect = domEl.getBoundingClientRect();
+    _screenNdc.set(
+      ((clientX - rect.left) / rect.width) * 2 - 1,
+      -((clientY - rect.top) / rect.height) * 2 + 1,
+    );
+    _screenRay.setFromCamera(_screenNdc, camera.current);
+    _groundPlane.constant = -y;
+    return _screenRay.ray.intersectPlane(_groundPlane, _screenGroundHit) ? _screenGroundHit : null;
   }
 
-  onMount(async () => {
+  function computeBoxHeight(currentScreenY: number): number {
+    const dy = heightDragStartScreenY - currentScreenY;
+    const footprintDiag = Math.hypot(
+      (baseCornerB?.x ?? 0) - (baseCornerA?.x ?? 0),
+      (baseCornerB?.z ?? 0) - (baseCornerA?.z ?? 0),
+    );
+    return Math.max(footprintDiag * HEIGHT_MINIMUM_FROM_FOOTPRINT_RATIO, dy * footprintDiag * HEIGHT_DRAG_SCALE_PER_PX);
+  }
+
+  function updatePreviewFootprint(): void {
+    if (!baseCornerA || !baseCornerB) return;
+    const sx = Math.abs(baseCornerB.x - baseCornerA.x);
+    const sz = Math.abs(baseCornerB.z - baseCornerA.z);
+    const cx = (baseCornerA.x + baseCornerB.x) / 2;
+    const cz = (baseCornerA.z + baseCornerB.z) / 2;
+    previewCenter = [cx, floorY + boxHeight / 2, cz];
+    previewSize = [Math.max(MIN_GEOMETRY_SIZE, sx), Math.max(MIN_GEOMETRY_SIZE, boxHeight), Math.max(MIN_GEOMETRY_SIZE, sz)];
+  }
+
+  function updatePreviewHeight(): void {
+    previewCenter = [previewCenter[0], floorY + boxHeight / 2, previewCenter[2]];
+    previewSize = [previewSize[0], Math.max(MIN_GEOMETRY_SIZE, boxHeight), previewSize[2]];
+  }
+
+  function resetDraw(): void {
+    drawPhase = "idle";
+    previewVisible = false;
+    baseCornerA = null;
+    baseCornerB = null;
+    boxHeight = 0;
+    moveStartGround = null;
+    previewQuaternion = new THREE.Quaternion();
+    editingBoxId = null;
+    onDrawCanceled?.();
+  }
+
+  function startEditingBox(bbox: LocalBBox3D): void {
+    const t = bboxTransform(bbox);
+    previewCenter = t.position;
+    previewSize = t.size;
+    previewQuaternion = t.quaternion.clone();
+    previewVisible = true;
+    boxHeight = t.size[1];
+    editingBoxId = bbox.id;
+    drawPhase = "confirming";
+    onReadyToConfirm?.(
+      threeBoxToLanceXYZWHD(t.position, t.size),
+      threeQuaternionToLanceRotation(t.quaternion),
+      bbox.id,
+    );
+  }
+
+  function fireReadyToConfirm(): void {
+    onReadyToConfirm?.(
+      threeBoxToLanceXYZWHD(previewCenter, previewSize),
+      threeQuaternionToLanceRotation(previewQuaternion),
+      editingBoxId ?? undefined,
+    );
+  }
+
+  // ─── Keyboard shortcuts ───────────────────────────────────────────────────────
+
+  onMount(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+      )
+        return;
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        resetDraw();
+      } else if (e.key === "Enter") {
+        if (drawPhase === "drawing-height") {
+          e.preventDefault();
+          if (boxHeight < MIN_BOX_HEIGHT) { resetDraw(); return; }
+          fireReadyToConfirm();
+          drawPhase = "confirming";
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  // ─── Point cloud loading ─────────────────────────────────────────────────────
+
+  onMount(() => {
     if (!pointCloudUrl) {
       loading = false;
       return;
     }
-    try {
-      const response = await fetch(pointCloudUrl);
-      const buffer = await response.arrayBuffer();
 
-      const floats = new Float32Array(buffer);
-      const stride = 5;
-      const pointCount = Math.floor(floats.length / stride);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-      const pos = new Float32Array(pointCount * 3);
-      const col = new Float32Array(pointCount * 3);
+    void (async () => {
+      try {
+        const response = await fetch(pointCloudUrl, { signal: controller.signal });
+        const buffer = await response.arrayBuffer();
 
-      let minZ = Infinity,
-        maxZ = -Infinity;
-      for (let i = 0; i < pointCount; i++) {
-        const z = floats[i * stride + 2];
-        if (z < minZ) minZ = z;
-        if (z > maxZ) maxZ = z;
-      }
-      const rangeZ = maxZ - minZ || 1;
+      const { positions: pos, colors: col, bounds } = parsePointCloud(buffer);
 
-      for (let i = 0; i < pointCount; i++) {
-        const [tx, ty, tz] = lanceToThree(
-          floats[i * stride],
-          floats[i * stride + 1],
-          floats[i * stride + 2],
-        );
-        pos[i * 3] = tx;
-        pos[i * 3 + 1] = ty;
-        pos[i * 3 + 2] = tz;
-
-        const t = (floats[i * stride + 2] - minZ) / rangeZ;
-        col[i * 3] = t;
-        col[i * 3 + 1] = 0.4 + t * 0.4;
-        col[i * 3 + 2] = 1 - t * 0.5;
-      }
-
-      // ✅ NEW: compute bounding box
-      let minX = Infinity,
-        minY = Infinity,
-        minZp = Infinity;
-      let maxX = -Infinity,
-        maxY = -Infinity,
-        maxZp = -Infinity;
-
-      for (let i = 0; i < pointCount; i++) {
-        const x = pos[i * 3];
-        const y = pos[i * 3 + 1];
-        const z = pos[i * 3 + 2];
-
-        if (x < minX) minX = x;
-        if (y < minY) minY = y;
-        if (z < minZp) minZp = z;
-
-        if (x > maxX) maxX = x;
-        if (y > maxY) maxY = y;
-        if (z > maxZp) maxZp = z;
-      }
+      floorY = bounds.minY;
 
       const center: [number, number, number] = [
-        (minX + maxX) / 2,
-        (minY + maxY) / 2,
-        (minZp + maxZp) / 2,
+        (bounds.minX + bounds.maxX) / 2,
+        (bounds.minY + bounds.maxY) / 2,
+        (bounds.minZ + bounds.maxZ) / 2,
       ];
 
-      const size = Math.max(maxX - minX, maxY - minY, maxZp - minZp);
+      const size = Math.max(
+        bounds.maxX - bounds.minX,
+        bounds.maxY - bounds.minY,
+        bounds.maxZ - bounds.minZ,
+      );
+      const distance = size * CAMERA_DISTANCE_FACTOR;
 
-      const distance = size * 1.2;
-
+      const newPos: [number, number, number] = [
+        center[0] + distance,
+        center[1] + distance * CAMERA_HEIGHT_FACTOR,
+        center[2] + distance,
+      ];
       cameraTarget = center;
-      cameraPosition = [center[0] + distance, center[1] + distance * 0.5, center[2] + distance];
+      cameraPosition = newPos;
+
+      // Directly sync OrbitControls since we removed the reactive target prop.
+      // The <T.PerspectiveCamera position={cameraPosition}> effect is async, so
+      // we also set the camera position directly so update() uses the right value.
+      if (controlsRef) {
+        const cam = controlsRef.object as THREE.PerspectiveCamera;
+        cam.position.set(newPos[0], newPos[1], newPos[2]);
+        cam.lookAt(center[0], center[1], center[2]);
+        controlsRef.target.set(center[0], center[1], center[2]);
+        controlsRef.update();
+      }
 
       positions = pos;
       colors = col;
-    } catch (e) {
-      console.error("Failed to load point cloud:", e);
-    }
-    loading = false;
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") {
+          onLoadError?.("Point cloud load timed out");
+        } else {
+          onLoadError?.(e instanceof Error ? e.message : "Failed to load point cloud");
+        }
+      } finally {
+        clearTimeout(timeoutId);
+        loading = false;
+      }
+    })();
+
+    return () => {
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
   });
 
   const LABEL_OFFSET = 0.3;
   let boxRenders = $derived(
-    bboxes3d.map((bbox) => {
+    bboxes3d.filter((bbox) => bbox.id !== editingBoxId).map((bbox) => {
       const t = bboxTransform(bbox);
       const labelPos: [number, number, number] = [
         t.position[0],
-        t.position[1] + t.size[2] / 2 + LABEL_OFFSET,
+        t.position[1] + t.size[1] / 2 + LABEL_OFFSET,
         t.position[2],
       ];
+      // BoxGeometry is created here (stable per bboxes3d change) and disposed in the
+      // template's oncreate once EdgesGeometry has consumed it in its constructor.
+      const boxGeometry = new THREE.BoxGeometry(t.size[0], t.size[1], t.size[2]);
       return {
+        id: bbox.id,
         transform: t,
+        boxGeometry,
         labelPos,
         label: pickEntityLabel(bbox.entity),
       };
@@ -250,17 +917,16 @@ License: CECILL-C
   }}
 >
   <OrbitControls
-    target={cameraTarget}
+    enableDamping={cameraMode === "orbit"}
+    dampingFactor={ORBIT_DAMPING_FACTOR}
     oncreate={(ref) => {
-      ref.enableZoom = false;
-      ref.enableRotate = false;
-      ref.mouseButtons = { LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY };
+      ref.target.set(cameraTarget[0], cameraTarget[1], cameraTarget[2]);
       controlsRef = ref;
     }}
   />
 </T.PerspectiveCamera>
 
-<T.AmbientLight intensity={0.6} />
+<T.AmbientLight intensity={AMBIENT_LIGHT_INTENSITY} />
 
 {#if !loading && positions.length > 0}
   <T.Points>
@@ -270,11 +936,11 @@ License: CECILL-C
         ref.setAttribute("color", new THREE.BufferAttribute(colors, 3));
       }}
     />
-    <T.PointsMaterial size={0.05} vertexColors sizeAttenuation />
+    <T.PointsMaterial size={POINT_RENDER_SIZE} vertexColors sizeAttenuation />
   </T.Points>
 {/if}
 
-{#each boxRenders as render, i (bboxes3d[i]?.id ?? i)}
+{#each boxRenders as render (render.id)}
   <T.LineSegments
     position={render.transform.position}
     quaternion={[
@@ -285,15 +951,10 @@ License: CECILL-C
     ]}
   >
     <T.EdgesGeometry
-      args={[
-        new THREE.BoxGeometry(
-          render.transform.size[0],
-          render.transform.size[1],
-          render.transform.size[2],
-        ),
-      ]}
+      args={[render.boxGeometry]}
+      oncreate={() => render.boxGeometry.dispose()}
     />
-    <T.LineBasicMaterial color="#22d3ee" linewidth={2} />
+    <T.LineBasicMaterial color={BOX_COLOR_PERSISTED} linewidth={BOX_LINE_WIDTH} />
   </T.LineSegments>
 
   {#if render.label}
@@ -307,4 +968,63 @@ License: CECILL-C
   {/if}
 {/each}
 
-<T.GridHelper args={[100, 50, "#333333", "#222222"]} />
+<!-- Draft preview box (amber while drawing / adjusting) -->
+{#if previewVisible && previewEdgesGeometry}
+  <T.LineSegments
+    position={previewCenter}
+    quaternion={[previewQuaternion.x, previewQuaternion.y, previewQuaternion.z, previewQuaternion.w]}
+    geometry={previewEdgesGeometry}
+  >
+    <T.LineBasicMaterial color={BOX_COLOR_PREVIEW} linewidth={BOX_LINE_WIDTH} />
+  </T.LineSegments>
+{/if}
+
+<!-- Rotation gizmo rings — visible while adjusting (confirming / rotating), toggleable -->
+{#if previewVisible && showRings && (drawPhase === "confirming" || drawPhase === "rotating")}
+  {#each RING_DEFS as ring}
+    <T.Mesh position={previewCenter} rotation={[ring.euler.x, ring.euler.y, ring.euler.z]}>
+      <T.TorusGeometry args={[gizmoRingRadius, gizmoTubeRadius, 6, 64]} />
+      <T.MeshBasicMaterial color={ring.color} transparent opacity={0.75} />
+    </T.Mesh>
+  {/each}
+{/if}
+
+<!-- Resize arrows — shaft + arrowhead per face, visible while confirming or actively resizing -->
+{#if previewVisible && showArrows && (drawPhase === "confirming" || drawPhase === "resizing-face")}
+  {#each arrowGizmos as arrow (arrow.id)}
+    <T.Group position={arrow.pos} quaternion={arrow.quat}>
+      <T.Mesh position={[0, arrowShaftOffsetY, 0]}>
+        <T.CylinderGeometry args={[arrowShaftRadius, arrowShaftRadius, arrowShaftLength, 8]} />
+        <T.MeshBasicMaterial color={arrow.color} transparent opacity={0.85} />
+      </T.Mesh>
+      <T.Mesh position={[0, arrowHeadOffsetY, 0]}>
+        <T.ConeGeometry args={[arrowRadius, arrowHeadLength, 8]} />
+        <T.MeshBasicMaterial color={arrow.color} transparent opacity={0.85} />
+      </T.Mesh>
+    </T.Group>
+  {/each}
+{/if}
+
+<!-- Phase hint (non-interactive) -->
+{#if activeDragging}
+  <HTML position={cameraTarget} center pointerEvents="none">
+    <div
+      class="pointer-events-none rounded bg-black/60 px-2 py-1 text-[10px] text-white"
+      style="transform: translate(-50%, calc(-50% - 60px));"
+    >
+      {#if drawPhase === "drawing-base"}
+        Drag to define footprint
+      {:else if drawPhase === "drawing-height"}
+        Move mouse to set height · Click or Enter to confirm
+      {:else if drawPhase === "moving"}
+        Drag to reposition · Release to lock
+      {:else if drawPhase === "resizing-face"}
+        Drag to resize · Release to lock
+      {:else if drawPhase === "rotating"}
+        Drag ring to rotate · Release to lock
+      {/if}
+    </div>
+  </HTML>
+{/if}
+
+<T.GridHelper args={[GRID_SIZE, GRID_DIVISIONS, GRID_COLOR_CENTER, GRID_COLOR_LINES]} />

--- a/ui/apps/web/src/lib/components/widgets/PointCloudWidget.svelte
+++ b/ui/apps/web/src/lib/components/widgets/PointCloudWidget.svelte
@@ -5,8 +5,22 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { Box, Eye, Globe, MousePointer2, Orbit, Save, Scaling } from "lucide-svelte";
+  import { getContext, onMount } from "svelte";
   import type { Component } from "svelte";
+
+  import {
+    buildBBox3DCreate,
+    buildBBox3DUpdate,
+    DEFAULT_3D_ROTATION,
+    generateShortId,
+  } from "$lib/annotations/buildPayloads.js";
+  import type {
+    DraftBBox3D,
+    PointCloudWidgetStorage,
+  } from "$lib/annotations/types.js";
+  import type { LocalBBox3D } from "$lib/api/annotations.js";
+  import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
   interface Props {
     widgetId: string;
@@ -14,12 +28,42 @@ License: CECILL-C
     data?: Record<string, unknown>;
   }
 
-  let { widgetId, options, data }: Props = $props();
+  let { widgetId, data }: Props = $props();
+
+  const manager = getContext<WorkspaceManager>("workspaceManager");
+  // svelte-ignore state_referenced_locally
+  const stableWidgetId = widgetId;
+  const storage = manager.getStorage(stableWidgetId) as PointCloudWidgetStorage;
+
+  // svelte-ignore state_referenced_locally
+  const datasetId = (data?.datasetId as string | undefined) ?? "";
+  // svelte-ignore state_referenced_locally
+  const recordId = (data?.recordId as string | undefined) ?? "";
+  // svelte-ignore state_referenced_locally
+  const viewId = (data?.viewId as string | undefined) ?? "";
+
+  // Camera control mode — local UI state, not persisted to backend
+  let cameraMode = $state<"orbit" | "first-person">("orbit");
+
+  // Non-null while the user is confirming edits to an existing box (its id)
+  let confirmEditingId = $state<string | null>(null);
+  // Optimistic coordinate overrides for persisted boxes edited but not yet reloaded from backend
+  let localOverrides = $state<Record<string, { coords: [number, number, number, number, number, number]; rotation?: number[] }>>({});
+  $effect(() => { void data; localOverrides = {}; });
 
   let ready = $state(false);
   let error = $state<string | null>(null);
   let CanvasComponent = $state<Component | null>(null);
   let SceneComponent = $state<Component | null>(null);
+  let canvasEl = $state<HTMLDivElement | null>(null);
+
+  // Confirm overlay state — set by scene's onReadyToConfirm, cleared on save/cancel
+  let confirmCoords = $state<[number, number, number, number, number, number] | null>(null);
+  let confirmRotation = $state<number[] | undefined>(undefined);
+  let showRings = $state(true);
+  let showArrows = $state(true);
+  // Incrementing this tells the scene to reset its FSM (used by Cancel button)
+  let externalReset = $state(0);
 
   onMount(async () => {
     try {
@@ -32,32 +76,276 @@ License: CECILL-C
       ready = true;
     } catch (e) {
       error = e instanceof Error ? e.message : "Failed to load 3D viewer";
-      console.error("PointCloudWidget init error:", e);
     }
   });
+
+  $effect(() => {
+    if (!canvasEl) return;
+    canvasEl.style.cursor = storage.mode === "draw-bbox3d" ? "crosshair" : "default";
+  });
+
+  function handleReadyToConfirm(
+    coords: [number, number, number, number, number, number],
+    rotation?: number[],
+    editingId?: string,
+  ): void {
+    confirmEditingId = editingId ?? null;
+    confirmCoords = coords;
+    confirmRotation = rotation;
+  }
+
+  function handleDrawCanceled(): void {
+    confirmCoords = null;
+    confirmEditingId = null;
+  }
+
+  function handleConfirmSave(): void {
+    if (!confirmCoords) return;
+    const coords = confirmCoords;
+    const rotation = confirmRotation;
+    confirmCoords = null;
+
+    if (confirmEditingId) {
+      const boxId = confirmEditingId;
+      confirmEditingId = null;
+      const existing = allBboxes3d.find((b) => b.id === boxId);
+      if (existing) {
+        const updateBody = buildBBox3DUpdate(
+          { datasetId, recordId, viewId },
+          boxId,
+          existing.entity_id,
+          coords,
+          rotation,
+        );
+        const pending = manager.pendingMutations.find(
+          (m) => m.op === "update" && m.resource === "bbox3ds" && m.id === boxId,
+        );
+        if (pending && pending.op === "update") {
+          pending.body = updateBody;
+        } else {
+          manager.queueMutation({
+            op: "update",
+            resource: "bbox3ds",
+            id: boxId,
+            body: updateBody,
+            widgetId: stableWidgetId,
+            localBBoxId: boxId,
+          });
+        }
+        // Optimistic update so the box shows new coords immediately
+        const draftIdx = storage.drafts.findIndex((d) => d.id === boxId);
+        if (draftIdx >= 0) {
+          storage.drafts[draftIdx] = { ...storage.drafts[draftIdx], coordsLance: coords, rotation };
+        } else {
+          localOverrides[boxId] = { coords, rotation };
+        }
+      }
+    } else {
+      const localId = generateShortId();
+      const { entityId, mutations } = buildBBox3DCreate(
+        { datasetId, recordId, viewId },
+        coords,
+        { widgetId: stableWidgetId, localBBoxId: localId, rotation },
+      );
+      const draft: DraftBBox3D = {
+        id: localId,
+        entityId,
+        coordsLance: coords,
+        rotation,
+        persisted: false,
+      };
+      storage.drafts.push(draft);
+      for (const m of mutations) {
+        manager.queueMutation(m);
+      }
+    }
+    // Reset the scene FSM so the user can draw/edit another box immediately.
+    externalReset++;
+  }
+
+  // Cancel button in the DOM overlay — clear coords and tell scene to reset
+  function handleConfirmCancel(): void {
+    confirmCoords = null;
+    confirmEditingId = null;
+    externalReset++;
+  }
+
+  // All boxes: loaded from backend + locally added drafts (shown immediately for feedback)
+  const allBboxes3d = $derived<LocalBBox3D[]>([
+    ...((data?.bboxes3d as LocalBBox3D[] | undefined) ?? []).map((bbox) => {
+      const ov = localOverrides[bbox.id];
+      if (!ov) return bbox;
+      return { ...bbox, coords: ov.coords, rotation: ov.rotation ?? bbox.rotation };
+    }),
+    ...storage.drafts.map(
+      (d): LocalBBox3D => ({
+        id: d.id,
+        record_id: recordId,
+        entity_id: d.entityId,
+        view_id: viewId,
+        coords: d.coordsLance,
+        format: "xyzwhd",
+        rotation: d.rotation ?? DEFAULT_3D_ROTATION,
+        is_normalized: false,
+        entity: d.entity,
+      }),
+    ),
+  ]);
 </script>
 
-<div class="relative h-full w-full bg-card">
+<div class="relative flex h-full w-full flex-col bg-card">
+  <!-- Toolbar -->
+  <div
+    class="flex items-center gap-0.5 border-b border-border bg-muted/30 px-1.5 py-0.5"
+    onpointerdown={(e) => e.stopPropagation()}
+    role="toolbar"
+    aria-label="Point cloud tools"
+    tabindex="0"
+  >
+    <button
+      type="button"
+      onclick={() => (storage.mode = "navigate")}
+      title="Navigate"
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {storage.mode ===
+      'navigate'
+        ? 'bg-accent text-accent-foreground'
+        : ''}"
+    >
+      <MousePointer2 class="h-3.5 w-3.5" />
+    </button>
+    <button
+      type="button"
+      onclick={() => (storage.mode = storage.mode === "draw-bbox3d" ? "navigate" : "draw-bbox3d")}
+      title="Draw 3D box"
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {storage.mode ===
+      'draw-bbox3d'
+        ? 'bg-accent text-accent-foreground'
+        : ''}"
+    >
+      <Box class="h-3.5 w-3.5" />
+    </button>
+    <div class="mx-1 h-4 w-px bg-border"></div>
+    <!-- Camera control mode -->
+    <button
+      type="button"
+      onclick={() => (cameraMode = "orbit")}
+      title="Orbit mode (Left drag to orbit · Right drag to pan · Scroll to zoom)"
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {cameraMode ===
+      'orbit'
+        ? 'bg-accent text-accent-foreground'
+        : ''}"
+    >
+      <Globe class="h-3.5 w-3.5" />
+    </button>
+    <button
+      type="button"
+      onclick={() => (cameraMode = "first-person")}
+      title="First person mode (Left drag to pan · Right drag to look around · Scroll to move forward/back)"
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {cameraMode ===
+      'first-person'
+        ? 'bg-accent text-accent-foreground'
+        : ''}"
+    >
+      <Eye class="h-3.5 w-3.5" />
+    </button>
+    <div class="mx-1 h-4 w-px bg-border"></div>
+    <button
+      type="button"
+      onclick={() => manager.flushSave()}
+      disabled={manager.pendingCount === 0 || manager.saving}
+      title="Save annotations"
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      <Save class="h-3.5 w-3.5" />
+    </button>
+    {#if manager.pendingCount > 0}
+      <span class="ml-1 text-[10px] text-muted-foreground">{manager.pendingCount} unsaved</span>
+    {/if}
+    {#if manager.saveError}
+      <span
+        class="ml-1 max-w-[200px] truncate text-[10px] text-destructive"
+        title={manager.saveError}>Save failed</span
+      >
+    {/if}
+  </div>
+
+  <!-- 3D canvas area -->
   {#if error}
-    <div class="flex h-full items-center justify-center">
+    <div class="flex flex-1 items-center justify-center">
       <div class="text-center text-muted-foreground">
         <div class="mb-1 text-sm">3D Viewer Error</div>
         <div class="text-xs">{error}</div>
       </div>
     </div>
   {:else if ready && CanvasComponent && SceneComponent}
-    <div class="absolute inset-0">
-      <CanvasComponent>
-        <SceneComponent
-          pointCloudUrl={data?.pointCloudUrl as string | undefined}
-          bboxes3d={data?.bboxes3d as
-            | import("$lib/api/annotations").LocalBBox3D[]
-            | undefined}
-        />
-      </CanvasComponent>
+    <div bind:this={canvasEl} class="relative flex-1" onpointerdown={(e) => e.stopPropagation()}>
+      <div class="absolute inset-0">
+        <CanvasComponent>
+          <SceneComponent
+            pointCloudUrl={data?.pointCloudUrl as string | undefined}
+            bboxes3d={allBboxes3d}
+            drawMode={storage.mode === "draw-bbox3d"}
+            {cameraMode}
+            onReadyToConfirm={handleReadyToConfirm}
+            onDrawCanceled={handleDrawCanceled}
+            onLoadError={(msg) => (error = msg)}
+            {externalReset}
+            {showRings}
+            {showArrows}
+          />
+        </CanvasComponent>
+      </div>
+
+      <!-- Confirm overlay — plain DOM, guaranteed reliable click handling -->
+      {#if confirmCoords}
+        <div
+          class="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center"
+        >
+          <div
+            class="pointer-events-auto flex items-center gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-sm shadow-lg backdrop-blur-sm"
+          >
+            <span class="text-muted-foreground">Save this 3D box?</span>
+            <button
+              type="button"
+              onclick={handleConfirmSave}
+              class="rounded bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onclick={handleConfirmCancel}
+              class="rounded border border-border px-2.5 py-1 text-xs hover:bg-accent"
+            >
+              Cancel
+            </button>
+            <div class="mx-1 h-4 w-px bg-border"></div>
+            <button
+              type="button"
+              onclick={() => (showRings = !showRings)}
+              title={showRings ? "Hide rotation rings" : "Show rotation rings"}
+              class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {showRings
+                ? 'bg-accent text-accent-foreground'
+                : ''}"
+            >
+              <Orbit class="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onclick={() => (showArrows = !showArrows)}
+              title={showArrows ? "Hide resize arrows" : "Show resize arrows"}
+              class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {showArrows
+                ? 'bg-accent text-accent-foreground'
+                : ''}"
+            >
+              <Scaling class="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      {/if}
     </div>
   {:else}
-    <div class="flex h-full items-center justify-center">
+    <div class="flex flex-1 items-center justify-center">
       <div class="text-xs text-muted-foreground">Loading 3D viewer...</div>
     </div>
   {/if}

--- a/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
@@ -42,6 +42,9 @@ export const ImageExtension = WidgetExtension.create<ImageWidgetOptions, ImageWi
     selectedId: null,
     bboxes: [],
   }),
+  findLocalDraft: (storage, localId) => {
+    return (storage as ImageWidgetStorage).bboxes?.find((b) => b.id === localId);
+  },
   addRecordSeed: async ({ datasetId, recordId, viewName, viewDef, entitiesById, gateway }) => {
     if (!viewDef.base || !CLAIMED_BASES.has(viewDef.base)) return null;
 

--- a/ui/apps/web/src/lib/extensions/builtin/PointCloudExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/PointCloudExtension.ts
@@ -5,6 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { BBox3DRow, LocalBBox3D } from "$lib/api/annotations.js";
+import type { PointCloudWidgetStorage } from "$lib/annotations/types.js";
 import PointCloudWidget from "$lib/components/widgets/PointCloudWidget.svelte";
 
 import { WidgetExtension } from "../WidgetExtension.js";
@@ -27,6 +28,13 @@ export const PointCloudExtension = WidgetExtension.create({
     backgroundColor: "#1e293b",
     logicalName: "",
   }),
+  addStorage: (): PointCloudWidgetStorage => ({
+    mode: "navigate",
+    drafts: [],
+  }),
+  findLocalDraft: (storage, localId) => {
+    return (storage as PointCloudWidgetStorage).drafts?.find((b) => b.id === localId);
+  },
   addRecordSeed: async ({ datasetId, recordId, viewName, viewDef, entitiesById, gateway }) => {
     if (!viewDef.base || !CLAIMED_BASES.has(viewDef.base)) return null;
 
@@ -56,7 +64,7 @@ export const PointCloudExtension = WidgetExtension.create({
     return {
       title: viewName,
       options: {},
-      data: { pointCloudUrl: pointCloud?.src, bboxes3d },
+      data: { pointCloudUrl: pointCloud?.src, bboxes3d, datasetId, recordId, viewId: pointCloud?.id ?? "" },
     };
   },
 });

--- a/ui/apps/web/src/lib/extensions/builtin/__tests__/ImageExtension.test.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/__tests__/ImageExtension.test.ts
@@ -34,10 +34,10 @@ function makeGateway(image: ImageResponse | null, bboxes: BBoxRow[]): DatasetGat
     loadPointCloudByLogicalName: () => Promise.resolve(null),
     listBBox3Ds: () => Promise.resolve([]),
     createEntity: () => Promise.resolve({}),
-    createBBox: () => Promise.resolve({}),
-    updateBBox: () => Promise.resolve({}),
-    deleteBBox: () => Promise.resolve(),
     deleteEntity: () => Promise.resolve(),
+    createAnnotation: () => Promise.resolve({}),
+    updateAnnotation: () => Promise.resolve({}),
+    deleteAnnotation: () => Promise.resolve(),
   };
 }
 

--- a/ui/apps/web/src/lib/extensions/types.ts
+++ b/ui/apps/web/src/lib/extensions/types.ts
@@ -93,6 +93,16 @@ export interface WidgetExtensionConfig<
    * `WorkspaceManager` can ask the next extension.
    */
   addRecordSeed?: (ctx: SeedContext) => Promise<RecordWidgetSeed<TStorage> | null>;
+
+  /**
+   * Optional: locate a draft annotation in this widget's storage by local id.
+   * Used by `WorkspaceManager` to flip `persisted` after a successful create
+   * without the manager needing to know the storage shape of each widget type.
+   */
+  findLocalDraft?: (
+    storage: Record<string, unknown>,
+    localId: string,
+  ) => { persisted: boolean } | undefined;
 }
 
 /** A widget instance in the workspace */

--- a/ui/apps/web/src/lib/workspace/__tests__/mutationQueue.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/mutationQueue.svelte.test.ts
@@ -34,20 +34,20 @@ function makeGateway(opts: { failOn?: keyof MutationGateway; error?: Error } = {
       record("createEntity", args);
       return Promise.resolve({});
     },
-    createBBox: (...args) => {
-      record("createBBox", args);
-      return Promise.resolve({});
-    },
-    updateBBox: (...args) => {
-      record("updateBBox", args);
-      return Promise.resolve({});
-    },
-    deleteBBox: (...args) => {
-      record("deleteBBox", args);
-      return Promise.resolve();
-    },
     deleteEntity: (...args) => {
       record("deleteEntity", args);
+      return Promise.resolve();
+    },
+    createAnnotation: (...args) => {
+      record("createAnnotation", args);
+      return Promise.resolve({});
+    },
+    updateAnnotation: (...args) => {
+      record("updateAnnotation", args);
+      return Promise.resolve({});
+    },
+    deleteAnnotation: (...args) => {
+      record("deleteAnnotation", args);
       return Promise.resolve();
     },
   };
@@ -106,8 +106,8 @@ describe("MutationQueue.flush", () => {
 
     expect(calls.map((c) => c.method)).toEqual([
       "createEntity",
-      "createBBox",
-      "deleteBBox",
+      "createAnnotation",
+      "deleteAnnotation",
     ]);
     expect(queue.count).toBe(0);
     expect(queue.saveError).toBeNull();
@@ -135,22 +135,22 @@ describe("MutationQueue.flush", () => {
   });
 
   it("surfaces ApiError detail in saveError", async () => {
-    const apiErr = new ApiError("createBBox failed with 422 Unprocessable", 422, '{"detail":"bad"}');
-    const { gateway } = makeGateway({ failOn: "createBBox", error: apiErr });
+    const apiErr = new ApiError("createAnnotation(bboxes) failed with 422 Unprocessable", 422, '{"detail":"bad"}');
+    const { gateway } = makeGateway({ failOn: "createAnnotation", error: apiErr });
     const queue = new MutationQueue(gateway, makeSession(), noopLocator);
 
     queue.queue({ op: "create", resource: "bboxes", body: {} } as ResourceMutation);
 
     await queue.flush();
 
-    expect(queue.saveError).toContain("createBBox failed with 422");
+    expect(queue.saveError).toContain("createAnnotation(bboxes) failed with 422");
     expect(queue.saveError).toContain('{"detail":"bad"}');
     expect(queue.saving).toBe(false);
   });
 
   it("drops already-applied mutations so a retry does not re-send them", async () => {
-    const apiErr = new ApiError("createBBox failed with 422 Unprocessable", 422, '{"detail":"bad"}');
-    const { gateway, calls } = makeGateway({ failOn: "createBBox", error: apiErr });
+    const apiErr = new ApiError("createAnnotation(bboxes) failed with 422 Unprocessable", 422, '{"detail":"bad"}');
+    const { gateway, calls } = makeGateway({ failOn: "createAnnotation", error: apiErr });
     const queue = new MutationQueue(gateway, makeSession(), noopLocator);
 
     queue.queue({ op: "create", resource: "entities", body: {} } as ResourceMutation);
@@ -159,8 +159,8 @@ describe("MutationQueue.flush", () => {
 
     await queue.flush();
 
-    // createEntity ran first (sort order) and succeeded; createBBox failed.
-    expect(calls.map((c) => c.method)).toEqual(["createEntity", "createBBox"]);
+    // createEntity ran first (sort order) and succeeded; createAnnotation(bboxes) failed.
+    expect(calls.map((c) => c.method)).toEqual(["createEntity", "createAnnotation"]);
     // createEntity was dropped; createBBox and deleteBBox remain for retry.
     expect(queue.count).toBe(2);
   });
@@ -174,10 +174,10 @@ describe("MutationQueue.flush", () => {
         await inflight;
         return {};
       },
-      createBBox: () => Promise.resolve({}),
-      updateBBox: () => Promise.resolve({}),
-      deleteBBox: () => Promise.resolve(),
       deleteEntity: () => Promise.resolve(),
+      createAnnotation: () => Promise.resolve({}),
+      updateAnnotation: () => Promise.resolve({}),
+      deleteAnnotation: () => Promise.resolve(),
     };
 
     const queue = new MutationQueue(gateway, makeSession(), noopLocator);

--- a/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
@@ -64,10 +64,10 @@ function makeGateway(opts: {
       Promise.resolve(opts.pointClouds?.get(name) ?? null),
     listBBox3Ds: () => Promise.resolve(opts.bboxes3d ?? []),
     createEntity: () => Promise.resolve({}),
-    createBBox: () => Promise.resolve({}),
-    updateBBox: () => Promise.resolve({}),
-    deleteBBox: () => Promise.resolve(),
     deleteEntity: () => Promise.resolve(),
+    createAnnotation: () => Promise.resolve({}),
+    updateAnnotation: () => Promise.resolve({}),
+    deleteAnnotation: () => Promise.resolve(),
   };
 }
 

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
@@ -74,10 +74,10 @@ function makeGateway(state: FakeGatewayState) {
       return Promise.resolve(state.bboxes3d);
     },
     createEntity: () => Promise.resolve({}),
-    createBBox: () => Promise.resolve({}),
-    updateBBox: () => Promise.resolve({}),
-    deleteBBox: () => Promise.resolve(),
     deleteEntity: () => Promise.resolve(),
+    createAnnotation: () => Promise.resolve({}),
+    updateAnnotation: () => Promise.resolve({}),
+    deleteAnnotation: () => Promise.resolve(),
   };
   return { gateway, calls };
 }
@@ -281,7 +281,7 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
       entityId: "ent-1",
       persisted: true,
     });
-    expect(storage?.bboxes[0].entity).toBe(entity);
+    expect(storage?.bboxes[0].entity).toStrictEqual(entity);
   });
 
   it("forwards 3D boxes (with entity attached) to the point-cloud widget data", async () => {
@@ -372,6 +372,9 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
       updateBBox: () => Promise.resolve({}),
       deleteBBox: () => Promise.resolve(),
       deleteEntity: () => Promise.resolve(),
+      createBBox3D: () => Promise.resolve({}),
+      updateBBox3D: () => Promise.resolve({}),
+      deleteBBox3D: () => Promise.resolve(),
     };
 
     const manager = new WorkspaceManager(makeRegistry(), gateway);

--- a/ui/apps/web/src/lib/workspace/datasetGateway.ts
+++ b/ui/apps/web/src/lib/workspace/datasetGateway.ts
@@ -65,20 +65,22 @@ export interface MutationGateway {
     body: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
 
-  createBBox(
+  deleteEntity(datasetId: string, id: string): Promise<void>;
+
+  createAnnotation(
     datasetId: string,
+    resource: string,
     body: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
 
-  updateBBox(
+  updateAnnotation(
     datasetId: string,
+    resource: string,
     id: string,
     body: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
 
-  deleteBBox(datasetId: string, id: string): Promise<void>;
-
-  deleteEntity(datasetId: string, id: string): Promise<void>;
+  deleteAnnotation(datasetId: string, resource: string, id: string): Promise<void>;
 }
 
 /** Combined read+write gateway used by the workspace facade. */
@@ -100,8 +102,8 @@ export const httpDatasetGateway: DatasetGateway = {
   listBBox3Ds: (datasetId, params) => api.listBBox3Ds(datasetId, params),
 
   createEntity: (datasetId, body) => api.createEntity(datasetId, body),
-  createBBox: (datasetId, body) => api.createBBox(datasetId, body),
-  updateBBox: (datasetId, id, body) => api.updateBBox(datasetId, id, body),
-  deleteBBox: (datasetId, id) => api.deleteBBox(datasetId, id),
   deleteEntity: (datasetId, id) => api.deleteEntity(datasetId, id),
+  createAnnotation: (datasetId, resource, body) => api.createAnnotation(datasetId, resource, body),
+  updateAnnotation: (datasetId, resource, id, body) => api.updateAnnotation(datasetId, resource, id, body),
+  deleteAnnotation: (datasetId, resource, id) => api.deleteAnnotation(datasetId, resource, id),
 };

--- a/ui/apps/web/src/lib/workspace/mutationQueue.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/mutationQueue.svelte.ts
@@ -107,7 +107,7 @@ export class MutationQueue {
         this.pending = this.pending.filter((m) => m !== mutation);
         if (
           mutation.op === "create" &&
-          mutation.resource === "bboxes" &&
+          mutation.resource !== "entities" &&
           mutation.widgetId &&
           mutation.localBBoxId
         ) {
@@ -133,25 +133,20 @@ export class MutationQueue {
   }
 
   private async run(datasetId: string, mutation: ResourceMutation): Promise<void> {
-    if (mutation.op === "create" && mutation.resource === "entities") {
-      await this.gateway.createEntity(datasetId, mutation.body);
+    if (mutation.resource === "entities") {
+      if (mutation.op === "create") {
+        await this.gateway.createEntity(datasetId, mutation.body);
+      } else if (mutation.op === "delete") {
+        await this.gateway.deleteEntity(datasetId, mutation.id);
+      }
       return;
     }
-    if (mutation.op === "create" && mutation.resource === "bboxes") {
-      await this.gateway.createBBox(datasetId, mutation.body);
-      return;
-    }
-    if (mutation.op === "update" && mutation.resource === "bboxes") {
-      await this.gateway.updateBBox(datasetId, mutation.id, mutation.body);
-      return;
-    }
-    if (mutation.op === "delete" && mutation.resource === "bboxes") {
-      await this.gateway.deleteBBox(datasetId, mutation.id);
-      return;
-    }
-    if (mutation.op === "delete" && mutation.resource === "entities") {
-      await this.gateway.deleteEntity(datasetId, mutation.id);
-      return;
+    if (mutation.op === "create") {
+      await this.gateway.createAnnotation(datasetId, mutation.resource, mutation.body);
+    } else if (mutation.op === "update") {
+      await this.gateway.updateAnnotation(datasetId, mutation.resource, mutation.id, mutation.body);
+    } else if (mutation.op === "delete") {
+      await this.gateway.deleteAnnotation(datasetId, mutation.resource, mutation.id);
     }
   }
 }

--- a/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
@@ -4,7 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { ImageWidgetStorage, ResourceMutation } from "$lib/annotations/types.js";
+import type { ResourceMutation } from "$lib/annotations/types.js";
 import type { WidgetInstance, WidgetLayout, WorkspacePreset } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 
@@ -52,14 +52,16 @@ export class WorkspaceManager {
     this.registry = registry;
     this.session = new WorkspaceSession();
 
-    // Locator closure keeps `ImageWidgetStorage`-shape knowledge confined
-    // to this wiring; `MutationQueue` itself stays widget-storage-agnostic.
+    // Each extension owns the knowledge of its own storage shape via findLocalDraft.
+    // The manager delegates rather than enumerating widget-type-specific fields.
     this.mutations = new MutationQueue(gateway, this.session, {
       findLocalBBox: (widgetId, localBBoxId) => {
-        const storage = this.storageMap.get(widgetId) as
-          | ImageWidgetStorage
-          | undefined;
-        return storage?.bboxes.find((b) => b.id === localBBoxId);
+        const storage = this.storageMap.get(widgetId);
+        if (!storage) return undefined;
+        const widget = this.widgets.find((w) => w.id === widgetId);
+        if (!widget) return undefined;
+        const config = this.registry.get(widget.extensionName);
+        return config?.findLocalDraft?.(storage, localBBoxId);
       },
     });
 
@@ -150,7 +152,9 @@ export class WorkspaceManager {
     }
 
     const options = config.addOptions?.() ?? {};
-    const storage = { ...(config.addStorage?.() ?? {}), ...(seedStorage ?? {}) };
+    // Wrap in $state so property mutations (e.g. storage.mode = "draw-bbox3d")
+    // are tracked by Svelte's reactivity system inside widget components.
+    const storage = $state({ ...(config.addStorage?.() ?? {}), ...(seedStorage ?? {}) });
 
     const widget: WidgetInstance = {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Description

  Add interactive editing of 3D bounding boxes in the point cloud widget.
  Previously, boxes could only be created by drawing. Now, clicking any
  existing box enters an edit mode where the user can reposition it by
  dragging the body, resize individual faces by dragging directional
  arrows, or rotate it around any axis by dragging coloured rings — one
  per axis (X/Y/Z). Both the rings and arrows can be toggled off when they
  clutter the view. Edits are staged and must be confirmed or cancelled
  before the next action.

  Navigation now defaults to orbit mode, where the camera revolves around
  a fixed point in the scene — more intuitive for inspecting a static
  point cloud from all angles. Users can switch to the legacy walk/fly
  mode for first-person navigation.

  On the infrastructure side, coordinate conversion and point cloud
  parsing were extracted into dedicated modules to be reusable across
  future widgets. Point cloud loading now times out cleanly and reports
  errors to the user rather than swallowing them silently. Edits to the
  same box are coalesced into a single save request rather than
  accumulating one per interaction.