### PR TITLE
Feat/frictionless data importer

### DIFF
--- a/src/pixano/api/routers/__init__.py
+++ b/src/pixano/api/routers/__init__.py
@@ -10,6 +10,7 @@ from fastapi.routing import APIRouter
 from pixano.api.routers.bboxes import router as bboxes_router
 from pixano.api.routers.conversations import router as conversations_router
 from pixano.api.routers.datasets import router as datasets_router
+from pixano.api.routers.import_datasets import router as import_datasets_router
 from pixano.api.routers.embeddings import router as embeddings_router
 from pixano.api.routers.entities import router as entities_router
 from pixano.api.routers.entity_dynamic_states import router as entity_dynamic_states_router
@@ -42,6 +43,7 @@ RESOURCE_ROUTERS: tuple[APIRouter, ...] = (
 )
 
 API_ROUTERS: tuple[APIRouter, ...] = (
+    import_datasets_router,
     datasets_router,
     inference_app_router,
     inference_router,

--- a/src/pixano/api/routers/__init__.py
+++ b/src/pixano/api/routers/__init__.py
@@ -10,10 +10,10 @@ from fastapi.routing import APIRouter
 from pixano.api.routers.bboxes import router as bboxes_router
 from pixano.api.routers.conversations import router as conversations_router
 from pixano.api.routers.datasets import router as datasets_router
-from pixano.api.routers.import_datasets import router as import_datasets_router
 from pixano.api.routers.embeddings import router as embeddings_router
 from pixano.api.routers.entities import router as entities_router
 from pixano.api.routers.entity_dynamic_states import router as entity_dynamic_states_router
+from pixano.api.routers.import_datasets import router as import_datasets_router
 from pixano.api.routers.inference import app_router as inference_app_router
 from pixano.api.routers.inference import router as inference_router
 from pixano.api.routers.keypoints import router as keypoints_router

--- a/src/pixano/api/routers/import_datasets.py
+++ b/src/pixano/api/routers/import_datasets.py
@@ -58,12 +58,16 @@ IMPORT_TYPES = {
 
 
 class ImportRequest(BaseModel):
+    """Request body for starting a dataset import job."""
+
     source_dir: str
     import_type: str = "unlabeled_images"
     dataset_name: str = ""
 
 
 class ImportJobResponse(BaseModel):
+    """Response body for import job status queries."""
+
     job_id: str
     status: str
     message: str
@@ -131,7 +135,11 @@ def _run_video_import(job_id: str, source_path: Path, name: str, target_name: st
     try:
         import cv2
     except ImportError:
-        _set_job(job_id, "error", "opencv-python (cv2) is required for video import. Install it with: pip install opencv-python")
+        _set_job(
+            job_id,
+            "error",
+            "opencv-python (cv2) is required for video import. Install it with: pip install opencv-python",
+        )
         return
 
     from pixano.datasets.builders.folders.video import VIDEO_EXTENSIONS
@@ -235,6 +243,4 @@ def get_import_job(
         job = _jobs.get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail=f"Import job '{job_id}' not found.")
-    return ImportJobResponse(
-        job_id=job.id, status=job.status, message=job.message, dataset_id=job.dataset_id
-    )
+    return ImportJobResponse(job_id=job.id, status=job.status, message=job.message, dataset_id=job.dataset_id)

--- a/src/pixano/api/routers/import_datasets.py
+++ b/src/pixano/api/routers/import_datasets.py
@@ -1,0 +1,151 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import os
+import re
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Literal
+
+import shortuuid
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from pixano.api.settings import Settings, get_settings
+from pixano.datasets.builders.folders.image import ImageFolderBuilder
+from pixano.datasets.dataset_info import DatasetInfo
+
+
+def _snake_case_name(value: str) -> str:
+    snake = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower())
+    return re.sub(r"_+", "_", snake).strip("_")
+
+
+@dataclass
+class _ImportJob:
+    id: str
+    status: Literal["pending", "running", "done", "error"] = "pending"
+    message: str = ""
+    dataset_id: str = ""
+
+
+_jobs: dict[str, _ImportJob] = {}
+_jobs_lock = threading.Lock()
+
+router = APIRouter(prefix="/datasets", tags=["Datasets"])
+
+IMPORT_TYPES = {
+    "unlabeled_images": ImageFolderBuilder,
+}
+
+
+class ImportRequest(BaseModel):
+    source_dir: str
+    import_type: str = "unlabeled_images"
+    dataset_name: str = ""
+
+
+class ImportJobResponse(BaseModel):
+    job_id: str
+    status: str
+    message: str
+    dataset_id: str
+
+
+def _set_job(job_id: str, status: str, message: str = "", dataset_id: str = "") -> None:
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+        if job:
+            job.status = status  # type: ignore[assignment]
+            job.message = message
+            job.dataset_id = dataset_id
+
+
+def _run_import(job_id: str, source_dir_str: str, dataset_name: str, library_dir: Path) -> None:
+    _set_job(job_id, "running", "Preparing import…")
+
+    source_path = Path(source_dir_str)
+    if not source_path.is_dir():
+        _set_job(job_id, "error", f"Directory not found: {source_dir_str}")
+        return
+
+    name = dataset_name.strip() or source_path.name
+    target_name = _snake_case_name(name)
+    if not target_name:
+        _set_job(job_id, "error", "Could not derive a valid dataset name.")
+        return
+
+    if (library_dir / target_name).exists():
+        _set_job(job_id, "error", f"Dataset '{target_name}' already exists. Choose a different name.")
+        return
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.symlink(source_path.resolve(), Path(tmp) / "val")
+            builder = ImageFolderBuilder(
+                source_dir=tmp,
+                library_dir=library_dir,
+                info=DatasetInfo(name=name),
+                target_name=target_name,
+            )
+            _set_job(job_id, "running", "Validating source folder…")
+            report = builder.preflight_metadata()
+            if not report.is_valid:
+                _set_job(job_id, "error", f"Validation failed with {report.error_count} error(s).")
+                return
+            _set_job(job_id, "running", "Importing images…")
+            dataset = builder.build()
+
+        _set_job(
+            job_id,
+            "done",
+            f"Successfully imported {dataset.num_rows} image(s).",
+            dataset.info.id,
+        )
+    except Exception as exc:
+        _set_job(job_id, "error", str(exc))
+
+
+@router.post("/import", response_model=ImportJobResponse, operation_id="start_dataset_import")
+def start_import(
+    request: ImportRequest,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ImportJobResponse:
+    """Start an asynchronous dataset import job from a local folder."""
+    if not isinstance(settings.library_dir, Path):
+        raise HTTPException(status_code=400, detail="UI import is only supported for local storage.")
+    if request.import_type not in IMPORT_TYPES:
+        raise HTTPException(status_code=400, detail=f"Unknown import type: {request.import_type!r}.")
+
+    job_id = shortuuid.uuid()
+    with _jobs_lock:
+        _jobs[job_id] = _ImportJob(id=job_id)
+
+    thread = threading.Thread(
+        target=_run_import,
+        args=(job_id, request.source_dir, request.dataset_name, settings.library_dir),
+        daemon=True,
+    )
+    thread.start()
+
+    return ImportJobResponse(job_id=job_id, status="pending", message="", dataset_id="")
+
+
+@router.get("/import/{job_id}", response_model=ImportJobResponse, operation_id="get_import_job")
+def get_import_job(
+    job_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ImportJobResponse:
+    """Poll the status of an import job."""
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Import job '{job_id}' not found.")
+    return ImportJobResponse(
+        job_id=job.id, status=job.status, message=job.message, dataset_id=job.dataset_id
+    )

--- a/src/pixano/api/routers/import_datasets.py
+++ b/src/pixano/api/routers/import_datasets.py
@@ -18,7 +18,19 @@ from pydantic import BaseModel
 
 from pixano.api.settings import Settings, get_settings
 from pixano.datasets.builders.folders.image import ImageFolderBuilder
+from pixano.datasets.builders.folders.video import VideoFolderBuilder
 from pixano.datasets.dataset_info import DatasetInfo
+from pixano.schemas import Entity, Record
+
+
+class _ImageEntity(Entity):
+    category: str = ""
+    sub_category: str = ""
+
+
+class _VideoEntity(Entity):
+    category: str = ""
+    sub_category: str = ""
 
 
 def _snake_case_name(value: str) -> str:
@@ -41,6 +53,7 @@ router = APIRouter(prefix="/datasets", tags=["Datasets"])
 
 IMPORT_TYPES = {
     "unlabeled_images": ImageFolderBuilder,
+    "unlabeled_videos": VideoFolderBuilder,
 }
 
 
@@ -66,7 +79,7 @@ def _set_job(job_id: str, status: str, message: str = "", dataset_id: str = "") 
             job.dataset_id = dataset_id
 
 
-def _run_import(job_id: str, source_dir_str: str, dataset_name: str, library_dir: Path) -> None:
+def _run_import(job_id: str, source_dir_str: str, import_type: str, dataset_name: str, library_dir: Path) -> None:
     _set_job(job_id, "running", "Preparing import…")
 
     source_path = Path(source_dir_str)
@@ -84,13 +97,20 @@ def _run_import(job_id: str, source_dir_str: str, dataset_name: str, library_dir
         _set_job(job_id, "error", f"Dataset '{target_name}' already exists. Choose a different name.")
         return
 
+    if import_type == "unlabeled_videos":
+        _run_video_import(job_id, source_path, name, target_name, library_dir)
+    else:
+        _run_image_import(job_id, source_path, name, target_name, library_dir)
+
+
+def _run_image_import(job_id: str, source_path: Path, name: str, target_name: str, library_dir: Path) -> None:
     try:
         with tempfile.TemporaryDirectory() as tmp:
             os.symlink(source_path.resolve(), Path(tmp) / "val")
             builder = ImageFolderBuilder(
                 source_dir=tmp,
                 library_dir=library_dir,
-                info=DatasetInfo(name=name),
+                info=DatasetInfo(name=name, record=Record, entity=_ImageEntity),
                 target_name=target_name,
             )
             _set_job(job_id, "running", "Validating source folder…")
@@ -100,13 +120,82 @@ def _run_import(job_id: str, source_dir_str: str, dataset_name: str, library_dir
                 return
             _set_job(job_id, "running", "Importing images…")
             dataset = builder.build()
+        _set_job(job_id, "done", f"Successfully imported {dataset.num_rows} image(s).", dataset.info.id)
+    except Exception as exc:
+        _set_job(job_id, "error", str(exc))
 
-        _set_job(
-            job_id,
-            "done",
-            f"Successfully imported {dataset.num_rows} image(s).",
-            dataset.info.id,
-        )
+
+def _run_video_import(job_id: str, source_path: Path, name: str, target_name: str, library_dir: Path) -> None:
+    import json
+
+    try:
+        import cv2
+    except ImportError:
+        _set_job(job_id, "error", "opencv-python (cv2) is required for video import. Install it with: pip install opencv-python")
+        return
+
+    from pixano.datasets.builders.folders.video import VIDEO_EXTENSIONS
+
+    video_files = sorted(f for f in source_path.iterdir() if f.is_file() and f.suffix.lower() in VIDEO_EXTENSIONS)
+    if not video_files:
+        _set_job(job_id, "error", f"No video files found in {source_path} (supported: {', '.join(VIDEO_EXTENSIONS)}).")
+        return
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            val_frames_dir = tmp_path / "val" / "frames"
+            val_frames_dir.mkdir(parents=True)
+
+            metadata_lines: list[str] = []
+            for i, video_path in enumerate(video_files):
+                _set_job(job_id, "running", f"Extracting frames from {video_path.name} ({i + 1}/{len(video_files)})…")
+                frame_dir = val_frames_dir / video_path.stem
+                frame_dir.mkdir()
+
+                cap = cv2.VideoCapture(str(video_path))
+                fps = cap.get(cv2.CAP_PROP_FPS) or 24.0
+                frame_idx = 0
+                while True:
+                    ret, frame = cap.read()
+                    if not ret:
+                        break
+                    cv2.imwrite(str(frame_dir / f"{frame_idx:05d}.jpg"), frame)
+                    frame_idx += 1
+                cap.release()
+
+                if frame_idx == 0:
+                    _set_job(job_id, "error", f"Could not extract any frames from {video_path.name}.")
+                    return
+
+                entry = {
+                    "status": "unlabeled",
+                    "views": {
+                        "image": {
+                            "path": f"frames/{video_path.stem}/*.jpg",
+                            "fps": round(fps),
+                        }
+                    },
+                }
+                metadata_lines.append(json.dumps(entry))
+
+            (tmp_path / "val" / "metadata.jsonl").write_text("\n".join(metadata_lines) + "\n")
+
+            builder = VideoFolderBuilder(
+                source_dir=tmp,
+                library_dir=library_dir,
+                info=DatasetInfo(name=name, record=Record, entity=_VideoEntity),
+                target_name=target_name,
+            )
+            _set_job(job_id, "running", "Building dataset…")
+            report = builder.preflight_metadata()
+            if not report.is_valid:
+                _set_job(job_id, "error", f"Validation failed with {report.error_count} error(s).")
+                return
+            _set_job(job_id, "running", "Importing video frames…")
+            dataset = builder.build()
+
+        _set_job(job_id, "done", f"Successfully imported {len(video_files)} video(s).", dataset.info.id)
     except Exception as exc:
         _set_job(job_id, "error", str(exc))
 
@@ -128,7 +217,7 @@ def start_import(
 
     thread = threading.Thread(
         target=_run_import,
-        args=(job_id, request.source_dir, request.dataset_name, settings.library_dir),
+        args=(job_id, request.source_dir, request.import_type, request.dataset_name, settings.library_dir),
         daemon=True,
     )
     thread.start()

--- a/src/pixano/api/routers/import_datasets.py
+++ b/src/pixano/api/routers/import_datasets.py
@@ -20,7 +20,7 @@ from pixano.api.settings import Settings, get_settings
 from pixano.datasets.builders.folders.image import ImageFolderBuilder
 from pixano.datasets.builders.folders.video import VideoFolderBuilder
 from pixano.datasets.dataset_info import DatasetInfo
-from pixano.schemas import Entity, Record
+from pixano.schemas import CompressedRLE, Entity, Record
 
 
 class _ImageEntity(Entity):
@@ -110,7 +110,7 @@ def _run_image_import(job_id: str, source_path: Path, name: str, target_name: st
             builder = ImageFolderBuilder(
                 source_dir=tmp,
                 library_dir=library_dir,
-                info=DatasetInfo(name=name, record=Record, entity=_ImageEntity),
+                info=DatasetInfo(name=name, record=Record, entity=_ImageEntity, mask=CompressedRLE),
                 target_name=target_name,
             )
             _set_job(job_id, "running", "Validating source folder…")
@@ -184,7 +184,7 @@ def _run_video_import(job_id: str, source_path: Path, name: str, target_name: st
             builder = VideoFolderBuilder(
                 source_dir=tmp,
                 library_dir=library_dir,
-                info=DatasetInfo(name=name, record=Record, entity=_VideoEntity),
+                info=DatasetInfo(name=name, record=Record, entity=_VideoEntity, mask=CompressedRLE),
                 target_name=target_name,
             )
             _set_job(job_id, "running", "Building dataset…")

--- a/ui/apps/pixano/src/components/library/DatasetsLibrary.svelte
+++ b/ui/apps/pixano/src/components/library/DatasetsLibrary.svelte
@@ -10,8 +10,8 @@ License: CECILL-C
   import { untrack } from "svelte";
 
   import DatasetPreviewCard from "../../components/dataset/DatasetPreviewCard.svelte";
-  import ImportDatasetModal from "./ImportDatasetModal.svelte";
   import { panTool } from "../workspace";
+  import ImportDatasetModal from "./ImportDatasetModal.svelte";
   import { goto } from "$app/navigation";
   import { datasetFilter, datasetsStore } from "$lib/stores/appStores.svelte";
   import { modelsUiStore, resetColorScale, selectedTool } from "$lib/stores/workspaceStores.svelte";
@@ -72,7 +72,11 @@ License: CECILL-C
 </script>
 
 {#if showImport}
-  <ImportDatasetModal onClose={() => { showImport = false; }} />
+  <ImportDatasetModal
+    onClose={() => {
+      showImport = false;
+    }}
+  />
 {/if}
 
 {#if datasets && datasets.length > 0}
@@ -148,7 +152,9 @@ License: CECILL-C
     </p>
 
     <button
-      onclick={() => { showImport = true; }}
+      onclick={() => {
+        showImport = true;
+      }}
       class="mt-8 inline-flex items-center gap-2 h-11 px-6 rounded-xl bg-primary text-primary-foreground
         text-sm font-bold uppercase tracking-widest shadow-sm hover:bg-primary/90 active:scale-95
         transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/ui/apps/pixano/src/components/library/DatasetsLibrary.svelte
+++ b/ui/apps/pixano/src/components/library/DatasetsLibrary.svelte
@@ -6,10 +6,11 @@ License: CECILL-C
 
 <script lang="ts">
   // Imports
-  import { ArrowRight, Database } from "phosphor-svelte";
+  import { ArrowRight, Database, UploadSimple } from "phosphor-svelte";
   import { untrack } from "svelte";
 
   import DatasetPreviewCard from "../../components/dataset/DatasetPreviewCard.svelte";
+  import ImportDatasetModal from "./ImportDatasetModal.svelte";
   import { panTool } from "../workspace";
   import { goto } from "$app/navigation";
   import { datasetFilter, datasetsStore } from "$lib/stores/appStores.svelte";
@@ -36,6 +37,8 @@ License: CECILL-C
   }
 
   let { datasets }: Props = $props();
+
+  let showImport = $state(false);
 
   const handleSelectDataset = async (dataset: DatasetInfo) => {
     await goto(getExplorerRoute(dataset.id));
@@ -67,6 +70,10 @@ License: CECILL-C
     });
   });
 </script>
+
+{#if showImport}
+  <ImportDatasetModal onClose={() => { showImport = false; }} />
+{/if}
 
 {#if datasets && datasets.length > 0}
   <div class="flex flex-col gap-8">
@@ -137,27 +144,24 @@ License: CECILL-C
     <h2 class="text-2xl font-bold tracking-tight text-foreground">Your library is empty</h2>
 
     <p class="mt-3 text-sm text-muted-foreground max-w-md leading-relaxed">
-      Use the Pixano CLI to import a dataset and start your annotation workflow.
+      Import a folder of images or videos to start your annotation workflow.
     </p>
 
-    <div class="mt-8 w-full max-w-md">
-      <div class="rounded-xl bg-card border border-border/60 shadow-sm overflow-hidden">
-        <div class="px-4 py-2 border-b border-border/40 bg-muted/30">
-          <span class="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60">
-            Terminal
-          </span>
-        </div>
-        <pre
-          class="px-4 py-3 text-xs text-muted-foreground font-mono leading-relaxed text-left overflow-x-auto">pixano data import &lt;DATA_DIR&gt; &lt;SOURCE_DIR&gt; \
-  --info &lt;path/to/info.py:dataset_info&gt;</pre>
-      </div>
-    </div>
+    <button
+      onclick={() => { showImport = true; }}
+      class="mt-8 inline-flex items-center gap-2 h-11 px-6 rounded-xl bg-primary text-primary-foreground
+        text-sm font-bold uppercase tracking-widest shadow-sm hover:bg-primary/90 active:scale-95
+        transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <UploadSimple weight="bold" size={16} />
+      Import dataset
+    </button>
 
     <a
       href="https://pixano.github.io/pixano/latest/getting_started/"
       target="_blank"
       rel="noopener noreferrer"
-      class="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      class="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-primary hover:underline transition-colors"
     >
       Read the getting started guide
       <ArrowRight weight="bold" size={14} />

--- a/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
+++ b/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
@@ -5,21 +5,21 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { AlertDialog } from "bits-ui";
-  import { CircleNotch, CheckCircle, WarningCircle, FolderOpen } from "phosphor-svelte";
-  import { invalidateAll } from "$app/navigation";
-
   import PrimaryButton from "$components/ui/molecules/PrimaryButton.svelte";
-  import { startDatasetImport, getImportJob } from "$lib/api/datasets";
+  import { AlertDialog } from "bits-ui";
+  import { CheckCircle, CircleNotch, FolderOpen, WarningCircle } from "phosphor-svelte";
+
+  import { invalidateAll } from "$app/navigation";
+  import { getImportJob, startDatasetImport } from "$lib/api/datasets";
   import {
-    BLOCKING_ALERT_OVERLAY_CLASS,
-    BLOCKING_ALERT_VIEWPORT_CLASS,
+    BLOCKING_ALERT_ACTIONS_CLASS,
     BLOCKING_ALERT_CONTENT_CLASS,
     BLOCKING_ALERT_HEADER_CLASS,
-    BLOCKING_ALERT_TITLE_CLASS,
-    BLOCKING_ALERT_SUPPORTING_TEXT_CLASS,
-    BLOCKING_ALERT_ACTIONS_CLASS,
+    BLOCKING_ALERT_OVERLAY_CLASS,
     BLOCKING_ALERT_SECONDARY_BUTTON_CLASS,
+    BLOCKING_ALERT_SUPPORTING_TEXT_CLASS,
+    BLOCKING_ALERT_TITLE_CLASS,
+    BLOCKING_ALERT_VIEWPORT_CLASS,
   } from "$lib/constants/modalConstants";
 
   interface Props {
@@ -132,7 +132,11 @@ License: CECILL-C
   }
 </script>
 
-<AlertDialog.Root {open} onOpenChange={handleOpenChange} onOpenChangeComplete={handleOpenChangeComplete}>
+<AlertDialog.Root
+  {open}
+  onOpenChange={handleOpenChange}
+  onOpenChangeComplete={handleOpenChangeComplete}
+>
   <AlertDialog.Portal>
     <AlertDialog.Overlay class={BLOCKING_ALERT_OVERLAY_CLASS} />
 
@@ -142,15 +146,20 @@ License: CECILL-C
           class={BLOCKING_ALERT_CONTENT_CLASS}
           trapFocus={true}
           preventScroll={true}
-          onEscapeKeydown={(e) => { if (phase !== "running") { e.preventDefault(); handleClose(); } else { e.preventDefault(); } }}
+          onEscapeKeydown={(e) => {
+            if (phase !== "running") {
+              e.preventDefault();
+              handleClose();
+            } else {
+              e.preventDefault();
+            }
+          }}
           onCloseAutoFocus={handleCloseAutoFocus}
         >
           <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-primary/15"></div>
 
           <div class={BLOCKING_ALERT_HEADER_CLASS}>
-            <AlertDialog.Title class={BLOCKING_ALERT_TITLE_CLASS}>
-              Import Dataset
-            </AlertDialog.Title>
+            <AlertDialog.Title class={BLOCKING_ALERT_TITLE_CLASS}>Import Dataset</AlertDialog.Title>
             <AlertDialog.Description class={BLOCKING_ALERT_SUPPORTING_TEXT_CLASS}>
               <p>Select an import type and provide the path to your data folder on the server.</p>
             </AlertDialog.Description>
@@ -167,8 +176,8 @@ License: CECILL-C
                   <label
                     class="flex items-start gap-3 rounded-xl border px-4 py-3 cursor-pointer transition-colors duration-150
                       {selectedType === t.id
-                        ? 'border-primary/40 bg-primary/5'
-                        : 'border-border/50 bg-background/40 hover:border-border hover:bg-muted/30'}"
+                      ? 'border-primary/40 bg-primary/5'
+                      : 'border-border/50 bg-background/40 hover:border-border hover:bg-muted/30'}"
                   >
                     <input
                       type="radio"
@@ -188,11 +197,17 @@ License: CECILL-C
 
             <!-- Source folder path -->
             <div class="px-6 sm:px-7 pb-2 space-y-2">
-              <label for="import-source-dir" class="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <label
+                for="import-source-dir"
+                class="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
+              >
                 Source folder path
               </label>
               <div class="relative flex items-center">
-                <FolderOpen weight="regular" class="absolute left-3 h-4 w-4 text-muted-foreground/60 pointer-events-none" />
+                <FolderOpen
+                  weight="regular"
+                  class="absolute left-3 h-4 w-4 text-muted-foreground/60 pointer-events-none"
+                />
                 <input
                   id="import-source-dir"
                   type="text"
@@ -210,7 +225,10 @@ License: CECILL-C
 
             <!-- Optional dataset name -->
             <div class="px-6 sm:px-7 pb-5 space-y-2">
-              <label for="import-dataset-name" class="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <label
+                for="import-dataset-name"
+                class="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
+              >
                 Dataset name <span class="font-normal normal-case tracking-normal">(optional)</span>
               </label>
               <input
@@ -223,26 +241,29 @@ License: CECILL-C
                   focus:ring-primary/20 focus:bg-background transition-all duration-200"
               />
             </div>
-
           {:else if phase === "running"}
             <div class="px-6 sm:px-7 pb-5">
-              <div class="flex items-center gap-3 rounded-xl border border-border/50 bg-background/55 px-4 py-3 text-sm text-muted-foreground">
+              <div
+                class="flex items-center gap-3 rounded-xl border border-border/50 bg-background/55 px-4 py-3 text-sm text-muted-foreground"
+              >
                 <CircleNotch weight="regular" class="h-4 w-4 shrink-0 animate-spin text-primary" />
                 <span>{statusMessage}</span>
               </div>
             </div>
-
           {:else if phase === "done"}
             <div class="px-6 sm:px-7 pb-5">
-              <div class="flex items-center gap-3 rounded-xl border border-green-500/20 bg-green-500/8 px-4 py-3 text-sm text-green-600 dark:text-green-400">
+              <div
+                class="flex items-center gap-3 rounded-xl border border-green-500/20 bg-green-500/8 px-4 py-3 text-sm text-green-600 dark:text-green-400"
+              >
                 <CheckCircle weight="regular" class="h-4 w-4 shrink-0" />
                 <span>{statusMessage}</span>
               </div>
             </div>
-
           {:else if phase === "error"}
             <div class="px-6 sm:px-7 pb-5">
-              <div class="flex items-center gap-3 rounded-xl border border-destructive/20 bg-destructive/8 px-4 py-3 text-sm text-destructive">
+              <div
+                class="flex items-center gap-3 rounded-xl border border-destructive/20 bg-destructive/8 px-4 py-3 text-sm text-destructive"
+              >
                 <WarningCircle weight="regular" class="h-4 w-4 shrink-0" />
                 <span>{statusMessage}</span>
               </div>
@@ -251,13 +272,21 @@ License: CECILL-C
 
           <div class={BLOCKING_ALERT_ACTIONS_CLASS}>
             {#if phase === "form" || phase === "error"}
-              <button type="button" class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS} onclick={handleClose}>
+              <button
+                type="button"
+                class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
+                onclick={handleClose}
+              >
                 Cancel
               </button>
             {/if}
 
             {#if phase === "error"}
-              <button type="button" class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS} onclick={handleRetry}>
+              <button
+                type="button"
+                class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
+                onclick={handleRetry}
+              >
                 Try again
               </button>
             {/if}

--- a/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
+++ b/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
@@ -32,6 +32,11 @@ License: CECILL-C
       label: "Unlabeled Images Folder",
       description: "Import a flat folder of image files (JPG, PNG, BMP, TIFF…)",
     },
+    {
+      id: "unlabeled_videos",
+      label: "Unlabeled Videos Folder",
+      description: "Import a flat folder of video files (MP4, AVI, MOV, MKV…)",
+    },
   ] as const;
 
   let { onClose }: Props = $props();

--- a/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
+++ b/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
@@ -50,6 +50,11 @@ License: CECILL-C
   let jobId = $state<string | null>(null);
   let pollHandle = $state<ReturnType<typeof setInterval> | null>(null);
 
+  const previouslyFocusedElement: HTMLElement | null =
+    typeof document !== "undefined" && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
   const canSubmit = $derived(sourceDir.trim().length > 0 && phase === "form");
 
   function stopPolling() {
@@ -111,14 +116,23 @@ License: CECILL-C
       return;
     }
     open = nextOpen;
-    if (!nextOpen) {
-      stopPolling();
-      onClose();
+  }
+
+  function handleOpenChangeComplete(nextOpen: boolean) {
+    if (nextOpen) return;
+    stopPolling();
+    onClose();
+  }
+
+  function handleCloseAutoFocus(event: Event) {
+    event.preventDefault();
+    if (previouslyFocusedElement && previouslyFocusedElement.isConnected) {
+      previouslyFocusedElement.focus({ preventScroll: true });
     }
   }
 </script>
 
-<AlertDialog.Root {open} onOpenChange={handleOpenChange}>
+<AlertDialog.Root {open} onOpenChange={handleOpenChange} onOpenChangeComplete={handleOpenChangeComplete}>
   <AlertDialog.Portal>
     <AlertDialog.Overlay class={BLOCKING_ALERT_OVERLAY_CLASS} />
 
@@ -129,6 +143,7 @@ License: CECILL-C
           trapFocus={true}
           preventScroll={true}
           onEscapeKeydown={(e) => { if (phase !== "running") { e.preventDefault(); handleClose(); } else { e.preventDefault(); } }}
+          onCloseAutoFocus={handleCloseAutoFocus}
         >
           <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-primary/15"></div>
 

--- a/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
+++ b/ui/apps/pixano/src/components/library/ImportDatasetModal.svelte
@@ -1,0 +1,277 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { AlertDialog } from "bits-ui";
+  import { CircleNotch, CheckCircle, WarningCircle, FolderOpen } from "phosphor-svelte";
+  import { invalidateAll } from "$app/navigation";
+
+  import PrimaryButton from "$components/ui/molecules/PrimaryButton.svelte";
+  import { startDatasetImport, getImportJob } from "$lib/api/datasets";
+  import {
+    BLOCKING_ALERT_OVERLAY_CLASS,
+    BLOCKING_ALERT_VIEWPORT_CLASS,
+    BLOCKING_ALERT_CONTENT_CLASS,
+    BLOCKING_ALERT_HEADER_CLASS,
+    BLOCKING_ALERT_TITLE_CLASS,
+    BLOCKING_ALERT_SUPPORTING_TEXT_CLASS,
+    BLOCKING_ALERT_ACTIONS_CLASS,
+    BLOCKING_ALERT_SECONDARY_BUTTON_CLASS,
+  } from "$lib/constants/modalConstants";
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  const IMPORT_TYPES = [
+    {
+      id: "unlabeled_images",
+      label: "Unlabeled Images Folder",
+      description: "Import a flat folder of image files (JPG, PNG, BMP, TIFF…)",
+    },
+  ] as const;
+
+  let { onClose }: Props = $props();
+
+  let open = $state(true);
+  let selectedType = $state<string>(IMPORT_TYPES[0].id);
+  let sourceDir = $state("");
+  let datasetName = $state("");
+  let phase = $state<"form" | "running" | "done" | "error">("form");
+  let statusMessage = $state("");
+  let jobId = $state<string | null>(null);
+  let pollHandle = $state<ReturnType<typeof setInterval> | null>(null);
+
+  const canSubmit = $derived(sourceDir.trim().length > 0 && phase === "form");
+
+  function stopPolling() {
+    if (pollHandle !== null) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    phase = "running";
+    statusMessage = "Starting import…";
+
+    try {
+      const job = await startDatasetImport(sourceDir.trim(), selectedType, datasetName.trim());
+      jobId = job.job_id;
+      statusMessage = job.message || "Import started…";
+
+      pollHandle = setInterval(async () => {
+        if (!jobId) return;
+        try {
+          const status = await getImportJob(jobId);
+          statusMessage = status.message;
+          if (status.status === "done") {
+            stopPolling();
+            phase = "done";
+            await invalidateAll();
+          } else if (status.status === "error") {
+            stopPolling();
+            phase = "error";
+          }
+        } catch {
+          stopPolling();
+          phase = "error";
+          statusMessage = "Lost connection to server.";
+        }
+      }, 2000);
+    } catch (err: unknown) {
+      phase = "error";
+      statusMessage = err instanceof Error ? err.message : "Unexpected error starting import.";
+    }
+  }
+
+  function handleClose() {
+    stopPolling();
+    open = false;
+  }
+
+  function handleRetry() {
+    jobId = null;
+    phase = "form";
+    statusMessage = "";
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && phase === "running") {
+      open = true;
+      return;
+    }
+    open = nextOpen;
+    if (!nextOpen) {
+      stopPolling();
+      onClose();
+    }
+  }
+</script>
+
+<AlertDialog.Root {open} onOpenChange={handleOpenChange}>
+  <AlertDialog.Portal>
+    <AlertDialog.Overlay class={BLOCKING_ALERT_OVERLAY_CLASS} />
+
+    <div class={BLOCKING_ALERT_VIEWPORT_CLASS}>
+      <div class="flex min-h-full items-center justify-center">
+        <AlertDialog.Content
+          class={BLOCKING_ALERT_CONTENT_CLASS}
+          trapFocus={true}
+          preventScroll={true}
+          onEscapeKeydown={(e) => { if (phase !== "running") { e.preventDefault(); handleClose(); } else { e.preventDefault(); } }}
+        >
+          <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-primary/15"></div>
+
+          <div class={BLOCKING_ALERT_HEADER_CLASS}>
+            <AlertDialog.Title class={BLOCKING_ALERT_TITLE_CLASS}>
+              Import Dataset
+            </AlertDialog.Title>
+            <AlertDialog.Description class={BLOCKING_ALERT_SUPPORTING_TEXT_CLASS}>
+              <p>Select an import type and provide the path to your data folder on the server.</p>
+            </AlertDialog.Description>
+          </div>
+
+          {#if phase === "form"}
+            <!-- Import type selector -->
+            <div class="px-6 sm:px-7 pb-2 space-y-3">
+              <p class="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                Import type
+              </p>
+              <div class="space-y-2">
+                {#each IMPORT_TYPES as t}
+                  <label
+                    class="flex items-start gap-3 rounded-xl border px-4 py-3 cursor-pointer transition-colors duration-150
+                      {selectedType === t.id
+                        ? 'border-primary/40 bg-primary/5'
+                        : 'border-border/50 bg-background/40 hover:border-border hover:bg-muted/30'}"
+                  >
+                    <input
+                      type="radio"
+                      name="import-type"
+                      value={t.id}
+                      bind:group={selectedType}
+                      class="mt-0.5 accent-primary"
+                    />
+                    <span class="flex flex-col gap-0.5">
+                      <span class="text-sm font-semibold text-foreground">{t.label}</span>
+                      <span class="text-xs text-muted-foreground">{t.description}</span>
+                    </span>
+                  </label>
+                {/each}
+              </div>
+            </div>
+
+            <!-- Source folder path -->
+            <div class="px-6 sm:px-7 pb-2 space-y-2">
+              <label for="import-source-dir" class="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                Source folder path
+              </label>
+              <div class="relative flex items-center">
+                <FolderOpen weight="regular" class="absolute left-3 h-4 w-4 text-muted-foreground/60 pointer-events-none" />
+                <input
+                  id="import-source-dir"
+                  type="text"
+                  placeholder="/path/to/my/images"
+                  bind:value={sourceDir}
+                  class="w-full h-10 pl-9 pr-4 rounded-xl bg-muted/50 border border-border font-mono text-sm
+                    text-foreground placeholder-muted-foreground/50 focus:outline-none focus:ring-2
+                    focus:ring-primary/20 focus:bg-background transition-all duration-200"
+                />
+              </div>
+              <p class="text-[11px] text-muted-foreground/70">
+                Absolute path to the folder on the machine running the Pixano server.
+              </p>
+            </div>
+
+            <!-- Optional dataset name -->
+            <div class="px-6 sm:px-7 pb-5 space-y-2">
+              <label for="import-dataset-name" class="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                Dataset name <span class="font-normal normal-case tracking-normal">(optional)</span>
+              </label>
+              <input
+                id="import-dataset-name"
+                type="text"
+                placeholder="Defaults to folder name"
+                bind:value={datasetName}
+                class="w-full h-10 px-4 rounded-xl bg-muted/50 border border-border text-sm
+                  text-foreground placeholder-muted-foreground/50 focus:outline-none focus:ring-2
+                  focus:ring-primary/20 focus:bg-background transition-all duration-200"
+              />
+            </div>
+
+          {:else if phase === "running"}
+            <div class="px-6 sm:px-7 pb-5">
+              <div class="flex items-center gap-3 rounded-xl border border-border/50 bg-background/55 px-4 py-3 text-sm text-muted-foreground">
+                <CircleNotch weight="regular" class="h-4 w-4 shrink-0 animate-spin text-primary" />
+                <span>{statusMessage}</span>
+              </div>
+            </div>
+
+          {:else if phase === "done"}
+            <div class="px-6 sm:px-7 pb-5">
+              <div class="flex items-center gap-3 rounded-xl border border-green-500/20 bg-green-500/8 px-4 py-3 text-sm text-green-600 dark:text-green-400">
+                <CheckCircle weight="regular" class="h-4 w-4 shrink-0" />
+                <span>{statusMessage}</span>
+              </div>
+            </div>
+
+          {:else if phase === "error"}
+            <div class="px-6 sm:px-7 pb-5">
+              <div class="flex items-center gap-3 rounded-xl border border-destructive/20 bg-destructive/8 px-4 py-3 text-sm text-destructive">
+                <WarningCircle weight="regular" class="h-4 w-4 shrink-0" />
+                <span>{statusMessage}</span>
+              </div>
+            </div>
+          {/if}
+
+          <div class={BLOCKING_ALERT_ACTIONS_CLASS}>
+            {#if phase === "form" || phase === "error"}
+              <button type="button" class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS} onclick={handleClose}>
+                Cancel
+              </button>
+            {/if}
+
+            {#if phase === "error"}
+              <button type="button" class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS} onclick={handleRetry}>
+                Try again
+              </button>
+            {/if}
+
+            {#if phase === "form"}
+              <PrimaryButton
+                class="w-full sm:w-auto border-primary/70 font-mono text-[11px] tracking-[0.18em]"
+                isSelected={true}
+                disabled={!canSubmit}
+                onclick={handleSubmit}
+              >
+                Import
+              </PrimaryButton>
+            {:else if phase === "running"}
+              <PrimaryButton
+                class="w-full sm:w-auto border-primary/70 font-mono text-[11px] tracking-[0.18em] opacity-60"
+                isSelected={true}
+                disabled={true}
+              >
+                <CircleNotch weight="regular" class="h-4 w-4 animate-spin" />
+                Importing…
+              </PrimaryButton>
+            {:else if phase === "done"}
+              <PrimaryButton
+                class="w-full sm:w-auto border-primary/70 font-mono text-[11px] tracking-[0.18em]"
+                isSelected={true}
+                onclick={handleClose}
+              >
+                Done
+              </PrimaryButton>
+            {/if}
+          </div>
+        </AlertDialog.Content>
+      </div>
+    </div>
+  </AlertDialog.Portal>
+</AlertDialog.Root>

--- a/ui/apps/pixano/src/lib/api/datasets.ts
+++ b/ui/apps/pixano/src/lib/api/datasets.ts
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import { toDataset, toDatasetInfo } from "./adapters";
-import { apiFetch, requestJson, JSON_HEADERS } from "./apiClient";
+import { apiFetch, JSON_HEADERS, requestJson } from "./apiClient";
 import type { DatasetInfoResponse, DatasetResponse } from "./restTypes";
 import type { Dataset, DatasetInfo } from "$lib/types/dataset";
 
@@ -31,11 +31,19 @@ export async function startDatasetImport(
   importType: string,
   datasetName: string,
 ): Promise<ImportJobStatus> {
-  return requestJson<ImportJobStatus>("/datasets/import", {
-    method: "POST",
-    headers: JSON_HEADERS,
-    body: JSON.stringify({ source_dir: sourceDir, import_type: importType, dataset_name: datasetName }),
-  }, "startDatasetImport");
+  return requestJson<ImportJobStatus>(
+    "/datasets/import",
+    {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        source_dir: sourceDir,
+        import_type: importType,
+        dataset_name: datasetName,
+      }),
+    },
+    "startDatasetImport",
+  );
 }
 
 export async function getImportJob(jobId: string): Promise<ImportJobStatus> {

--- a/ui/apps/pixano/src/lib/api/datasets.ts
+++ b/ui/apps/pixano/src/lib/api/datasets.ts
@@ -5,9 +5,16 @@ License: CECILL-C
 -------------------------------------*/
 
 import { toDataset, toDatasetInfo } from "./adapters";
-import { apiFetch, requestJson } from "./apiClient";
+import { apiFetch, requestJson, JSON_HEADERS } from "./apiClient";
 import type { DatasetInfoResponse, DatasetResponse } from "./restTypes";
 import type { Dataset, DatasetInfo } from "$lib/types/dataset";
+
+export interface ImportJobStatus {
+  job_id: string;
+  status: "pending" | "running" | "done" | "error";
+  message: string;
+  dataset_id: string;
+}
 
 export async function listDatasets(): Promise<DatasetInfo[]> {
   const datasets = await apiFetch<DatasetInfoResponse[]>("/datasets", {}, [], "listDatasets");
@@ -17,6 +24,22 @@ export async function listDatasets(): Promise<DatasetInfo[]> {
 export async function getDataset(datasetId: string): Promise<Dataset> {
   const dataset = await requestJson<DatasetResponse>(`/datasets/${datasetId}`, {}, "getDataset");
   return toDataset(dataset);
+}
+
+export async function startDatasetImport(
+  sourceDir: string,
+  importType: string,
+  datasetName: string,
+): Promise<ImportJobStatus> {
+  return requestJson<ImportJobStatus>("/datasets/import", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ source_dir: sourceDir, import_type: importType, dataset_name: datasetName }),
+  }, "startDatasetImport");
+}
+
+export async function getImportJob(jobId: string): Promise<ImportJobStatus> {
+  return requestJson<ImportJobStatus>(`/datasets/import/${jobId}`, {}, "getImportJob");
 }
 
 export async function getDatasetStats(

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -121,7 +121,9 @@ License: CECILL-C
                 class="flex items-center gap-2.5 px-3 py-2 cursor-pointer rounded-lg mx-1
                   text-foreground hover:bg-accent focus-visible:bg-accent
                   focus-visible:outline-none transition-colors"
-                onSelect={() => { showImportModal = true; }}
+                onSelect={() => {
+                  showImportModal = true;
+                }}
               >
                 <FolderOpen weight="regular" class="h-4 w-4 text-muted-foreground" />
                 Import dataset…
@@ -142,6 +144,10 @@ License: CECILL-C
   </div>
 
   {#if showImportModal}
-    <ImportDatasetModal onClose={() => { showImportModal = false; }} />
+    <ImportDatasetModal
+      onClose={() => {
+        showImportModal = false;
+      }}
+    />
   {/if}
 </Tooltip.Provider>

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -5,11 +5,13 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Tooltip } from "bits-ui";
+  import { DropdownMenu, Tooltip } from "bits-ui";
+  import { CaretDown, FolderOpen } from "phosphor-svelte";
   import { fade } from "svelte/transition";
 
   import pixanoFavicon from "../assets/favicon.ico";
   import DatasetHeader from "../components/layout/DatasetHeader.svelte";
+  import ImportDatasetModal from "../components/library/ImportDatasetModal.svelte";
   import type { LayoutProps } from "./$types";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
@@ -60,6 +62,8 @@ License: CECILL-C
     return () => window.removeEventListener("error", handleEffectDepthExceeded);
   });
 
+  let showImportModal = $state(false);
+
   async function navigateToHome() {
     await goto("/");
   }
@@ -94,7 +98,38 @@ License: CECILL-C
         {/if}
       </div>
 
-      <div class="flex items-center shrink-0">
+      <div class="flex items-center gap-2 shrink-0">
+        <!-- File menu -->
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger
+            class="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg border border-border/60
+              bg-background/60 text-sm font-semibold text-foreground hover:bg-accent
+              hover:border-border transition-all duration-150 focus-visible:outline-none
+              focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            File
+            <CaretDown weight="bold" class="h-3 w-3 text-muted-foreground" />
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              class="z-[300] min-w-[200px] rounded-xl border border-border bg-background/95
+                backdrop-blur-sm shadow-lg py-1.5 text-sm"
+              sideOffset={6}
+              align="end"
+            >
+              <DropdownMenu.Item
+                class="flex items-center gap-2.5 px-3 py-2 cursor-pointer rounded-lg mx-1
+                  text-foreground hover:bg-accent focus-visible:bg-accent
+                  focus-visible:outline-none transition-colors"
+                onSelect={() => { showImportModal = true; }}
+              >
+                <FolderOpen weight="regular" class="h-4 w-4 text-muted-foreground" />
+                Import dataset…
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+
         <ThemeToggle mode={themeMode.value} onToggle={toggleTheme} />
       </div>
     </header>
@@ -105,4 +140,8 @@ License: CECILL-C
       </div>
     </main>
   </div>
+
+  {#if showImportModal}
+    <ImportDatasetModal onClose={() => { showImportModal = false; }} />
+  {/if}
 </Tooltip.Provider>


### PR DESCRIPTION
## Issue
Users complain that unlabeled data importation takes too many steps and require writing scripts

Fixes #

## Description


  Adds a frictionless dataset importer directly from the Pixano UI, so users can import local folders of images or videos without writing any Python scripts.

  Backend (src/pixano/api/routers/import_datasets.py)
  - New POST /datasets/import endpoint that starts an asynchronous import job and returns a job_id
  - New GET /datasets/import/{job_id} endpoint for polling job status
  - Two import pipelines:
    - Unlabeled images — symlinks the source folder into a temp directory and runs ImageFolderBuilder
    - Unlabeled videos — extracts frames with OpenCV into a temp directory (matching the val/frames/<name>/*.jpg layout expected by VideoFolderBuilder), writes a metadata.jsonl, then runs VideoFolderBuilder
  - Imported datasets include category and sub_category fields on entities, and a CompressedRLE mask table

  Frontend
  - +layout.svelte: adds a File dropdown menu in the header with an Import dataset… item
  - ImportDatasetModal.svelte: 4-phase modal (form → running → done/error) with import type selector (images or videos), source folder path input, and optional dataset name; polls the backend job every 2 s and
  refreshes the dataset list on success
  - DatasetsLibrary.svelte: adds an Import dataset call-to-action button on the empty-library screen
  - datasets.ts: adds startDatasetImport and getImportJob API helpers

