### PR TITLE
DO NOT MERGE --- feat: add cookie-based frontend toggle between classic and new UI

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -19,7 +19,8 @@ class CustomBuildHook(BuildHookInterface):
             return
 
         ui_dir = os.path.join(self.root, "ui")
-        app_dir = os.path.join(ui_dir, "apps", "pixano")
+        classic_app_dir = os.path.join(ui_dir, "apps", "pixano")
+        web_app_dir = os.path.join(ui_dir, "apps", "web")
 
         if not os.path.isdir(ui_dir):
             return
@@ -31,9 +32,16 @@ class CustomBuildHook(BuildHookInterface):
             check=True,
         )
 
-        self.app.display_info("Building frontend...")
+        self.app.display_info("Building classic frontend...")
         subprocess.run(
             ["pnpm", "build"],
-            cwd=app_dir,
+            cwd=classic_app_dir,
+            check=True,
+        )
+
+        self.app.display_info("Building web frontend...")
+        subprocess.run(
+            ["pnpm", "build"],
+            cwd=web_app_dir,
             check=True,
         )

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -19,7 +19,7 @@ class CustomBuildHook(BuildHookInterface):
             return
 
         ui_dir = os.path.join(self.root, "ui")
-        classic_app_dir = os.path.join(ui_dir, "apps", "pixano")
+        legacy_app_dir = os.path.join(ui_dir, "apps", "pixano")
         web_app_dir = os.path.join(ui_dir, "apps", "web")
 
         if not os.path.isdir(ui_dir):
@@ -32,10 +32,10 @@ class CustomBuildHook(BuildHookInterface):
             check=True,
         )
 
