### PR TITLE
Toggle frontend toggle between classic and new UI, add dark/light theme toggle and some fixes

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -19,7 +19,8 @@ class CustomBuildHook(BuildHookInterface):
             return
 
         ui_dir = os.path.join(self.root, "ui")
-        app_dir = os.path.join(ui_dir, "apps", "pixano")
+        classic_app_dir = os.path.join(ui_dir, "apps", "pixano")
+        web_app_dir = os.path.join(ui_dir, "apps", "web")
 
         if not os.path.isdir(ui_dir):
             return
@@ -31,9 +32,16 @@ class CustomBuildHook(BuildHookInterface):
             check=True,
         )
 
-        self.app.display_info("Building frontend...")
+        self.app.display_info("Building classic frontend...")
         subprocess.run(
             ["pnpm", "build"],
-            cwd=app_dir,
+            cwd=classic_app_dir,
+            check=True,
+        )
+
+        self.app.display_info("Building web frontend...")
+        subprocess.run(
+            ["pnpm", "build"],
+            cwd=web_app_dir,
             check=True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-artifacts = ["src/pixano/api/dist"]
+artifacts = ["src/pixano/api/dist", "src/pixano/api/classic_dist"]
 
 [tool.hatch.build.hooks.custom]
 

--- a/src/pixano/api/serve.py
+++ b/src/pixano/api/serve.py
@@ -37,9 +37,12 @@ LOGO = """
 """
 ASSETS_PATH = str(files("pixano").joinpath("api/dist/_app"))
 TEMPLATE_PATH = str(files("pixano").joinpath("api/dist"))
+CLASSIC_ASSETS_PATH = str(files("pixano").joinpath("api/classic_dist/_classic_app"))
+CLASSIC_TEMPLATE_PATH = str(files("pixano").joinpath("api/classic_dist"))
 NON_SPA_PREFIXES = (
     *API_PREFIXES,
     "/_app",
+    "/_classic_app",
     "/app_models",
     "/health",
     "/docs",
@@ -141,11 +144,15 @@ class App:
         # Create app
         settings = get_settings_override()
         templates = Jinja2Templates(directory=TEMPLATE_PATH)
+        classic_templates = Jinja2Templates(directory=CLASSIC_TEMPLATE_PATH)
         self.app = create_app(settings=settings)
         self.app.dependency_overrides[get_settings] = get_settings_override
 
         @self.app.get("/", response_class=HTMLResponse)
         def main_page(request: fastapi.Request):
+            # TODO: if classic_dist is not built and cookie is "classic", clear cookie and serve new app to avoid 500
+            if request.cookies.get("pixano_ui_version") == "classic":
+                return classic_templates.TemplateResponse(request, "index.html")
             return templates.TemplateResponse(request, "index.html")
 
         def _is_non_spa_path(path: str) -> bool:
@@ -158,6 +165,14 @@ class App:
             warnings.warn(
                 "Pixano app assets not found. If it is a production environment, this is not expected, "
                 "check if you have built the assets for the UI."
+            )
+
+        try:
+            self.app.mount("/_classic_app", StaticFiles(directory=CLASSIC_ASSETS_PATH), name="classic_assets")
+        except RuntimeError:
+            warnings.warn(
+                "Classic app assets not found. If it is a production environment, this is not expected, "
+                "check if you have built the assets for the classic UI."
             )
 
         @self.app.get("/{full_path:path}", include_in_schema=False)

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -15,6 +15,8 @@ License: CECILL-C
   import { page } from "$app/state";
   import { pixanoLogo } from "$lib/assets";
   import { datasetsStore, themeMode, toggleTheme } from "$lib/stores/appStores.svelte";
+  import { ArrowsLeftRight } from "phosphor-svelte";
+
   import { getEffectProbeSnapshot, IconButton, ThemeToggle } from "$lib/ui";
 
   import "./styles.css";
@@ -94,7 +96,18 @@ License: CECILL-C
         {/if}
       </div>
 
-      <div class="flex items-center shrink-0">
+      <div class="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onclick={() => {
+            document.cookie = "pixano_ui_version=next; max-age=31536000; path=/";
+            window.location.href = "/";
+          }}
+          class="inline-flex items-center justify-center rounded-lg p-1.5 text-foreground/60 transition-colors hover:bg-primary/5 hover:text-foreground"
+          title="Switch to new UI"
+        >
+          <ArrowsLeftRight size={20} />
+        </button>
         <ThemeToggle mode={themeMode.value} onToggle={toggleTheme} />
       </div>
     </header>

--- a/ui/apps/pixano/svelte.config.js
+++ b/ui/apps/pixano/svelte.config.js
@@ -7,10 +7,11 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({
-      pages: "build",
-      assets: "build",
+      pages: "../../../src/pixano/api/classic_dist",
+      assets: "../../../src/pixano/api/classic_dist",
       fallback: "index.html",
     }),
+    appDir: "_classic_app",
     alias: pixanoAliases,
   },
 };

