### PR TITLE
Fix arrow colors

### DIFF
--- a/ui/apps/web/src/lib/components/widgets/PointCloudScene.svelte
+++ b/ui/apps/web/src/lib/components/widgets/PointCloudScene.svelte
@@ -209,10 +209,10 @@ License: CECILL-C
   const _ARROW_DEFS = [
     { id: "+x", localDir: new THREE.Vector3( 1,  0,  0), color: "#ef4444", axis: 0 as const, sign:  1 as const },
     { id: "-x", localDir: new THREE.Vector3(-1,  0,  0), color: "#ef4444", axis: 0 as const, sign: -1 as const },
-    { id: "+y", localDir: new THREE.Vector3( 0,  1,  0), color: "#22c55e", axis: 1 as const, sign:  1 as const },
-    { id: "-y", localDir: new THREE.Vector3( 0, -1,  0), color: "#22c55e", axis: 1 as const, sign: -1 as const },
-    { id: "+z", localDir: new THREE.Vector3( 0,  0,  1), color: "#3b82f6", axis: 2 as const, sign:  1 as const },
-    { id: "-z", localDir: new THREE.Vector3( 0,  0, -1), color: "#3b82f6", axis: 2 as const, sign: -1 as const },
+    { id: "+y", localDir: new THREE.Vector3( 0,  1,  0), color: "#3b82f6", axis: 1 as const, sign:  1 as const },
+    { id: "-y", localDir: new THREE.Vector3( 0, -1,  0), color: "#3b82f6", axis: 1 as const, sign: -1 as const },
+    { id: "+z", localDir: new THREE.Vector3( 0,  0,  1), color: "#22c55e", axis: 2 as const, sign:  1 as const },
+    { id: "-z", localDir: new THREE.Vector3( 0,  0, -1), color: "#22c55e", axis: 2 as const, sign: -1 as const },
   ] as const;
   const arrowGizmos = $derived(
     (() => {


### PR DESCRIPTION
In PointCloudScene.svelte:212-215, the Y-axis arrows are now blue (#3b82f6) and the Z-axis arrows are now green (#22c55e) — only the color values were swapped, nothing else was changed.
