### PR TITLE
fix: prefix route URLs with # for SvelteKit hash routing in dev mode

### DIFF
--- a/ui/apps/pixano/src/lib/utils/routes.ts
+++ b/ui/apps/pixano/src/lib/utils/routes.ts
@@ -11,13 +11,13 @@ export const EXPLORER_ROUTE_ID = "/explorer/[datasetId]";
 export const WORKSPACE_ROUTE_ID = "/explorer/[datasetId]/workspace/[itemId]";
 
 export const getExplorerRoute = (datasetId: string, query?: string): string => {
-  const baseRoute = `/explorer/${datasetId}`;
+  const baseRoute = `#/explorer/${datasetId}`;
   if (!query) return baseRoute;
   return query.startsWith("?") ? `${baseRoute}${query}` : `${baseRoute}?${query}`;
 };
 
 export const getWorkspaceRoute = (datasetId: string, itemId: string): string =>
-  `/explorer/${datasetId}/workspace/${itemId}`;
+  `#/explorer/${datasetId}/workspace/${itemId}`;
 
 export const findNeighborItemId = (
   itemsIds: string[],


### PR DESCRIPTION
The problem:

- When you click on a dataset, the app needs to take you to a new page. To do that, it sends the browser an address to navigate to — like /explorer/my-dataset.

- But the app is set up to work with a special kind of address that starts with a # symbol, like /#/explorer/my-dataset. This # tells the browser: "don't ask the server for this page — handle it yourself, locally."

- In the development environment, the app was generating addresses without the #. When the browser tried to go there, it asked the server for /explorer/my-dataset. The development server didn't know anything about that address and replied:
  "Not found."

- The production environment happened to work anyway because it had a safety net: a rule that automatically redirected any such wrong address to the correct #-prefixed version. The development environment had no such safety net.

The fix:

- Simply add the # to the start of the addresses the app generates when navigating between pages. Two lines of code changed, from /explorer/... to #/explorer/.... Now the browser never asks the server for those pages — it handles navigation locally, as intended.