### PR TITLE
DO NOT MERGE ---  Feature/entities tab calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 # Modules
 node_modules
 dist
+classic_dist
 dist-ssr
 *.local
 .vite

--- a/src/pixano/api/models.py
+++ b/src/pixano/api/models.py
@@ -182,6 +182,21 @@ class ImageResponse(ResponseModel):
     src: str
 
 
+class CalibratedImageResponse(ImageResponse):
+    """Response model for a calibrated image view row.
+
+    Extends ``ImageResponse`` with optional camera intrinsics, extrinsics and
+    ego-to-world pose.  Fields are ``None`` when the underlying row comes from
+    the plain ``images`` table so that callers always receive this type.
+    """
+
+    f: tuple[float, float] | None = None
+    c: tuple[float, float] | None = None
+    distortion: list[float] | None = None
+    extrinsic_matrix: list[float] | None = None
+    ego_to_world: list[float] | None = None
+
+
 class TextResponse(ResponseModel):
     """Response model for a text view row."""
 
@@ -446,6 +461,7 @@ __all__ = [
     "MessageResponse",
     "MessageUpdate",
     "PaginatedResponse",
+    "CalibratedImageResponse",
     "ImageResponse",
     "PointCloudResponse",
     "SFrameResponse",

--- a/src/pixano/api/routers/views.py
+++ b/src/pixano/api/routers/views.py
@@ -14,7 +14,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
 from pixano.api.media import MULTIPART_BOUNDARY, iter_multipart_frames, media_type_from_format
-from pixano.api.models import ImageResponse, PaginatedResponse, PointCloudResponse, SFrameResponse, TextResponse
+from pixano.api.models import (
+    CalibratedImageResponse,
+    ImageResponse,
+    PaginatedResponse,
+    PointCloudResponse,
+    SFrameResponse,
+    TextResponse,
+)
 from pixano.api.routers._deps import PaginationParams, get_dataset_dep
 from pixano.datasets import Dataset
 from pixano.datasets.utils import DatasetPaginationError
@@ -158,6 +165,20 @@ def _to_image_response(dataset_id: str, row: Any) -> ImageResponse:
     )
 
 
+def _to_calibrated_image_response(dataset_id: str, row: Any) -> CalibratedImageResponse:
+    base = _to_image_response(dataset_id, row)
+    raw_extrinsic = getattr(row, "extrinsic_matrix", None)
+    raw_ego = getattr(row, "ego_to_world", None)
+    return CalibratedImageResponse(
+        **base.model_dump(),
+        f=getattr(row, "f", None),
+        c=getattr(row, "c", None),
+        distortion=getattr(row, "distortion", None),
+        extrinsic_matrix=list(raw_extrinsic) if raw_extrinsic is not None else None,
+        ego_to_world=list(raw_ego) if raw_ego is not None else None,
+    )
+
+
 def _to_text_response(row: Any) -> TextResponse:
     return TextResponse(
         id=row.id,
@@ -194,17 +215,23 @@ def _list_image_responses(
     record_id: str | None = None,
     view_name: str | None = None,
     where: str | None = None,
-) -> PaginatedResponse[ImageResponse]:
+) -> PaginatedResponse[CalibratedImageResponse]:
+    table_name = _resolve_image_table(dataset)
     rows, total = _list_rows(
         dataset,
-        _resolve_image_table(dataset),
+        table_name,
         pagination=pagination,
         record_id=record_id,
         view_name=view_name,
         where=where,
     )
