### PR TITLE
fix : Add error detections and warnings while searching for view media files

### DIFF
--- a/src/pixano/cli/data.py
+++ b/src/pixano/cli/data.py
@@ -134,6 +134,10 @@ def import_data(
         for inferred, aggregate in sorted(report.inferred.items()):
             samples = ", ".join(aggregate.samples)
             typer.echo(f"- Inferred mapping: {inferred} ({aggregate.count} rows; e.g. {samples})")
+    if report.warnings:
+        for warning, aggregate in sorted(report.warnings.items()):
+            samples = ", ".join(aggregate.samples)
+            typer.echo(f"- Warning: {warning} ({aggregate.count} rows; e.g. {samples})")
     if report.errors:
         for code, aggregate in sorted(report.errors.items()):
             samples = ", ".join(aggregate.samples)

--- a/src/pixano/datasets/builders/folders/metadata.py
+++ b/src/pixano/datasets/builders/folders/metadata.py
@@ -7,12 +7,30 @@
 from __future__ import annotations
 
 import json
+import re
+import unicodedata
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
 from pixano.schemas import canonical_table_name_for_slot
+
+
+def _snake_case_name(value: str) -> str:
+    snake = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower())
+    snake = re.sub(r"_+", "_", snake).strip("_")
+    return snake
+
+
+def _has_diacritics(chaine: str):
+    for caractere in chaine:
+        # Normaliser le caractère pour obtenir sa forme décomposée
+        normalise = unicodedata.normalize("NFD", caractere)
+        # Vérifier si le caractère a été décomposé en un caractère de base et un diacritique
+        if len(normalise) > 1 and unicodedata.category(normalise[-1]) == "Mn":
+            return True
+    return False
 
 
 @dataclass
@@ -25,7 +43,7 @@ class MetadataIssueAggregate:
     def add(self, location: str) -> None:
         """Record one occurrence of an issue at the given location."""
         self.count += 1
-        if len(self.samples) < 3 and location not in self.samples:
+        if len(self.samples) < 5 and location not in self.samples:
             self.samples.append(location)
 
 
@@ -271,8 +289,22 @@ class FolderMetadataService:
                     continue
                 files = self._resolve_view_files(split_name, value, self.views_schema[key])
                 if not files:
+                    if _has_diacritics(str(value)):
+                        report.add_error("ensure_view_media_has_no_diacritics", location)
                     report.add_error("missing_view_media", location)
                 else:
+                    if _has_diacritics(str(value)):
+                        report.add_warning("prefer_view_media_has_no_diacritics", location)
+                    print(
+                        value,
+                        [(f.stem, _snake_case_name(f.stem)) for f in files],
+                    )
+                    if any(f.stem != _snake_case_name(f.stem) for f in files):
+                        if validation_mode == "strict":
+                            report.add_error("ensure_snake_case_view_media", location)
+                            continue
+                        else:
+                            report.add_warning("prefer_snake_case_view_media", location)
                     report.add_normalized_example(f"{key} -> logical view '{key}'")
                 continue
             if key in self.entities_schema:

--- a/src/pixano/datasets/builders/folders/metadata.py
+++ b/src/pixano/datasets/builders/folders/metadata.py
@@ -18,16 +18,23 @@ from pixano.schemas import canonical_table_name_for_slot
 
 
 def _snake_case_name(value: str) -> str:
+    """Transform a string into snake case, useful for filenames."""
+    # TODO: move snake_case in a library to avoid dupplicates
     snake = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower())
     snake = re.sub(r"_+", "_", snake).strip("_")
     return snake
 
 
-def _has_diacritics(chaine: str):
+def _has_diacritics(chaine: str) -> bool:
+    """Check if a string contains diacritics."""
     for caractere in chaine:
-        # Normaliser le caractère pour obtenir sa forme décomposée
+        # Normalize the character to get its decomposed form.
+        # > Normal form D (NFD) is also known as canonical decomposition,
+        # > and translates each character into its decomposed form
         normalise = unicodedata.normalize("NFD", caractere)
-        # Vérifier si le caractère a été décomposé en un caractère de base et un diacritique
+        # Check if the character was decomposed into a base character and a diacritic.
+        # > The category codes are abbreviations describing the nature of the character.
+        # > 'Mn' is “Mark, nonspacing”
         if len(normalise) > 1 and unicodedata.category(normalise[-1]) == "Mn":
             return True
     return False
@@ -43,7 +50,9 @@ class MetadataIssueAggregate:
     def add(self, location: str) -> None:
         """Record one occurrence of an issue at the given location."""
         self.count += 1
-        if len(self.samples) < 5 and location not in self.samples:
+        # Number of occurence to keep for display in the report. Supplementary occurences are dropped.
+        nb_sample_to_keep = 5
+        if len(self.samples) < nb_sample_to_keep and location not in self.samples:
             self.samples.append(location)
 
 
@@ -295,10 +304,6 @@ class FolderMetadataService:
                 else:
                     if _has_diacritics(str(value)):
                         report.add_warning("prefer_view_media_has_no_diacritics", location)
-                    print(
-                        value,
-                        [(f.stem, _snake_case_name(f.stem)) for f in files],
-                    )
                     if any(f.stem != _snake_case_name(f.stem) for f in files):
                         if validation_mode == "strict":
                             report.add_error("ensure_snake_case_view_media", location)


### PR DESCRIPTION
add user-friendly warning and error messages in "pixano data import" when the media files are not found because of filename encodings and formating.

This is specially usefull to solve the failing use case of importing the MEL dataset.