### PR TITLE
fix: TextSpan missing view_id on save

### DIFF
--- a/ui/apps/pixano/src/components/workspace/Inspector/ChildCard.svelte
+++ b/ui/apps/pixano/src/components/workspace/Inspector/ChildCard.svelte
@@ -440,17 +440,32 @@ License: CECILL-C
         {#if bboxData}
           <div class="rounded-md bg-muted/30 border border-border/30 p-2 space-y-1.5">
             <!-- Coordinate grid -->
-            <div class="grid grid-cols-2 gap-x-3 gap-y-0.5">
-              {#each bboxData.labels as label, i}
-                {#if i < bboxData.coords.length}
-                  <div class="flex items-center justify-between">
-                    <span class="text-[10px] text-muted-foreground/70 font-medium">{label}</span>
-                    <span class="text-[11px] font-mono text-foreground/90">
-                      {fmtCoord(bboxData.coords[i])}
-                    </span>
-                  </div>
-                {/if}
-              {/each}
+            <div class="flex gap-2 items-stretch">
+              <div class="flex-1 min-w-0 space-y-0.5">
+                {#each bboxData.labels as label, i}
+                  {#if i < bboxData.coords.length && i % 2 === 0}
+                    <div class="flex items-center justify-between gap-1">
+                      <span class="text-[10px] text-foreground font-medium">{label}</span>
+                      <span class="text-[11px] font-mono text-foreground/70">
+                        {fmtCoord(bboxData.coords[i])}
+                      </span>
+                    </div>
+                  {/if}
+                {/each}
+              </div>
+              <div class="w-[50px] bg-border/20 shrink-0 self-stretch"></div>
+              <div class="flex-1 min-w-0 space-y-0.5">
+                {#each bboxData.labels as label, i}
+                  {#if i < bboxData.coords.length && i % 2 === 1}
+                    <div class="flex items-center justify-between gap-1">
+                      <span class="text-[10px] text-foreground font-medium">{label}</span>
+                      <span class="text-[11px] font-mono text-foreground/70">
+                        {fmtCoord(bboxData.coords[i])}
+                      </span>
+                    </div>
+                  {/if}
+                {/each}
+              </div>
             </div>
 
             <!-- Format row -->
@@ -476,16 +491,16 @@ License: CECILL-C
           <div class="rounded-md bg-muted/30 border border-border/30 p-2 space-y-1">
             {#if maskData.size.length >= 2}
               <div class="flex items-center gap-2">
-                <span class="text-[10px] text-muted-foreground/70 font-medium">Size</span>
-                <span class="text-[11px] font-mono text-foreground/90">
+                <span class="text-[10px] text-foreground font-medium">Size</span>
+                <span class="text-[11px] font-mono text-foreground/70">
                   {maskData.size[0]} &times; {maskData.size[1]}
                 </span>
               </div>
             {/if}
             {#if maskData.bounds}
               <div class="flex items-center gap-2">
-                <span class="text-[10px] text-muted-foreground/70 font-medium">Bounds</span>
-                <span class="text-[11px] font-mono text-foreground/80">
+                <span class="text-[10px] text-foreground font-medium">Bounds</span>
+                <span class="text-[11px] font-mono text-foreground/70">
                   {Math.round(maskData.bounds.x)}, {Math.round(maskData.bounds.y)} &mdash; {Math.round(
                     maskData.bounds.width,
                   )}&times;{Math.round(maskData.bounds.height)}
@@ -504,7 +519,7 @@ License: CECILL-C
                   weight="fill"
                   class="h-3 w-3 text-muted-foreground/40 flex-shrink-0 mt-0.5"
                 />
-                <span class="text-[11px] italic text-foreground/90 leading-snug break-words">
+                <span class="text-[11px] italic text-foreground/70 leading-snug break-words">
                   {textSpanData.mention}
                 </span>
               </div>
@@ -513,10 +528,10 @@ License: CECILL-C
             <!-- Span offsets -->
             {#if textSpanData.spans.length > 0}
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-[10px] text-muted-foreground/70 font-medium">Spans</span>
+                <span class="text-[10px] text-foreground font-medium">Spans</span>
                 {#each textSpanData.spans as span}
                   <span
-                    class="px-1.5 py-0.5 rounded bg-muted/50 text-[10px] font-mono text-muted-foreground leading-none"
+                    class="px-1.5 py-0.5 rounded bg-muted/50 text-[10px] font-mono text-foreground/70 leading-none"
                   >
                     [{span[0]}, {span[1]}]
                   </span>
@@ -531,7 +546,7 @@ License: CECILL-C
                   <span
                     class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-accent/30 text-[10px] font-medium text-foreground/70 leading-none"
                   >
-                    <span class="text-muted-foreground/60">{extra.key}:</span>
+                    <span class="text-foreground">{extra.key}:</span>
                     {extra.value}
                   </span>
                 {/each}
@@ -544,15 +559,15 @@ License: CECILL-C
           <div class="rounded-md bg-muted/30 border border-border/30 p-2 space-y-1">
             {#if keypointsData.templateId}
               <div class="flex items-center gap-2">
-                <span class="text-[10px] text-muted-foreground/70 font-medium">Template</span>
-                <span class="text-[11px] font-mono text-foreground/80">
+                <span class="text-[10px] text-foreground font-medium">Template</span>
+                <span class="text-[11px] font-mono text-foreground/70">
                   {keypointsData.templateId}
                 </span>
               </div>
             {/if}
             <div class="flex items-center gap-2">
-              <span class="text-[10px] text-muted-foreground/70 font-medium">Vertices</span>
-              <span class="text-[11px] text-foreground/80">{keypointsData.vertexCount}</span>
+              <span class="text-[10px] text-foreground font-medium">Vertices</span>
+              <span class="text-[11px] text-foreground/70">{keypointsData.vertexCount}</span>
               {#if keypointsData.visibleCount > 0 || keypointsData.hiddenCount > 0}
                 <span class="text-[9px] text-muted-foreground/50">
                   ({keypointsData.visibleCount} visible, {keypointsData.hiddenCount} hidden)
@@ -565,12 +580,12 @@ License: CECILL-C
         {:else if trackletData}
           <div class="rounded-md bg-muted/30 border border-border/30 p-2">
             <div class="flex items-center gap-2">
-              <span class="text-[10px] text-muted-foreground/70 font-medium">Frames</span>
-              <span class="text-[11px] font-mono text-foreground/80">
+              <span class="text-[10px] text-foreground font-medium">Frames</span>
+              <span class="text-[11px] font-mono text-foreground/70">
                 {trackletData.startFrame}
               </span>
               <span class="text-[10px] text-muted-foreground/40">&rarr;</span>
-              <span class="text-[11px] font-mono text-foreground/80">
+              <span class="text-[11px] font-mono text-foreground/70">
                 {trackletData.endFrame}
               </span>
               <span class="text-[9px] text-muted-foreground/50">

--- a/ui/apps/pixano/src/components/workspace/Inspector/EntityCard.svelte
+++ b/ui/apps/pixano/src/components/workspace/Inspector/EntityCard.svelte
@@ -170,17 +170,20 @@ License: CECILL-C
   };
 
   const totalAllowableChildCount = $derived.by(() => {
+    void entities.value;
     return entity.ui.childs?.filter((ann) => isAllowableChild(ann)).length ?? 0;
   });
 
   const allowedChilds = $derived.by(() => {
     if (!isExpanded) return [];
     if (currentFrameIndex.value === undefined) return [];
+    void entities.value;
     return entity.ui.childs?.filter((ann) => isAllowedChild(ann)).sort(sortChilds) ?? [];
   });
 
   // ─── Annotation type summary for header pills ──────────────────────────────
   const annotationTypeSummary = $derived.by(() => {
+    void entities.value;
     const counts: Record<string, number> = {};
     for (const ann of entity.ui.childs ?? []) {
       if (!isAllowableChild(ann)) continue;

--- a/ui/apps/pixano/src/components/workspace/canvas2d/BBox2D.svelte
+++ b/ui/apps/pixano/src/components/workspace/canvas2d/BBox2D.svelte
@@ -161,7 +161,7 @@ License: CECILL-C
     ontransformend={handleTransformEnd}
   />
   {#if editing}
-    <Transformer bind:this={trComponent} rotateEnabled={false} />
+    <Transformer bind:this={trComponent} rotateEnabled={false} keepRatio={false} />
   {/if}
   <LabelTag
     id={bbox.id}

--- a/ui/apps/pixano/src/lib/utils/entityOperations.ts
+++ b/ui/apps/pixano/src/lib/utils/entityOperations.ts
@@ -246,6 +246,7 @@ export const defineCreatedAnnotation = (
   const baseData = {
     item_id: entity.data.item_id,
     view_name: annotationViewRef.name,
+    view_id: annotationViewRef.id,
     entity_id: entity.id,
     source_type: PIXANO_SOURCE.type,
     source_name: PIXANO_SOURCE.name,

--- a/ui/apps/pixano/src/routes/explorer/[datasetId]/+layout.ts
+++ b/ui/apps/pixano/src/routes/explorer/[datasetId]/+layout.ts
@@ -19,7 +19,6 @@ export const load: LayoutLoad = async ({ params, parent }) => {
     api.getDataset(params.datasetId),
     api.listAllRecordIds(params.datasetId),
   ]);
-
   return {
     dataset,
     schema: ds.schema,


### PR DESCRIPTION
fix: TextSpan missing view_id on save, EntityCard reactive stalls, BBox resize aspect ratio lock, and ChildCard typography consistency

- entityOperations.ts: add view_id to TextSpan data payload so freshly drawn spans are grouped and rendered correctly after save
- EntityCard.svelte: add void entities.value reactive bridge to allowedChilds, totalAllowableChildCount, and annotationTypeSummary deriveds so annotation deletion immediately removes the card from DOM
- BBox2D.svelte: add keepRatio={false} to Konva Transformer to allow independent width/height adjustment during corner resize
- ChildCard.svelte: restructure bbox coordinate grid into two flex columns with a 50px vertical divider for clearer visual separation
- ChildCard.svelte: normalize key-value typography across all annotation