--- a/ui/apps/web/src/app.html
+++ b/ui/apps/web/src/app.html
@@ -1,9 +1,24 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      /* Theme key: keep in sync with STORAGE_KEY in src/lib/stores/theme.svelte.ts */
+      (function () {
+        var stored = null;
+        try {
+          stored = localStorage.getItem("pixano-theme");
+        } catch (_) {
+          /* localStorage blocked (e.g. Tor Browser, dom.storage.enabled=false) */
+        }
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (stored === "dark" || ((stored === null || stored === "") && prefersDark)) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/ui/apps/web/src/lib/components/shell/Toolbar.svelte
+++ b/ui/apps/web/src/lib/components/shell/Toolbar.svelte
@@ -5,9 +5,10 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Lock, PanelRight, Unlock } from "lucide-svelte";
+  import { Lock, Moon, PanelRight, Sun, Unlock } from "lucide-svelte";
 
   import type { PanelState } from "$lib/components/ui/resizable-panel/PanelState.svelte.js";
+  import { themeStore } from "$lib/stores/theme.svelte.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
   import pixanoLogo from "$lib/assets/pixano.png";
   interface Props {
@@ -16,6 +17,8 @@ License: CECILL-C
   }
 
   let { manager, rightPanel }: Props = $props();
+
+  const isDark = $derived(themeStore.mode === "dark");
 
   function toggleEditMode() {
     manager.editMode = !manager.editMode;
@@ -48,6 +51,18 @@ License: CECILL-C
       {:else}
         <Lock class="h-3.5 w-3.5" />
         <span>Locked</span>
+      {/if}
+    </button>
+
+    <button
+      onclick={() => themeStore.toggle()}
+      class="flex items-center justify-center rounded-md border border-border p-1 text-xs text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {#if isDark}
+        <Sun class="h-3.5 w-3.5" />
+      {:else}
+        <Moon class="h-3.5 w-3.5" />
       {/if}
     </button>
 

--- a/ui/apps/web/src/lib/components/shell/Toolbar.svelte
+++ b/ui/apps/web/src/lib/components/shell/Toolbar.svelte
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Lock, Moon, PanelRight, Sun, Unlock } from "lucide-svelte";
+  import { Lock, Moon, PanelRight, Sun, Unlock, ArrowLeftRight } from "lucide-svelte";
 
   import type { PanelState } from "$lib/components/ui/resizable-panel/PanelState.svelte.js";
   import { themeStore } from "$lib/stores/theme.svelte.js";
@@ -52,6 +52,18 @@ License: CECILL-C
         <Lock class="h-3.5 w-3.5" />
         <span>Locked</span>
       {/if}
+    </button>
+
+    <button
+      type="button"
+      onclick={() => {
+        document.cookie = "pixano_ui_version=classic; max-age=31536000; path=/";
+        window.location.href = "/";
+      }}
+      class="flex items-center justify-center rounded-md border border-border p-1 text-xs text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
+      title="Switch to classic UI"
+    >
+      <ArrowLeftRight class="h-3.5 w-3.5" />
     </button>
 
     <button

--- a/ui/apps/web/src/lib/stores/theme.svelte.ts
+++ b/ui/apps/web/src/lib/stores/theme.svelte.ts
@@ -1,0 +1,42 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+const VALID_MODES = ["light", "dark"] as const;
+export type ThemeMode = (typeof VALID_MODES)[number];
+
+// NOTE: This key is also used as a literal string in app.html.
+// If you rename it here, update app.html too.
+export const STORAGE_KEY = "pixano-theme";
+
+function isValidThemeMode(value: string | null): value is ThemeMode {
+  return (VALID_MODES as readonly string[]).includes(value as string);
+}
+
+function getSystemTheme(): ThemeMode {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+class ThemeStore {
+  mode = $state<ThemeMode>("dark");
+
+  constructor() {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        this.mode = isValidThemeMode(stored) ? stored : getSystemTheme();
+      } catch (_) {
+        // localStorage blocked — fall back to system preference
+        this.mode = getSystemTheme();
+      }
+    }
+  }
+
+  toggle() {
+    this.mode = this.mode === "dark" ? "light" : "dark";
+  }
+}
+
+export const themeStore = new ThemeStore();

--- a/ui/apps/web/src/routes/+layout.svelte
+++ b/ui/apps/web/src/routes/+layout.svelte
@@ -9,7 +9,18 @@ License: CECILL-C
 
   import type { Snippet } from "svelte";
 
+  import { STORAGE_KEY, themeStore } from "$lib/stores/theme.svelte";
+
   let { children }: { children: Snippet } = $props();
+
+  $effect(() => {
+    document.documentElement.classList.toggle("dark", themeStore.mode === "dark");
+    try {
+      localStorage.setItem(STORAGE_KEY, themeStore.mode);
+    } catch (_) {
+      // localStorage blocked — theme works in-session but won't persist
+    }
+  });
 </script>
 
 {@render children()}


### PR DESCRIPTION
  Serve both the classic (pixano app) and new (web app) frontends at /,
  selected by a pixano_ui_version cookie (1-year persistence).

  - Classic app uses appDir='_classic_app' to avoid /_app asset conflict
  - Backend reads cookie to choose which index.html to serve at /
  - Toggle buttons in each frontend set the cookie and reload
  - hatch_build.py now builds both frontends; classic_dist added to artifacts

Add dark/light theme toggle
Add a persistent theme toggle button to the toolbar. The chosen theme is
saved in localStorage and restored on next visit. When no preference has
been saved, the app follows the OS color scheme preference.

The implementation is hardened against restricted environments (private
browsing, Tor Browser) where storage access may be blocked: the page
always renders correctly and the toggle still works in-session even if
the preference cannot be persisted.