### PR TITLE
feat(web): add dark/light theme toggle

### DIFF
--- a/ui/apps/web/src/app.html
+++ b/ui/apps/web/src/app.html
@@ -1,9 +1,24 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      /* Theme key: keep in sync with STORAGE_KEY in src/lib/stores/theme.svelte.ts */
+      (function () {
+        var stored = null;
+        try {
+          stored = localStorage.getItem("pixano-theme");
+        } catch (_) {
+          /* localStorage blocked (e.g. Tor Browser, dom.storage.enabled=false) */
+        }
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (stored === "dark" || ((stored === null || stored === "") && prefersDark)) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/ui/apps/web/src/lib/components/shell/Toolbar.svelte
+++ b/ui/apps/web/src/lib/components/shell/Toolbar.svelte
@@ -5,9 +5,10 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Lock, PanelRight, Unlock } from "lucide-svelte";
+  import { Lock, Moon, PanelRight, Sun, Unlock } from "lucide-svelte";
 
   import type { PanelState } from "$lib/components/ui/resizable-panel/PanelState.svelte.js";
+  import { themeStore } from "$lib/stores/theme.svelte.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
   import pixanoLogo from "$lib/assets/pixano.png";
   interface Props {
@@ -16,6 +17,8 @@ License: CECILL-C
   }
 
   let { manager, rightPanel }: Props = $props();
+
+  const isDark = $derived(themeStore.mode === "dark");
 
   function toggleEditMode() {
     manager.editMode = !manager.editMode;
@@ -48,6 +51,18 @@ License: CECILL-C
       {:else}
         <Lock class="h-3.5 w-3.5" />
         <span>Locked</span>
+      {/if}
+    </button>
+
+    <button
+      onclick={() => themeStore.toggle()}
+      class="flex items-center justify-center rounded-md border border-border p-1 text-xs text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {#if isDark}
+        <Sun class="h-3.5 w-3.5" />
+      {:else}
+        <Moon class="h-3.5 w-3.5" />
       {/if}
     </button>
 

--- a/ui/apps/web/src/lib/stores/theme.svelte.ts
+++ b/ui/apps/web/src/lib/stores/theme.svelte.ts
@@ -1,0 +1,42 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+const VALID_MODES = ["light", "dark"] as const;
+export type ThemeMode = (typeof VALID_MODES)[number];
+
+// NOTE: This key is also used as a literal string in app.html.
+// If you rename it here, update app.html too.
+export const STORAGE_KEY = "pixano-theme";
+
+function isValidThemeMode(value: string | null): value is ThemeMode {
+  return (VALID_MODES as readonly string[]).includes(value as string);
+}
+
+function getSystemTheme(): ThemeMode {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+class ThemeStore {
+  mode = $state<ThemeMode>("dark");
+
+  constructor() {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        this.mode = isValidThemeMode(stored) ? stored : getSystemTheme();
+      } catch (_) {
+        // localStorage blocked — fall back to system preference
+        this.mode = getSystemTheme();
+      }
+    }
+  }
+
+  toggle() {
+    this.mode = this.mode === "dark" ? "light" : "dark";
+  }
+}
+
+export const themeStore = new ThemeStore();

--- a/ui/apps/web/src/routes/+layout.svelte
+++ b/ui/apps/web/src/routes/+layout.svelte
@@ -9,7 +9,18 @@ License: CECILL-C
 
   import type { Snippet } from "svelte";
 
+  import { STORAGE_KEY, themeStore } from "$lib/stores/theme.svelte";
+
   let { children }: { children: Snippet } = $props();
+
+  $effect(() => {
+    document.documentElement.classList.toggle("dark", themeStore.mode === "dark");
+    try {
+      localStorage.setItem(STORAGE_KEY, themeStore.mode);
+    } catch (_) {
+      // localStorage blocked — theme works in-session but won't persist
+    }
+  });
 </script>
 
 {@render children()}


### PR DESCRIPTION
Add a persistent theme toggle button to the toolbar. The chosen theme is saved in localStorage and restored on next visit. When no preference has been saved, the app follows the OS color scheme preference.

The implementation is hardened against restricted environments (private browsing, Tor Browser) where storage access may be blocked: the page always renders correctly and the toggle still works in-session even if the preference cannot be persisted.