-        self.app.display_info("Building classic frontend...")
+        self.app.display_info("Building legacy frontend...")
         subprocess.run(
             ["pnpm", "build"],
-            cwd=classic_app_dir,
+            cwd=legacy_app_dir,
             check=True,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-artifacts = ["src/pixano/api/dist"]
+artifacts = ["src/pixano/api/dist", "src/pixano/api/classic_dist"]
 
 [tool.hatch.build.hooks.custom]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-artifacts = ["src/pixano/api/dist", "src/pixano/api/classic_dist"]
+artifacts = ["src/pixano/api/dist", "src/pixano/api/legacy_dist"]
 
 [tool.hatch.build.hooks.custom]
 

--- a/src/pixano/api/serve.py
+++ b/src/pixano/api/serve.py
@@ -8,6 +8,7 @@ import asyncio
 import warnings
 from functools import lru_cache
 from importlib.resources import files
+from pathlib import Path
 
 import fastapi
 import uvicorn
@@ -150,9 +151,12 @@ class App:
 
         @self.app.get("/", response_class=HTMLResponse)
         def main_page(request: fastapi.Request):
-            # TODO: if legacy_dist is not built and cookie is "legacy", clear cookie and serve new app to avoid 500
             if request.cookies.get("pixano_ui_version") == "legacy":
-                return legacy_templates.TemplateResponse(request, "index.html")
+                if (Path(LEGACY_TEMPLATE_PATH) / "index.html").exists():
+                    return legacy_templates.TemplateResponse(request, "index.html")
+                response = templates.TemplateResponse(request, "index.html")
+                response.delete_cookie("pixano_ui_version")
+                return response
             return templates.TemplateResponse(request, "index.html")
 
         def _is_non_spa_path(path: str) -> bool:

--- a/src/pixano/api/serve.py
+++ b/src/pixano/api/serve.py
@@ -37,12 +37,12 @@ LOGO = """
 """
 ASSETS_PATH = str(files("pixano").joinpath("api/dist/_app"))
 TEMPLATE_PATH = str(files("pixano").joinpath("api/dist"))
-CLASSIC_ASSETS_PATH = str(files("pixano").joinpath("api/classic_dist/_classic_app"))
-CLASSIC_TEMPLATE_PATH = str(files("pixano").joinpath("api/classic_dist"))
+LEGACY_ASSETS_PATH = str(files("pixano").joinpath("api/legacy_dist/_legacy_app"))
+LEGACY_TEMPLATE_PATH = str(files("pixano").joinpath("api/legacy_dist"))
 NON_SPA_PREFIXES = (
     *API_PREFIXES,
     "/_app",
-    "/_classic_app",
+    "/_legacy_app",
     "/app_models",
     "/health",
     "/docs",
@@ -144,15 +144,15 @@ class App:
         # Create app
         settings = get_settings_override()
         templates = Jinja2Templates(directory=TEMPLATE_PATH)
-        classic_templates = Jinja2Templates(directory=CLASSIC_TEMPLATE_PATH)
+        legacy_templates = Jinja2Templates(directory=LEGACY_TEMPLATE_PATH)
         self.app = create_app(settings=settings)
         self.app.dependency_overrides[get_settings] = get_settings_override
 
         @self.app.get("/", response_class=HTMLResponse)
         def main_page(request: fastapi.Request):
-            # TODO: if classic_dist is not built and cookie is "classic", clear cookie and serve new app to avoid 500
-            if request.cookies.get("pixano_ui_version") == "classic":
-                return classic_templates.TemplateResponse(request, "index.html")
+            # TODO: if legacy_dist is not built and cookie is "legacy", clear cookie and serve new app to avoid 500
+            if request.cookies.get("pixano_ui_version") == "legacy":
+                return legacy_templates.TemplateResponse(request, "index.html")
             return templates.TemplateResponse(request, "index.html")
 
         def _is_non_spa_path(path: str) -> bool:
@@ -168,11 +168,11 @@ class App:
             )
 
         try:
-            self.app.mount("/_classic_app", StaticFiles(directory=CLASSIC_ASSETS_PATH), name="classic_assets")
+            self.app.mount("/_legacy_app", StaticFiles(directory=LEGACY_ASSETS_PATH), name="legacy_assets")
         except RuntimeError:
             warnings.warn(
-                "Classic app assets not found. If it is a production environment, this is not expected, "
-                "check if you have built the assets for the classic UI."
+                "Legacy app assets not found. If it is a production environment, this is not expected, "
+                "check if you have built the assets for the legacy UI."
             )
 
         @self.app.get("/{full_path:path}", include_in_schema=False)

--- a/src/pixano/api/serve.py
+++ b/src/pixano/api/serve.py
@@ -37,9 +37,12 @@ LOGO = """
 """
 ASSETS_PATH = str(files("pixano").joinpath("api/dist/_app"))
 TEMPLATE_PATH = str(files("pixano").joinpath("api/dist"))
+CLASSIC_ASSETS_PATH = str(files("pixano").joinpath("api/classic_dist/_classic_app"))
+CLASSIC_TEMPLATE_PATH = str(files("pixano").joinpath("api/classic_dist"))
 NON_SPA_PREFIXES = (
     *API_PREFIXES,
     "/_app",
+    "/_classic_app",
     "/app_models",
     "/health",
     "/docs",
@@ -141,11 +144,15 @@ class App:
         # Create app
         settings = get_settings_override()
         templates = Jinja2Templates(directory=TEMPLATE_PATH)
+        classic_templates = Jinja2Templates(directory=CLASSIC_TEMPLATE_PATH)
         self.app = create_app(settings=settings)
         self.app.dependency_overrides[get_settings] = get_settings_override
 
         @self.app.get("/", response_class=HTMLResponse)
         def main_page(request: fastapi.Request):
+            # TODO: if classic_dist is not built and cookie is "classic", clear cookie and serve new app to avoid 500
+            if request.cookies.get("pixano_ui_version") == "classic":
+                return classic_templates.TemplateResponse(request, "index.html")
             return templates.TemplateResponse(request, "index.html")
 
         def _is_non_spa_path(path: str) -> bool:
@@ -158,6 +165,14 @@ class App:
             warnings.warn(
                 "Pixano app assets not found. If it is a production environment, this is not expected, "
                 "check if you have built the assets for the UI."
+            )
+
+        try:
+            self.app.mount("/_classic_app", StaticFiles(directory=CLASSIC_ASSETS_PATH), name="classic_assets")
+        except RuntimeError:
+            warnings.warn(
+                "Classic app assets not found. If it is a production environment, this is not expected, "
+                "check if you have built the assets for the classic UI."
             )
 
         @self.app.get("/{full_path:path}", include_in_schema=False)

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -15,6 +15,8 @@ License: CECILL-C
   import { page } from "$app/state";
   import { pixanoLogo } from "$lib/assets";
   import { datasetsStore, themeMode, toggleTheme } from "$lib/stores/appStores.svelte";
+  import { ArrowsLeftRight } from "phosphor-svelte";
+
   import { getEffectProbeSnapshot, IconButton, ThemeToggle } from "$lib/ui";
 
   import "./styles.css";
@@ -94,7 +96,18 @@ License: CECILL-C
         {/if}
       </div>
 
-      <div class="flex items-center shrink-0">
+      <div class="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onclick={() => {
+            document.cookie = "pixano_ui_version=next; max-age=31536000; path=/";
+            window.location.href = "/";
+          }}
+          class="inline-flex items-center justify-center rounded-lg p-1.5 text-foreground/60 transition-colors hover:bg-primary/5 hover:text-foreground"
+          title="Switch to new UI"
+        >
+          <ArrowsLeftRight size={20} />
+        </button>
         <ThemeToggle mode={themeMode.value} onToggle={toggleTheme} />
       </div>
     </header>