+    convert = (
+        _to_calibrated_image_response
+        if table_name == CALIBRATED_IMAGE_TABLE
+        else lambda ds, row: CalibratedImageResponse(**_to_image_response(ds, row).model_dump())
+    )
     return PaginatedResponse(
-        items=[_to_image_response(dataset_id, row) for row in rows],
+        items=[convert(dataset_id, row) for row in rows],
         total=total,
         limit=pagination.limit,
         offset=pagination.offset,
@@ -296,7 +323,7 @@ def _list_point_cloud_responses(
     )
 
 
-@router.get("/images", response_model=PaginatedResponse[ImageResponse], operation_id="list_images")
+@router.get("/images", response_model=PaginatedResponse[CalibratedImageResponse], operation_id="list_images")
 def list_images(
     dataset_id: str,
     dataset: Dataset = Depends(get_dataset_dep),
@@ -304,7 +331,7 @@ def list_images(
     record_id: str | None = None,
     view_name: str | None = None,
     where: str | None = None,
-) -> PaginatedResponse[ImageResponse]:
+) -> PaginatedResponse[CalibratedImageResponse]:
     """List image views with optional filtering."""
     return _list_image_responses(
         dataset_id,
@@ -316,10 +343,14 @@ def list_images(
     )
 
 
-@router.get("/images/{id}", response_model=ImageResponse, operation_id="get_image")
-def get_image(id: str, dataset_id: str, dataset: Dataset = Depends(get_dataset_dep)) -> ImageResponse:
+@router.get("/images/{id}", response_model=CalibratedImageResponse, operation_id="get_image")
+def get_image(id: str, dataset_id: str, dataset: Dataset = Depends(get_dataset_dep)) -> CalibratedImageResponse:
     """Fetch a single image view by ID."""
-    return _to_image_response(dataset_id, _get_row(dataset, _resolve_image_table(dataset), id))
+    table_name = _resolve_image_table(dataset)
+    row = _get_row(dataset, table_name, id)
+    if table_name == CALIBRATED_IMAGE_TABLE:
+        return _to_calibrated_image_response(dataset_id, row)
+    return CalibratedImageResponse(**_to_image_response(dataset_id, row).model_dump())
 
 
 @router.get("/images/{id}/blob", operation_id="get_image_blob")
@@ -398,7 +429,7 @@ def get_sframe_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> 
 
 @router.get(
     "/records/{record_id}/images",
-    response_model=PaginatedResponse[ImageResponse],
+    response_model=PaginatedResponse[CalibratedImageResponse],
     operation_id="list_record_images",
 )
 def list_record_images(
@@ -408,7 +439,7 @@ def list_record_images(
     pagination: PaginationParams = Depends(),
     view_name: str | None = None,
     where: str | None = None,
-) -> PaginatedResponse[ImageResponse]:
+) -> PaginatedResponse[CalibratedImageResponse]:
     """List images belonging to a specific record."""
     return _list_image_responses(
         dataset_id,

--- a/ui/apps/web/src/lib/annotations/types.ts
+++ b/ui/apps/web/src/lib/annotations/types.ts
@@ -57,6 +57,18 @@ export function pickEntityLabel(entity: Record<string, unknown> | undefined): st
 }
 
 /**
+ * Camera intrinsics and extrinsics from a CalibratedImage view.
+ * All matrices are row-major, 4×4 flattened to 16 floats.
+ */
+export interface CameraCalibration {
+  f: [number, number];
+  c: [number, number];
+  distortion: number[];
+  extrinsicMatrix: number[];
+  egoToWorld: number[];
+}
+
+/**
  * Options attached to every image widget instance. `WorkspaceManager.selectRecordInDataset`
  * populates these so the widget can build valid BBox payloads without
  * having to reach back into global state.
@@ -68,6 +80,7 @@ export interface ImageWidgetOptions {
   viewName: string;
   imageWidth: number;
   imageHeight: number;
+  calibration: CameraCalibration | null;
   [key: string]: unknown;
 }
 

--- a/ui/apps/web/src/lib/api/restTypes.ts
+++ b/ui/apps/web/src/lib/api/restTypes.ts
@@ -89,6 +89,16 @@ export interface ImageResponse {
   src: string;
 }
 
+export interface CalibratedImageResponse extends ImageResponse {
+  f: [number, number] | null;
+  c: [number, number] | null;
+  distortion: number[] | null;
+  /** 4×4 camera-to-world matrix flattened to 16 floats (row-major). */
+  extrinsic_matrix: number[] | null;
+  /** 4×4 ego-to-world matrix flattened to 16 floats (row-major). */
+  ego_to_world: number[] | null;
+}
+
 export interface TextResponse {
   id: string;
   record_id: string;

--- a/ui/apps/web/src/lib/api/workspace.ts
+++ b/ui/apps/web/src/lib/api/workspace.ts
@@ -13,7 +13,7 @@ export async function loadImage(
   imageId: string,
 ): Promise<ImageResponse> {
   return await requestJson<ImageResponse>(
-    `/datasets/${datasetId}/records/${recordId}/images/${imageId}`,
+    `/datasets/${datasetId}/images/${imageId}`,
     {},
     "getImage",
   );

--- a/ui/apps/web/src/lib/api/workspace.ts
+++ b/ui/apps/web/src/lib/api/workspace.ts
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import { requestJson } from "./apiClient";
-import type { ImageResponse, PaginatedResponse, PointCloudResponse } from "./restTypes";
+import type { CalibratedImageResponse, ImageResponse, PaginatedResponse, PointCloudResponse } from "./restTypes";
 
 export async function loadImage(
   datasetId: string,
@@ -32,8 +32,8 @@ export async function loadImageByLogicalName(
   datasetId: string,
   recordId: string,
   logicalName: string,
-): Promise<ImageResponse | null> {
-  const res = await requestJson<PaginatedResponse<ImageResponse>>(
+): Promise<CalibratedImageResponse | null> {
+  const res = await requestJson<PaginatedResponse<CalibratedImageResponse>>(
     `/datasets/${datasetId}/records/${recordId}/images?view_name=${encodeURIComponent(logicalName)}`,
     {},
     "loadImageByLogicalName",

--- a/ui/apps/web/src/lib/components/grid/GridWorkspace.svelte
+++ b/ui/apps/web/src/lib/components/grid/GridWorkspace.svelte
@@ -71,7 +71,7 @@ License: CECILL-C
 
     const element = grid.getGridItems().find((i) => i.dataset.widgetId === widgetId);
     if (element) {
-      grid.removeWidget(element, false);
+      grid.removeWidget(element, true);
     }
   }
 
@@ -151,22 +151,23 @@ License: CECILL-C
     }
   });
 
-  // React to widget additions/removals from manager
+  // React to widget additions/removals/visibility changes from manager
   $effect(() => {
     if (!grid) return;
 
     const currentIds = new Set(mountedWidgets.keys());
-    const managerIds = new Set(manager.widgets.map((w) => w.id));
+    const visibleWidgets = manager.widgets.filter((w) => !w.hidden);
+    const visibleIds = new Set(visibleWidgets.map((w) => w.id));
 
-    // Remove widgets no longer in manager
+    // Remove widgets no longer in manager or now hidden
     for (const id of currentIds) {
-      if (!managerIds.has(id)) {
+      if (!visibleIds.has(id)) {
         unmountWidget(id);
       }
     }
 
-    // Add new widgets from manager
-    for (const widget of manager.widgets) {
+    // Add new visible widgets from manager
+    for (const widget of visibleWidgets) {
       if (!currentIds.has(widget.id)) {
         mountWidget(widget);
       }

--- a/ui/apps/web/src/lib/components/shell/EntitiesPanel.svelte
+++ b/ui/apps/web/src/lib/components/shell/EntitiesPanel.svelte
@@ -1,0 +1,52 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import type { EntityRow } from "$lib/api/annotations.js";
+
+  interface Props {
+    entities: EntityRow[];
+    entitySchemaName: string | null;
+  }
+
+  let { entities, entitySchemaName }: Props = $props();
+
+  function resolveCategory(entity: EntityRow): string {
+    for (const key of ["category", "label", "class", "name"]) {
+      const value = entity[key];
+      if (typeof value === "string" && value.length > 0) return value;
+    }
+    return entitySchemaName ?? "Entity";
+  }
+
+  function shortenId(id: string): string {
+    return id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-6)}` : id;
+  }
+</script>
+
+<div class="p-3">
+  {#if entities.length === 0}
+    <p class="text-xs text-muted-foreground">No entities in this record.</p>
+  {:else}
+    <p class="mb-2 text-xs text-muted-foreground">{entities.length} entit{entities.length === 1 ? "y" : "ies"}</p>
+    <div class="space-y-1.5">
+      {#each entities as entity (entity.id)}
+        <div class="rounded-md border border-border bg-card px-2.5 py-2">
+          <div class="flex items-center gap-2">
+            <span
+              class="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary"
+            >
+              {resolveCategory(entity)}
+            </span>
+            <span class="min-w-0 truncate font-mono text-[10px] text-muted-foreground">
+              {shortenId(entity.id)}
+            </span>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/ui/apps/web/src/lib/components/shell/RightPanel.svelte
+++ b/ui/apps/web/src/lib/components/shell/RightPanel.svelte
@@ -5,8 +5,9 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { MessageSquare, ScanSearch } from "lucide-svelte";
+  import { Eye, EyeOff, Layers, MessageSquare, ScanSearch } from "lucide-svelte";
 
+  import EntitiesPanel from "./EntitiesPanel.svelte";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
   interface Props {
@@ -15,10 +16,11 @@ License: CECILL-C
 
   let { manager }: Props = $props();
 
-  let activeTab = $state<"inspector" | "agent">("inspector");
+  let activeTab = $state<"inspector" | "entities" | "agent">("inspector");
 
   const tabs = [
     { id: "inspector" as const, label: "Inspector", icon: ScanSearch },
+    { id: "entities" as const, label: "Entities", icon: Layers },
     { id: "agent" as const, label: "Agent", icon: MessageSquare },
   ];
 </script>
@@ -43,7 +45,15 @@ License: CECILL-C
 
   <!-- Tab content -->
   <div class="flex-1 overflow-y-auto">
-    {#if activeTab === "inspector"}
+    {#if activeTab === "entities"}
+      {#if manager.recordId !== null}
+        <EntitiesPanel entities={manager.entities} entitySchemaName={manager.entitySchemaName} />
+      {:else}
+        <div class="p-3">
+          <p class="text-xs text-muted-foreground">Open a record to inspect its entities.</p>
+        </div>
+      {/if}
+    {:else if activeTab === "inspector"}
       <div class="p-3">
         <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Properties
@@ -52,18 +62,33 @@ License: CECILL-C
         {#if manager.widgetCount > 0}
           <div class="space-y-2">
             {#each manager.widgets as widget (widget.id)}
-              <div class="rounded-md border border-border bg-card p-2">
-                <div class="flex items-center justify-between">
-                  <span class="text-xs font-medium text-card-foreground">{widget.title}</span>
-                  <span class="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              <div
+                class="rounded-md border border-border bg-card p-2 transition-opacity {widget.hidden
+                  ? 'opacity-50'
+                  : ''}"
+              >
+                <div class="flex items-center gap-2">
+                  <button
+                    onclick={() => manager.toggleWidgetVisibility(widget.id)}
+                    title={widget.hidden ? "Show widget" : "Hide widget"}
+                    class="shrink-0 text-muted-foreground hover:text-foreground"
+                  >
+                    {#if widget.hidden}
+                      <EyeOff class="h-3.5 w-3.5" />
+                    {:else}
+                      <Eye class="h-3.5 w-3.5" />
+                    {/if}
+                  </button>
+                  <span
+                    class="flex-1 truncate text-xs font-medium {widget.hidden
+                      ? 'text-muted-foreground line-through'
+                      : 'text-card-foreground'}"
+                  >
+                    {widget.title}
+                  </span>
+                  <span class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                     {widget.extensionName}
                   </span>
-                </div>
-                <div class="mt-1.5 grid grid-cols-2 gap-1 text-[10px] text-muted-foreground">
-                  <span>x: {widget.layout.x}</span>
-                  <span>y: {widget.layout.y}</span>
-                  <span>w: {widget.layout.w}</span>
-                  <span>h: {widget.layout.h}</span>
                 </div>
               </div>
             {/each}

--- a/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
@@ -72,10 +72,7 @@ export const ImageExtension = WidgetExtension.create<ImageWidgetOptions, ImageWi
     const allBBoxes = image
       ? await gateway
           .listBBoxes(datasetId, { recordId })
-          .catch((err) => {
-            console.error("listBBoxes failed", err);
-            return [] as BBoxRow[];
-          })
+          .catch(() => [] as BBoxRow[])
       : [];
 
     const existingBBoxes = allBBoxes.filter(

--- a/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
@@ -5,22 +5,36 @@ License: CECILL-C
 -------------------------------------*/
 
 import type {
+  CameraCalibration,
   CoordsNorm,
   ImageWidgetOptions,
   ImageWidgetStorage,
   LocalBBox,
 } from "$lib/annotations/types.js";
 import type { BBoxRow } from "$lib/api/annotations.js";
+import type { CalibratedImageResponse } from "$lib/api/restTypes.js";
 import ImageWidget from "$lib/components/widgets/ImageWidget.svelte";
 
 import { WidgetExtension } from "../WidgetExtension.js";
 
 /**
  * Bases this extension claims. `CalibratedImage` extends `Image` on the
- * backend (extra calibration fields the UI ignores for now), so it goes
- * through the same widget and endpoint.
+ * backend and now surfaces calibration data via `options.calibration`.
  */
 const CLAIMED_BASES = new Set(["Image", "CalibratedImage"]);
+
+function _extractCalibration(image: CalibratedImageResponse | null): CameraCalibration | null {
+  if (!image?.extrinsic_matrix || !image.ego_to_world || !image.f || !image.c || !image.distortion) {
+    return null;
+  }
+  return {
+    f: image.f,
+    c: image.c,
+    distortion: image.distortion,
+    extrinsicMatrix: image.extrinsic_matrix,
+    egoToWorld: image.ego_to_world,
+  };
+}
 
 export const ImageExtension = WidgetExtension.create<ImageWidgetOptions, ImageWidgetStorage>({
   name: "image",
@@ -36,6 +50,7 @@ export const ImageExtension = WidgetExtension.create<ImageWidgetOptions, ImageWi
     viewName: "",
     imageWidth: 0,
     imageHeight: 0,
+    calibration: null,
   }),
   addStorage: () => ({
     mode: "select",
@@ -101,6 +116,7 @@ export const ImageExtension = WidgetExtension.create<ImageWidgetOptions, ImageWi
         viewName,
         imageWidth: image?.width ?? 0,
         imageHeight: image?.height ?? 0,
+        calibration: _extractCalibration(image),
       },
       data: { imageUrl: image?.src },
       storage: { bboxes: seedBBoxes },

--- a/ui/apps/web/src/lib/extensions/builtin/__tests__/ImageExtension.test.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/__tests__/ImageExtension.test.ts
@@ -7,7 +7,7 @@ License: CECILL-C
 import { describe, expect, it, vi } from "vitest";
 
 import type { BBoxRow } from "$lib/api/annotations.js";
-import type { ImageResponse } from "$lib/api/restTypes.js";
+import type { CalibratedImageResponse } from "$lib/api/restTypes.js";
 import type { DatasetGateway } from "$lib/workspace/datasetGateway.js";
 
 // ImageExtension references ImageWidget.svelte which imports Konva (requires native canvas).
@@ -18,14 +18,20 @@ import { ImageExtension } from "../ImageExtension.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-const IMAGE: ImageResponse = {
+const IMAGE: CalibratedImageResponse = {
   id: "CAM_FRONT_0_0",
+  record_id: "rec_0",
   src: "/cam.jpg",
   width: 1600,
   height: 900,
-} as ImageResponse;
+  f: null,
+  c: null,
+  distortion: null,
+  extrinsic_matrix: null,
+  ego_to_world: null,
+};
 
-function makeGateway(image: ImageResponse | null, bboxes: BBoxRow[]): DatasetGateway {
+function makeGateway(image: CalibratedImageResponse | null, bboxes: BBoxRow[]): DatasetGateway {
   return {
     getDataset: () => Promise.resolve(null as never),
     listEntities: () => Promise.resolve([]),

--- a/ui/apps/web/src/lib/extensions/types.ts
+++ b/ui/apps/web/src/lib/extensions/types.ts
@@ -113,6 +113,7 @@ export interface WidgetInstance {
   layout: WidgetLayout;
   options: Record<string, unknown>;
   data?: Record<string, unknown>;
+  hidden?: boolean;
 }
 
 /** A workspace preset (named layout configuration) */

--- a/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
@@ -7,7 +7,7 @@ License: CECILL-C
 import { describe, expect, it, vi } from "vitest";
 
 import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
-import type { ImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
+import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
 import { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 import type { WidgetComponentProps, WidgetExtensionConfig } from "$lib/extensions/types.js";
 import { DatasetInfo } from "$lib/types/dataset";
@@ -49,7 +49,7 @@ function makeDataset(views: Record<string, { base: string }>): Dataset {
 function makeGateway(opts: {
   dataset?: Dataset;
   entities?: EntityRow[];
-  images?: Map<string, ImageResponse>;
+  images?: Map<string, CalibratedImageResponse>;
   pointClouds?: Map<string, PointCloudResponse>;
   bboxes?: BBoxRow[];
   bboxes3d?: BBox3DRow[];
@@ -118,7 +118,7 @@ describe("RecordLoader.load", () => {
     const loader = new RecordLoader({
       workspace: sink,
       registry: makeRegistry(makeImageExtension()),
-      gateway: makeGateway({ dataset, images: new Map([["cam", { id: "img-1", src: "/cam.jpg", width: 100, height: 100 } as ImageResponse]]) }),
+      gateway: makeGateway({ dataset, images: new Map([["cam", { id: "img-1", record_id: "rec-1", src: "/cam.jpg", width: 100, height: 100, f: null, c: null, distortion: null, extrinsic_matrix: null, ego_to_world: null } as CalibratedImageResponse]]) }),
       session,
     });
 
@@ -228,6 +228,73 @@ describe("RecordLoader.load", () => {
 
     expect(widgets).toHaveLength(1);
     expect(widgets[0].extensionName).toBe("high-image");
+  });
+
+  it("stores loaded entities in the session", async () => {
+    const entities: EntityRow[] = [
+      { id: "e1", record_id: "rec-1", category: "car" },
+      { id: "e2", record_id: "rec-1", category: "person" },
+    ];
+    const dataset = makeDataset({ cam: { base: "Image" } });
+    const { sink } = makeSink();
+    const session = new WorkspaceSession();
+    const loader = new RecordLoader({
+      workspace: sink,
+      registry: makeRegistry(makeImageExtension()),
+      gateway: makeGateway({ dataset, entities }),
+      session,
+    });
+
+    await loader.load("ds-1", "rec-1", VIEWPORT);
+
+    expect(session.entities).toHaveLength(2);
+    expect(session.entities[0].id).toBe("e1");
+    expect(session.entities[1].id).toBe("e2");
+  });
+
+  it("clears session entities at the start of a new load", async () => {
+    const dataset = makeDataset({ cam: { base: "Image" } });
+    const { sink } = makeSink();
+    const session = new WorkspaceSession();
+    session.entities = [{ id: "stale", record_id: "old-rec" }];
+
+    let resolveEntities!: (rows: EntityRow[]) => void;
+    const entitiesPromise = new Promise<EntityRow[]>((res) => { resolveEntities = res; });
+
+    const gateway = makeGateway({ dataset });
+    gateway.listEntities = () => entitiesPromise;
+    const loader = new RecordLoader({
+      workspace: sink,
+      registry: makeRegistry(makeImageExtension()),
+      gateway,
+      session,
+    });
+
+    const loadPromise = loader.load("ds-1", "rec-1", VIEWPORT);
+    // Entities cleared immediately when load starts, before the fetch resolves
+    expect(session.entities).toEqual([]);
+    resolveEntities([]);
+    await loadPromise;
+  });
+
+  it("stores empty entities array when listEntities fails", async () => {
+    const dataset = makeDataset({ cam: { base: "Image" } });
+    const { sink } = makeSink();
+    const session = new WorkspaceSession();
+    const gateway = makeGateway({ dataset });
+    gateway.listEntities = () => Promise.reject(new Error("network error"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loader = new RecordLoader({
+      workspace: sink,
+      registry: makeRegistry(makeImageExtension()),
+      gateway,
+      session,
+    });
+
+    await loader.load("ds-1", "rec-1", VIEWPORT);
+
+    expect(session.entities).toEqual([]);
+    consoleSpy.mockRestore();
   });
 
   it("passes entitiesById to each extension seed", async () => {

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
@@ -11,7 +11,7 @@ import type {
   BBoxRow,
   EntityRow,
 } from "$lib/api/annotations.js";
-import type { ImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
+import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
 import { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 import type {
   WidgetComponentProps,
@@ -33,7 +33,7 @@ import { WorkspaceManager } from "../workspaceManager.svelte.js";
 interface FakeGatewayState {
   dataset: Dataset;
   entities: EntityRow[];
-  imagesByLogicalName: Map<string, ImageResponse>;
+  imagesByLogicalName: Map<string, CalibratedImageResponse>;
   pointCloudsByLogicalName: Map<string, PointCloudResponse>;
   bboxes: BBoxRow[];
   bboxes3d: BBox3DRow[];
@@ -196,6 +196,39 @@ function makeDataset(views: Record<string, { base: string }>): Dataset {
 
 const FIXED_VIEWPORT = { width: 1600, height: 900 };
 
+describe("WorkspaceManager.toggleWidgetVisibility", () => {
+  function findWidget(manager: WorkspaceManager, id: string) {
+    return manager.widgets.find((w) => w.id === id);
+  }
+
+  it("toggles hidden from falsy to true", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    const { id } = manager.addWidget("image")!;
+
+    manager.toggleWidgetVisibility(id);
+
+    expect(findWidget(manager, id)?.hidden).toBe(true);
+  });
+
+  it("toggles hidden back to false on second call", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    const { id } = manager.addWidget("image")!;
+
+    manager.toggleWidgetVisibility(id);
+    manager.toggleWidgetVisibility(id);
+
+    expect(findWidget(manager, id)?.hidden).toBe(false);
+  });
+
+  it("does nothing for an unknown id", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    const { id } = manager.addWidget("image")!;
+
+    expect(() => manager.toggleWidgetVisibility("nonexistent")).not.toThrow();
+    expect(findWidget(manager, id)?.hidden).toBeUndefined();
+  });
+});
+
 describe("WorkspaceManager.selectRecordInDataset", () => {
   it("creates one widget per renderable view, in dataset order", async () => {
     const dataset = makeDataset({
@@ -207,8 +240,8 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
       dataset,
       entities: [],
       imagesByLogicalName: new Map([
-        ["cam_front", { id: "img-front", src: "/f.png", width: 100, height: 50 } as ImageResponse],
-        ["cam_back", { id: "img-back", src: "/b.png", width: 100, height: 50 } as ImageResponse],
+        ["cam_front", { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse],
+        ["cam_back", { id: "img-back", src: "/b.png", width: 100, height: 50 } as CalibratedImageResponse],
       ]),
       pointCloudsByLogicalName: new Map([
         ["lidar_top", { id: "pc-top", src: "/lidar.pcd" } as PointCloudResponse],
@@ -257,7 +290,7 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
       imagesByLogicalName: new Map([
         [
           "cam_front",
-          { id: "img-front", src: "/f.png", width: 100, height: 50 } as ImageResponse,
+          { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse,
         ],
       ]),
       pointCloudsByLogicalName: new Map(),
@@ -363,7 +396,7 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
         return entitiesPromise;
       },
       loadImageByLogicalName: () =>
-        Promise.resolve({ id: "img-1", src: "", width: 1, height: 1 } as ImageResponse),
+        Promise.resolve({ id: "img-1", src: "", width: 1, height: 1, f: null, c: null, distortion: null, extrinsic_matrix: null, ego_to_world: null } as CalibratedImageResponse),
       listBBoxes: () => Promise.resolve([]),
       loadPointCloudByLogicalName: () => Promise.resolve(null),
       listBBox3Ds: () => Promise.resolve([]),

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceSession.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceSession.svelte.test.ts
@@ -15,6 +15,12 @@ describe("WorkspaceSession", () => {
     expect(session.recordId).toBeNull();
   });
 
+  it("starts with empty entities and null entitySchemaName", () => {
+    const session = new WorkspaceSession();
+    expect(session.entities).toEqual([]);
+    expect(session.entitySchemaName).toBeNull();
+  });
+
   it("stores assigned datasetId and recordId", () => {
     const session = new WorkspaceSession();
     session.datasetId = "ds-1";
@@ -24,15 +30,29 @@ describe("WorkspaceSession", () => {
     expect(session.recordId).toBe("rec-42");
   });
 
-  it("reset() clears both fields back to null", () => {
+  it("stores assigned entities and entitySchemaName", () => {
+    const session = new WorkspaceSession();
+    session.entities = [{ id: "e1", record_id: "rec-1" }];
+    session.entitySchemaName = "VOCEntity";
+
+    expect(session.entities).toHaveLength(1);
+    expect(session.entities[0].id).toBe("e1");
+    expect(session.entitySchemaName).toBe("VOCEntity");
+  });
+
+  it("reset() clears all fields back to initial values", () => {
     const session = new WorkspaceSession();
     session.datasetId = "ds-1";
     session.recordId = "rec-42";
+    session.entities = [{ id: "e1", record_id: "rec-1" }];
+    session.entitySchemaName = "VOCEntity";
 
     session.reset();
 
     expect(session.datasetId).toBeNull();
     expect(session.recordId).toBeNull();
+    expect(session.entities).toEqual([]);
+    expect(session.entitySchemaName).toBeNull();
   });
 
   it("reset() is idempotent on an already-empty session", () => {
@@ -40,13 +60,17 @@ describe("WorkspaceSession", () => {
     session.reset();
     expect(session.datasetId).toBeNull();
     expect(session.recordId).toBeNull();
+    expect(session.entities).toEqual([]);
+    expect(session.entitySchemaName).toBeNull();
   });
 
   it("multiple sessions are independent", () => {
     const a = new WorkspaceSession();
     const b = new WorkspaceSession();
     a.datasetId = "ds-a";
+    a.entities = [{ id: "e1", record_id: "rec-1" }];
 
     expect(b.datasetId).toBeNull();
+    expect(b.entities).toEqual([]);
   });
 });

--- a/ui/apps/web/src/lib/workspace/datasetGateway.ts
+++ b/ui/apps/web/src/lib/workspace/datasetGateway.ts
@@ -10,7 +10,7 @@ import type {
   BBoxRow,
   EntityRow,
 } from "$lib/api/annotations.js";
-import type { ImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
+import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
 import type { Dataset } from "$lib/types/dataset";
 
 /**
@@ -40,7 +40,7 @@ export interface RecordReadGateway {
     datasetId: string,
     recordId: string,
     logicalName: string,
-  ): Promise<ImageResponse | null>;
+  ): Promise<CalibratedImageResponse | null>;
 
   listBBoxes(
     datasetId: string,

--- a/ui/apps/web/src/lib/workspace/recordLoader.ts
+++ b/ui/apps/web/src/lib/workspace/recordLoader.ts
@@ -78,13 +78,18 @@ export class RecordLoader {
     // still leaves a consistent session.
     this.session.datasetId = datasetId;
     this.session.recordId = recordId;
+    this.session.entities = [];
+    this.session.entitySchemaName = null;
 
     // Kick off both the dataset metadata fetch and the entities listing in
     // parallel — they don't depend on each other and the entities call is
     // record-scoped, not view-scoped.
     const [dataset, entityRows] = await Promise.all([
       this.readGateway.getDataset(datasetId),
-      this.readGateway.listEntities(datasetId, { recordId }).catch(() => [] as EntityRow[]),
+      this.readGateway.listEntities(datasetId, { recordId }).catch((err: unknown) => {
+        console.error("Failed to load entities:", err);
+        return [] as EntityRow[];
+      }),
     ]);
 
     // A newer load() was started while we were awaiting — discard our results.
@@ -96,6 +101,10 @@ export class RecordLoader {
     // seed the same map.
     const entitiesById = new Map<string, EntityRow>();
     for (const entity of entityRows) entitiesById.set(entity.id, entity);
+
+    // Expose entities and their schema name to consumers (e.g. the right panel).
+    this.session.entities = entityRows;
+    this.session.entitySchemaName = dataset.schema.schemas?.["entities"]?.schema ?? null;
 
     const candidates = Object.entries(dataset.info.views ?? {});
     const extensions = this.registry.getAll();

--- a/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
@@ -5,6 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { ResourceMutation } from "$lib/annotations/types.js";
+import type { EntityRow } from "$lib/api/annotations.js";
 import type { WidgetInstance, WidgetLayout, WorkspacePreset } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 
@@ -84,6 +85,14 @@ export class WorkspaceManager {
 
   get recordId(): string | null {
     return this.session.recordId;
+  }
+
+  get entities(): EntityRow[] {
+    return this.session.entities;
+  }
+
+  get entitySchemaName(): string | null {
+    return this.session.entitySchemaName;
   }
 
   // ─── Mutation queue forwarders ────────────────────────────────────────────
@@ -181,6 +190,14 @@ export class WorkspaceManager {
     const widget = this.widgets.find((w) => w.id === id);
     if (widget) {
       widget.layout = { ...widget.layout, ...layout };
+    }
+  }
+
+  /** Toggle the visibility of a widget in the workspace. */
+  toggleWidgetVisibility(id: string): void {
+    const widget = this.widgets.find((w) => w.id === id);
+    if (widget) {
+      widget.hidden = !widget.hidden;
     }
   }
 

--- a/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
@@ -4,6 +4,8 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import type { EntityRow } from "$lib/api/annotations.js";
+
 /**
  * Reactive "what record is currently loaded?" state, shared by the
  * sub-services of the workspace.
@@ -19,10 +21,14 @@ License: CECILL-C
 export class WorkspaceSession {
   datasetId = $state<string | null>(null);
   recordId = $state<string | null>(null);
+  entities = $state<EntityRow[]>([]);
+  entitySchemaName = $state<string | null>(null);
 
   /** Reset the selection (e.g. on `clearWorkspace`). */
   reset(): void {
     this.datasetId = null;
     this.recordId = null;
+    this.entities = [];
+    this.entitySchemaName = null;
   }
 }


### PR DESCRIPTION
  - Theme toggle: adds a persistent dark/light mode switch to the toolbar, backed by a theme.svelte.ts store that updates the <html> class and survives navigation.
  - Calibrated image API: introduces CalibratedImageResponse extending ImageResponse with optional fields f, c, distortion, extrinsic_matrix, and ego_to_world. All /images endpoints now return this type — plain image datasets get null fields so the change is fully backward-compatible.
  - Entities panel tab: adds an Entities tab to the right panel that lists entity cards for the current loaded record. Each widget card has an Eye/EyeOff visibility toggle; GridWorkspace respects hidden state. WorkspaceSession now holds entities and entitySchemaName populated by RecordLoader.
  - ImageExtension calibration pass-through: the extension extracts calibration data from the response and threads it into ImageWidgetOptions via a new CameraCalibration interface.