--- a/ui/apps/pixano/svelte.config.js
+++ b/ui/apps/pixano/svelte.config.js
@@ -7,11 +7,11 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({
-      pages: "../../../src/pixano/api/classic_dist",
-      assets: "../../../src/pixano/api/classic_dist",
+      pages: "../../../src/pixano/api/legacy_dist",
+      assets: "../../../src/pixano/api/legacy_dist",
       fallback: "index.html",
     }),
-    appDir: "_classic_app",
+    appDir: "_legacy_app",
     alias: pixanoAliases,
   },
 };

--- a/ui/apps/pixano/svelte.config.js
+++ b/ui/apps/pixano/svelte.config.js
@@ -7,10 +7,11 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({
-      pages: "build",
-      assets: "build",
+      pages: "../../../src/pixano/api/classic_dist",
+      assets: "../../../src/pixano/api/classic_dist",
       fallback: "index.html",
     }),
+    appDir: "_classic_app",
     alias: pixanoAliases,
   },
 };

--- a/ui/apps/web/src/lib/components/shell/Toolbar.svelte
+++ b/ui/apps/web/src/lib/components/shell/Toolbar.svelte
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Lock, PanelRight, Unlock } from "lucide-svelte";
+  import { Lock, PanelRight, Unlock, ArrowLeftRight } from "lucide-svelte";
 
   import type { PanelState } from "$lib/components/ui/resizable-panel/PanelState.svelte.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
@@ -49,6 +49,18 @@ License: CECILL-C
         <Lock class="h-3.5 w-3.5" />
         <span>Locked</span>
       {/if}
+    </button>
+
+    <button
+      type="button"
+      onclick={() => {
+        document.cookie = "pixano_ui_version=classic; max-age=31536000; path=/";
+        window.location.href = "/";
+      }}
+      class="flex items-center justify-center rounded-md border border-border p-1 text-xs text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
+      title="Switch to classic UI"
+    >
+      <ArrowLeftRight class="h-3.5 w-3.5" />
     </button>
 
     <button

--- a/ui/apps/web/src/lib/components/shell/Toolbar.svelte
+++ b/ui/apps/web/src/lib/components/shell/Toolbar.svelte
@@ -54,11 +54,11 @@ License: CECILL-C
     <button
       type="button"
       onclick={() => {
-        document.cookie = "pixano_ui_version=classic; max-age=31536000; path=/";
+        document.cookie = "pixano_ui_version=legacy; max-age=31536000; path=/";
         window.location.href = "/";
       }}
       class="flex items-center justify-center rounded-md border border-border p-1 text-xs text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
-      title="Switch to classic UI"
+      title="Switch to legacy UI"
     >
       <ArrowLeftRight class="h-3.5 w-3.5" />
     </button>


### PR DESCRIPTION
  feat: cookie-based toggle between legacy and new UI

  Allow users to switch between the legacy (apps/pixano) and new (apps/web) UI at runtime using a persistent cookie, without any server restart.

  How it works

  The backend reads a pixano_ui_version cookie on every GET / request:
  - "legacy" → serves the legacy frontend from legacy_dist/
  - anything else → serves the new frontend from dist/ (default)

  A toggle button in each UI sets the opposite cookie value (1-year max-age) and reloads the page. If the legacy assets are not built and the cookie is "legacy", the server clears the cookie and falls back to the new UI to avoid a 500.

  Changes

  Backend — src/pixano/api/serve.py
  - Mount /_legacy_app as a separate static route for legacy frontend assets
  - Read pixano_ui_version cookie on GET / and route to the appropriate template
  - Gracefully warn (no crash) when legacy assets aren't built
  - Fall back to new UI and clear the stale cookie when legacy index.html is missing

  Build — hatch_build.py, pyproject.toml
  - Build both frontends during packaging: legacy app → legacy_dist/, new app → dist/

  Legacy UI — ui/apps/pixano
  - Output build to legacy_dist/ with appDir: "_legacy_app" (svelte.config.js)
  - Add "Switch to new UI" button in the header (+layout.svelte)

  New UI — ui/apps/web
  - Add "Switch to legacy UI" button in the toolbar (Toolbar.svelte)

  Notes

  - Cookie is persistent (1 year), survives page refresh
  - No server restart needed to switch UI
  - If only one frontend is built, switching to the other falls back safely to the new UI