### PR TITLE
feat(web): link entities to 2D/3D boxes (deferred entity, reassign, delete)

### DIFF
--- a/src/pixano/api/routers/resources.py
+++ b/src/pixano/api/routers/resources.py
@@ -92,11 +92,18 @@ def create_resource_router(resource: ResourceSpec) -> APIRouter:
         def update_resource(
             id: str,
             body: update_model,  # type: ignore[valid-type]
+            prune_orphan_entity: bool = False,
             dataset: Dataset = Depends(get_dataset_dep),
         ) -> Any:
-            """Update a resource by id."""
+            """Update a resource by id.
+
+            When ``prune_orphan_entity`` is set and an annotation's ``entity_id``
+            changes, the previously attached entity is deleted if it is now
+            orphaned. Off by default so plain PUT semantics are unchanged.
+            """
             service = BaseService(dataset, resource)
-            return service.update(id, body.model_dump(exclude_unset=True))  # type: ignore[attr-defined]
+            payload = body.model_dump(exclude_unset=True)  # type: ignore[attr-defined]
+            return service.update(id, payload, prune_orphan_entity=prune_orphan_entity)
 
     if resource.allow_delete:
 
@@ -109,11 +116,17 @@ def create_resource_router(resource: ResourceSpec) -> APIRouter:
         )
         def delete_resource(
             id: str,
+            prune_orphan_entity: bool = False,
             dataset: Dataset = Depends(get_dataset_dep),
         ) -> None:
-            """Delete a resource by id."""
+            """Delete a resource by id.
+
+            When ``prune_orphan_entity`` is set and the resource is an annotation,
+            its parent entity is also deleted if this was the entity's last
+            annotation. Off by default so plain DELETE semantics are unchanged.
+            """
             service = BaseService(dataset, resource)
-            service.delete(id)
+            service.delete(id, prune_orphan_entity=prune_orphan_entity)
 
     return router
 

--- a/src/pixano/api/service.py
+++ b/src/pixano/api/service.py
@@ -249,12 +249,20 @@ class BaseService:
 
         return self._response(created_rows[0])
 
-    def update(self, id: str, data: dict[str, Any]) -> BaseModel:
-        """Update an existing resource row."""
+    def update(self, id: str, data: dict[str, Any], prune_orphan_entity: bool = False) -> BaseModel:
+        """Update an existing resource row.
+
+        When ``prune_orphan_entity`` is set and an annotation's ``entity_id``
+        changes, the previously attached entity is deleted if it has no
+        remaining annotations — the server-side orphan check shared with delete.
+        """
         resolved_table = self.resolve_table()
         existing = self.dataset.get_data(resolved_table, ids=id)
         if existing is None:
             raise HTTPException(status_code=404, detail=f"Resource '{id}' not found in '{resolved_table}'.")
+
+        prune_old_entity = prune_orphan_entity and self.resource.schema_group == SchemaGroup.ANNOTATION
+        old_entity_id = getattr(existing, "entity_id", None) if prune_old_entity else None
 
         merged = merge_update_payload(existing, data)
         schema = self.dataset.info.tables[resolved_table]
@@ -263,6 +271,15 @@ class BaseService:
         except Exception as err:
             raise HTTPException(status_code=400, detail=f"Invalid data: {err}")
 
+        # Reassigning an annotation to a different entity must reference an
+        # existing one — the create path validates this, so update does too
+        # (raises 400). Only checked when entity_id actually changes, so plain
+        # geometry edits skip it.
+        if self.resource.schema_group == SchemaGroup.ANNOTATION:
+            new_entity_id = getattr(row, "entity_id", None)
+            if new_entity_id and new_entity_id != getattr(existing, "entity_id", None):
+                self.validate_entity_exists(new_entity_id)
+
         try:
             updated_rows = self.dataset.update_data(resolved_table, [row])
         except DatasetIntegrityError as err:
@@ -270,14 +287,52 @@ class BaseService:
         except ValueError as err:
             raise HTTPException(status_code=400, detail=f"Invalid data: {err}")
 
+        # The annotation now points at the new entity, so the old one's count
+        # excludes it: an empty count means the reassignment orphaned it.
+        new_entity_id = getattr(updated_rows[0], "entity_id", None)
+        if old_entity_id and old_entity_id != new_entity_id and not self._entity_has_annotations(old_entity_id):
+            self._delete_orphan_entity(old_entity_id)
+
         return self._response(updated_rows[0])
 
-    def delete(self, id: str) -> None:
-        """Delete a resource by ID."""
+    def delete(self, id: str, prune_orphan_entity: bool = False) -> None:
+        """Delete a resource by ID.
+
+        When ``prune_orphan_entity`` is set and this resource is an annotation,
+        the parent entity is also deleted if the removed annotation was its last
+        one. The check runs server-side because only the backend sees every
+        annotation referencing the entity (the front-end loads one record at a
+        time). Kind-agnostic: works for any annotation resource.
+        """
         resolved_table = self.resolve_table()
+
+        entity_id: str | None = None
+        if prune_orphan_entity and self.resource.schema_group == SchemaGroup.ANNOTATION:
+            row = self.dataset.get_data(resolved_table, ids=id)
+            if row is not None and hasattr(row, "entity_id"):
+                entity_id = row.entity_id
+
         ids_not_found = self.dataset.delete_data(resolved_table, [id])
         if ids_not_found:
             raise HTTPException(status_code=404, detail=f"Resource '{id}' not found in '{resolved_table}'.")
+
+        # The annotation row is gone now, so an empty count means it was the last.
+        if entity_id and not self._entity_has_annotations(entity_id):
+            self._delete_orphan_entity(entity_id)
+
+    def _entity_has_annotations(self, entity_id: str) -> bool:
+        """Whether any annotation in any table still references the entity."""
+        for table in self.dataset.info.groups.get(SchemaGroup.ANNOTATION, []):
+            if self.dataset.open_table(table).count_rows(f"entity_id = '{entity_id}'") > 0:
+                return True
+        return False
+
+    def _delete_orphan_entity(self, entity_id: str) -> None:
+        """Delete the entity row from whichever entity table holds it (idempotent)."""
+        for table in self.dataset.info.groups.get(SchemaGroup.ENTITY, []):
+            if self.dataset.get_data(table, ids=entity_id) is not None:
+                self.dataset.delete_data(table, [entity_id])
+                return
 
 
 __all__ = ["BaseService"]

--- a/tests/app/test_api_v2.py
+++ b/tests/app/test_api_v2.py
@@ -359,6 +359,121 @@ class TestStaticImage:
         resp2 = static_image_client.get(f"{STATIC_BASE}/bboxes/bbox_to_delete")
         assert resp2.status_code == 404
 
+    def _seed_entity_with_bboxes(self, client: TestClient, entity_id: str, bbox_ids: list[str]) -> None:
+        client.post(f"{STATIC_BASE}/entities", json={"id": entity_id, "record_id": "record_0", "parent_id": ""})
+        for bbox_id in bbox_ids:
+            resp = client.post(
+                f"{STATIC_BASE}/bboxes",
+                json={
+                    "id": bbox_id,
+                    "record_id": "record_0",
+                    "entity_id": entity_id,
+                    "coords": [0.0, 0.0, 0.1, 0.1],
+                    "format": "xywh",
+                    "is_normalized": True,
+                },
+            )
+            assert resp.status_code == 201
+
+    def test_delete_annotation_prunes_orphan_entity(self, static_image_client: TestClient):
+        """Deleting an entity's last annotation with the flag removes the entity too."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_orphan", ["bbox_orphan"])
+
+        resp = static_image_client.delete(f"{STATIC_BASE}/bboxes/bbox_orphan?prune_orphan_entity=true")
+        assert resp.status_code == 204
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_orphan").status_code == 404
+
+    def test_delete_annotation_keeps_shared_entity(self, static_image_client: TestClient):
+        """An entity with another annotation left survives; it goes only on the last one."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_shared", ["bbox_shared_a", "bbox_shared_b"])
+
+        static_image_client.delete(f"{STATIC_BASE}/bboxes/bbox_shared_a?prune_orphan_entity=true")
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_shared").status_code == 200
+
+        static_image_client.delete(f"{STATIC_BASE}/bboxes/bbox_shared_b?prune_orphan_entity=true")
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_shared").status_code == 404
+
+    def test_delete_without_prune_flag_keeps_entity(self, static_image_client: TestClient):
+        """Plain delete (no flag) leaves the entity untouched, even when orphaned."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_noprune", ["bbox_noprune"])
+
+        resp = static_image_client.delete(f"{STATIC_BASE}/bboxes/bbox_noprune")
+        assert resp.status_code == 204
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_noprune").status_code == 200
+
+    def _reassign_bbox_entity(self, client: TestClient, bbox_id: str, new_entity_id: str, prune: bool = True):
+        return client.put(
+            f"{STATIC_BASE}/bboxes/{bbox_id}",
+            params={"prune_orphan_entity": str(prune).lower()},
+            json={
+                "id": bbox_id,
+                "record_id": "record_0",
+                "entity_id": new_entity_id,
+                "coords": [0.0, 0.0, 0.1, 0.1],
+                "format": "xywh",
+                "is_normalized": True,
+            },
+        )
+
+    def test_reassign_entity_prunes_old_orphan(self, static_image_client: TestClient):
+        """Reassigning a box's only annotation to another entity deletes the old one."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_from", ["bbox_reassign"])
+        self._seed_entity_with_bboxes(static_image_client, "entity_to", ["bbox_keepalive"])
+
+        resp = self._reassign_bbox_entity(static_image_client, "bbox_reassign", "entity_to")
+        assert resp.status_code == 200
+        # The previous entity is now orphaned → gone; the new one stays.
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_from").status_code == 404
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_to").status_code == 200
+
+    def test_reassign_entity_keeps_old_when_still_referenced(self, static_image_client: TestClient):
+        """The old entity survives reassignment when another annotation still uses it."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_multi", ["bbox_move", "bbox_stay"])
+        self._seed_entity_with_bboxes(static_image_client, "entity_dest", ["bbox_dest_anchor"])
+
+        resp = self._reassign_bbox_entity(static_image_client, "bbox_move", "entity_dest")
+        assert resp.status_code == 200
+        # bbox_stay still references entity_multi → kept.
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_multi").status_code == 200
+
+    def test_reassign_without_prune_flag_keeps_old_entity(self, static_image_client: TestClient):
+        """Without the flag, the old entity is left even if reassignment orphaned it."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_np_from", ["bbox_np_reassign"])
+        self._seed_entity_with_bboxes(static_image_client, "entity_np_to", ["bbox_np_anchor"])
+
+        resp = self._reassign_bbox_entity(static_image_client, "bbox_np_reassign", "entity_np_to", prune=False)
+        assert resp.status_code == 200
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_np_from").status_code == 200
+
+    def test_reassign_to_nonexistent_entity_is_rejected(self, static_image_client: TestClient):
+        """Update must reject a reassignment to a missing entity (no dangling FK, no prune)."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_src", ["bbox_badref"])
+
+        resp = self._reassign_bbox_entity(static_image_client, "bbox_badref", "entity_does_not_exist")
+        assert resp.status_code == 400
+        # The box still points at its original entity, which is left intact.
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_src").status_code == 200
+        assert static_image_client.get(f"{STATIC_BASE}/bboxes/bbox_badref").json()["entity_id"] == "entity_src"
+
+    def test_geometry_only_update_keeps_entity(self, static_image_client: TestClient):
+        """A geometry edit (entity_id unchanged) never prunes the entity."""
+        self._seed_entity_with_bboxes(static_image_client, "entity_geom", ["bbox_geom"])
+
+        resp = static_image_client.put(
+            f"{STATIC_BASE}/bboxes/bbox_geom",
+            params={"prune_orphan_entity": "true"},
+            json={
+                "id": "bbox_geom",
+                "record_id": "record_0",
+                "entity_id": "entity_geom",
+                "coords": [0.2, 0.2, 0.3, 0.3],
+                "format": "xywh",
+                "is_normalized": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert static_image_client.get(f"{STATIC_BASE}/entities/entity_geom").status_code == 200
+
 
 # ===========================================================================
 # Scenario 2: Multi-view image (rgb + thermal) with annotations on both views

--- a/ui/apps/web/src/lib/annotations/__tests__/buildPayloads.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/buildPayloads.test.ts
@@ -7,6 +7,7 @@ License: CECILL-C
 import { describe, expect, it } from "vitest";
 
 import {
+  buildBBox3DCreate,
   buildBBoxCreate,
   buildBBoxUpdate,
   mutationPriority,
@@ -87,6 +88,65 @@ describe("buildBBoxCreate", () => {
     expect(bboxBody.id).toBe("my-bbox");
     expect(bboxBody.entity_id).toBe("my-entity");
   });
+
+  it("merges entityFields onto the new entity body", () => {
+    const { mutations } = buildBBoxCreate(CTX, [0, 0, 1, 1], {
+      entityFields: { category: "car", is_difficult: false },
+    });
+    const entityBody = (mutations[0] as Extract<ResourceMutation, { op: "create" }>).body;
+
+    expect(entityBody.category).toBe("car");
+    expect(entityBody.is_difficult).toBe(false);
+    // System fields are still present.
+    expect(entityBody.parent_id).toBe("");
+  });
+
+  it("omits the entity create when linking to an existing entity", () => {
+    const { mutations } = buildBBoxCreate(CTX, [0, 0, 1, 1], {
+      entityId: "existing-1",
+      linkExisting: true,
+    });
+
+    expect(mutations).toHaveLength(1);
+    expect(mutations[0].resource).toBe("bboxes");
+    const bboxBody = (mutations[0] as Extract<ResourceMutation, { op: "create" }>).body;
+    expect(bboxBody.entity_id).toBe("existing-1");
+  });
+});
+
+describe("buildBBox3DCreate", () => {
+  const coords: [number, number, number, number, number, number] = [1, 2, 3, 4, 5, 6];
+
+  it("returns (entity, bbox3d) create mutations with a matching entity_id", () => {
+    const { entityId, mutations } = buildBBox3DCreate(CTX, coords);
+
+    expect(mutations).toHaveLength(2);
+    expect(mutations[0].resource).toBe("entities");
+    expect(mutations[1].resource).toBe("bbox3ds");
+    const bboxBody = (mutations[1] as Extract<ResourceMutation, { op: "create" }>).body;
+    expect(bboxBody.entity_id).toBe(entityId);
+    expect(bboxBody.format).toBe("xyzwhd");
+  });
+
+  it("merges entityFields onto the new entity body", () => {
+    const { mutations } = buildBBox3DCreate(CTX, coords, {
+      entityFields: { category: "pedestrian" },
+    });
+    const entityBody = (mutations[0] as Extract<ResourceMutation, { op: "create" }>).body;
+    expect(entityBody.category).toBe("pedestrian");
+  });
+
+  it("omits the entity create when linking to an existing entity", () => {
+    const { mutations } = buildBBox3DCreate(CTX, coords, {
+      entityId: "existing-3d",
+      linkExisting: true,
+    });
+
+    expect(mutations).toHaveLength(1);
+    expect(mutations[0].resource).toBe("bbox3ds");
+    const bboxBody = (mutations[0] as Extract<ResourceMutation, { op: "create" }>).body;
+    expect(bboxBody.entity_id).toBe("existing-3d");
+  });
 });
 
 describe("buildBBoxUpdate", () => {
@@ -152,11 +212,6 @@ describe("mutationPriority / sortMutations", () => {
       return `delete:${m.resource}`;
     });
 
-    expect(order).toEqual([
-      "create:entities",
-      "create:bboxes",
-      "delete:bboxes",
-      "delete:entities",
-    ]);
+    expect(order).toEqual(["create:entities", "create:bboxes", "delete:bboxes", "delete:entities"]);
   });
 });

--- a/ui/apps/web/src/lib/annotations/__tests__/entityFeatures.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/entityFeatures.test.ts
@@ -1,0 +1,118 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEntityFeatureInputs,
+  coerceFieldValue,
+  isEntityFormValid,
+  resolveEntityLabelField,
+  suggestionsForField,
+} from "../entityFeatures";
+import type { EntityRow } from "$lib/api/annotations";
+import type { FieldInfo } from "$lib/types/dataset";
+
+function field(type: string, collection = false): FieldInfo {
+  return { type, collection };
+}
+
+const CATEGORY_ENTITY: Record<string, FieldInfo> = {
+  id: field("str"),
+  record_id: field("str"),
+  parent_id: field("str"),
+  category: field("str"),
+  score: field("float"),
+  is_difficult: field("bool"),
+  tags: field("str", true),
+};
+
+describe("buildEntityFeatureInputs", () => {
+  it("keeps editable feature fields and drops system / collection fields", () => {
+    const inputs = buildEntityFeatureInputs(CATEGORY_ENTITY);
+    const names = inputs.map((i) => i.name);
+
+    expect(names).toContain("category");
+    expect(names).toContain("score");
+    expect(names).toContain("is_difficult");
+    expect(names).not.toContain("id");
+    expect(names).not.toContain("record_id");
+    expect(names).not.toContain("parent_id");
+    expect(names).not.toContain("tags"); // collection
+  });
+
+  it("maps field types onto input types", () => {
+    const inputs = buildEntityFeatureInputs(CATEGORY_ENTITY);
+    expect(inputs.find((i) => i.name === "category")?.type).toBe("str");
+    expect(inputs.find((i) => i.name === "score")?.type).toBe("float");
+    expect(inputs.find((i) => i.name === "is_difficult")?.type).toBe("bool");
+  });
+
+  it("returns an empty list when no schema is available", () => {
+    expect(buildEntityFeatureInputs(null)).toEqual([]);
+  });
+});
+
+describe("resolveEntityLabelField", () => {
+  it("prefers a known label field when present", () => {
+    expect(resolveEntityLabelField(CATEGORY_ENTITY)).toBe("category");
+  });
+
+  it("falls back to the first writable string field", () => {
+    expect(
+      resolveEntityLabelField({
+        id: field("str"),
+        title: field("str"),
+        score: field("float"),
+      }),
+    ).toBe("title");
+  });
+
+  it("falls back to a default when there is no string field", () => {
+    expect(resolveEntityLabelField({ id: field("str"), score: field("float") })).toBe("name");
+    expect(resolveEntityLabelField(null)).toBe("name");
+  });
+});
+
+describe("suggestionsForField", () => {
+  it("returns distinct non-empty sorted values", () => {
+    const entities = [
+      { id: "1", record_id: "r", category: "car" },
+      { id: "2", record_id: "r", category: "bike" },
+      { id: "3", record_id: "r", category: "car" },
+      { id: "4", record_id: "r", category: "" },
+    ] as unknown as EntityRow[];
+
+    expect(suggestionsForField(entities, "category")).toEqual(["bike", "car"]);
+  });
+});
+
+describe("coerceFieldValue", () => {
+  it("coerces values to their field type", () => {
+    expect(coerceFieldValue("int", "3.7")).toBe(3);
+    expect(coerceFieldValue("float", "2.5")).toBe(2.5);
+    expect(coerceFieldValue("bool", true)).toBe(true);
+    expect(coerceFieldValue("str", 42)).toBe("42");
+    expect(coerceFieldValue("int", "")).toBe(0);
+  });
+});
+
+describe("isEntityFormValid", () => {
+  it("accepts an existing entity selection", () => {
+    expect(isEntityFormValid({ mode: "existing", entityId: "e1" }, "category")).toBe(true);
+    expect(isEntityFormValid({ mode: "existing", entityId: "" }, "category")).toBe(false);
+  });
+
+  it("requires a non-empty primary label for a new entity", () => {
+    expect(isEntityFormValid({ mode: "new", entityFields: { category: "car" } }, "category")).toBe(
+      true,
+    );
+    expect(isEntityFormValid({ mode: "new", entityFields: { category: "  " } }, "category")).toBe(
+      false,
+    );
+    expect(isEntityFormValid({ mode: "new", entityFields: {} }, "category")).toBe(false);
+  });
+});

--- a/ui/apps/web/src/lib/annotations/__tests__/payloadBuilders.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/payloadBuilders.test.ts
@@ -4,10 +4,18 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import { AnnotationCollection } from "../annotationCollection.svelte.js";
 import type { LocalBBox, LocalBBox3DAnnotation } from "../annotationCollection.svelte.js";
-import { buildDeleteMutations, payloadBuilderFor } from "../payloadBuilders.js";
+import {
+  buildDeleteMutations,
+  commitDraftWithEntity,
+  payloadBuilderFor,
+  reassignEntity,
+  type DraftCommitContext,
+  type ReassignEntityContext,
+} from "../payloadBuilders.js";
 
 const CTX = { datasetId: "ds", recordId: "rec", viewId: "view" };
 
@@ -75,11 +83,122 @@ describe("bbox3d payload builder", () => {
 });
 
 describe("buildDeleteMutations", () => {
-  it("deletes the annotation row then its parent entity", () => {
+  it("deletes only the annotation row; the orphan entity is pruned server-side", () => {
     const mutations = buildDeleteMutations(BBOX, "w1");
     expect(mutations).toEqual([
-      expect.objectContaining({ op: "delete", resource: "bboxes", id: "ann-1" }),
-      expect.objectContaining({ op: "delete", resource: "entities", id: "ent-1" }),
+      expect.objectContaining({ op: "delete", resource: "bboxes", id: "ann-1", localAnnotationId: "ann-1" }),
     ]);
+  });
+});
+
+describe("commitDraftWithEntity (shared draft-commit)", () => {
+  function makeDraft(): LocalBBox {
+    return { id: "d1", entityId: "", kind: "bbox", viewId: "view", geometry: [0, 0, 1, 1], persisted: false };
+  }
+
+  function makeCtx(collection: AnnotationCollection, findEntity = vi.fn()): DraftCommitContext {
+    return {
+      collection,
+      mutations: { queue: vi.fn() },
+      buildContext: CTX,
+      widgetId: "w1",
+      findEntity,
+      requestRedraw: vi.fn(),
+    };
+  }
+
+  it("new entity: assigns a generated id + field snapshot and queues entity + bbox creates", () => {
+    const collection = new AnnotationCollection([makeDraft()]);
+    const ctx = makeCtx(collection);
+
+    commitDraftWithEntity(collection.find("d1")!, { mode: "new", entityFields: { category: "car" } }, ctx);
+
+    const draft = collection.find("d1")!;
+    expect(draft.entityId).not.toBe("");
+    expect(draft.entity).toMatchObject({ category: "car" });
+    expect(ctx.mutations.queue).toHaveBeenCalledTimes(2); // entity + bbox
+    expect(ctx.requestRedraw).toHaveBeenCalled();
+  });
+
+  it("existing entity: reuses the id, snapshots via findEntity, and queues only the bbox create", () => {
+    const collection = new AnnotationCollection([makeDraft()]);
+    const findEntity = vi.fn().mockReturnValue({ id: "ent-9", category: "bus" });
+    const ctx = makeCtx(collection, findEntity);
+
+    commitDraftWithEntity(collection.find("d1")!, { mode: "existing", entityId: "ent-9" }, ctx);
+
+    const draft = collection.find("d1")!;
+    expect(draft.entityId).toBe("ent-9");
+    expect(draft.entity).toMatchObject({ category: "bus" });
+    expect(findEntity).toHaveBeenCalledWith("ent-9");
+    expect(ctx.mutations.queue).toHaveBeenCalledTimes(1); // bbox only; entity already exists
+  });
+});
+
+describe("reassignEntity (change a persisted annotation's entity)", () => {
+  function makePersisted(): LocalBBox3DAnnotation {
+    return {
+      id: "box-1",
+      entityId: "old-ent",
+      kind: "bbox3d",
+      viewId: "",
+      geometry: { coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd" },
+      persisted: true,
+    };
+  }
+
+  function makeCtx(collection: AnnotationCollection, findEntity = vi.fn()): ReassignEntityContext {
+    return {
+      collection,
+      mutations: { queue: vi.fn(), upsertUpdate: vi.fn() },
+      buildContext: CTX,
+      widgetId: "w1",
+      findEntity,
+      requestRedraw: vi.fn(),
+    };
+  }
+
+  it("existing entity: repoints the box and upserts a single update, no create", () => {
+    const collection = new AnnotationCollection([makePersisted()]);
+    const findEntity = vi.fn().mockReturnValue({ id: "new-ent", category: "bus" });
+    const ctx = makeCtx(collection, findEntity);
+
+    reassignEntity(collection.find("box-1")!, { mode: "existing", entityId: "new-ent" }, ctx);
+
+    expect(collection.find("box-1")!.entityId).toBe("new-ent");
+    expect(ctx.mutations.queue).not.toHaveBeenCalled();
+    expect(ctx.mutations.upsertUpdate).toHaveBeenCalledTimes(1);
+    expect(ctx.mutations.upsertUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ op: "update", resource: "bbox3ds", id: "box-1" }),
+    );
+    expect(vi.mocked(ctx.mutations.upsertUpdate).mock.calls[0][0].body).toMatchObject({ entity_id: "new-ent" });
+  });
+
+  it("new entity: queues an entity create + the box update with the generated id", () => {
+    const collection = new AnnotationCollection([makePersisted()]);
+    const ctx = makeCtx(collection);
+
+    reassignEntity(collection.find("box-1")!, { mode: "new", entityFields: { category: "car" } }, ctx);
+
+    const box = collection.find("box-1")!;
+    expect(box.entityId).not.toBe("old-ent");
+    expect(box.entity).toMatchObject({ category: "car" });
+    expect(ctx.mutations.queue).toHaveBeenCalledTimes(1); // the new entity create
+    expect(ctx.mutations.queue).toHaveBeenCalledWith(
+      expect.objectContaining({ op: "create", resource: "entities" }),
+    );
+    expect(ctx.mutations.upsertUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a non-persisted (draft) annotation", () => {
+    const draft = { ...makePersisted(), persisted: false };
+    const collection = new AnnotationCollection([draft]);
+    const ctx = makeCtx(collection);
+
+    reassignEntity(collection.find("box-1")!, { mode: "existing", entityId: "new-ent" }, ctx);
+
+    expect(ctx.mutations.queue).not.toHaveBeenCalled();
+    expect(ctx.mutations.upsertUpdate).not.toHaveBeenCalled();
+    expect(collection.find("box-1")!.entityId).toBe("old-ent");
   });
 });

--- a/ui/apps/web/src/lib/annotations/annotationCollection.svelte.ts
+++ b/ui/apps/web/src/lib/annotations/annotationCollection.svelte.ts
@@ -98,6 +98,8 @@ export interface AnnotationStore {
   remove(id: string): void;
   select(id: string | null): void;
   setGeometry<G>(id: string, geometry: G): void;
+  /** Assign the annotation's parent entity (id + optional label snapshot). */
+  setEntity(id: string, entityId: string, entity?: Record<string, unknown>): void;
 }
 
 /**
@@ -146,6 +148,14 @@ export class AnnotationCollection implements AnnotationStore {
   setGeometry<G>(id: string, geometry: G): void {
     const annotation = this.find(id);
     if (annotation) annotation.geometry = geometry;
+  }
+
+  setEntity(id: string, entityId: string, entity?: Record<string, unknown>): void {
+    const annotation = this.find(id);
+    if (annotation) {
+      annotation.entityId = entityId;
+      annotation.entity = entity;
+    }
   }
 }
 
@@ -211,5 +221,9 @@ export class ViewScopedAnnotations implements AnnotationStore {
 
   setGeometry<G>(id: string, geometry: G): void {
     this.getParent().setGeometry(id, geometry);
+  }
+
+  setEntity(id: string, entityId: string, entity?: Record<string, unknown>): void {
+    this.getParent().setEntity(id, entityId, entity);
   }
 }

--- a/ui/apps/web/src/lib/annotations/buildPayloads.ts
+++ b/ui/apps/web/src/lib/annotations/buildPayloads.ts
@@ -39,6 +39,33 @@ export interface BuildBBoxResult {
 }
 
 /**
+ * Options shared by the 2D and 3D box-create builders.
+ *
+ *  - `entityFields` are merged into the new entity's body (e.g. `{ category }`).
+ *  - `linkExisting` attaches the box to an entity that already exists: the
+ *    entity-create mutation is omitted and `entityId` must be supplied.
+ */
+export interface BuildBBoxOpts {
+  widgetId?: string;
+  localAnnotationId?: string;
+  entityId?: string;
+  bboxId?: string;
+  entityFields?: Record<string, unknown>;
+  linkExisting?: boolean;
+}
+
+/**
+ * The entity decision threaded from the Inspector form to a kind's create
+ * builder: merge `entityFields` into a new entity, or `linkExisting` to attach
+ * the box to an already-existing entity (the annotation's `entityId`) and skip
+ * the entity-create. Empty `{}` means "new anonymous entity".
+ */
+export interface EntityCreateChoice {
+  entityFields?: Record<string, unknown>;
+  linkExisting?: boolean;
+}
+
+/**
  * Default annotation source metadata. Matches `PIXANO_SOURCE` in the legacy
  * pixano UI (`apps/pixano/src/lib/utils/entityLookupUtils.ts`) — using
  * `"other"` as the source type so we don't imply ground-truth provenance for
@@ -49,6 +76,28 @@ const DEFAULT_SOURCE = {
   source_name: "Pixano",
   source_metadata: "{}",
 } as const;
+
+/**
+ * The create mutation for a new entity. Entities carry only
+ * `{ id, record_id, parent_id }` plus any user-supplied fields (the `Entity`
+ * schema rejects unknown columns). Shared by every kind's create builder and by
+ * the entity-reassignment flow, so the entity body lives in exactly one place.
+ */
+export function buildEntityCreateMutation(
+  ctx: BuildContext,
+  entityId: string,
+  entityFields: Record<string, unknown> | undefined,
+  widgetId: string | undefined,
+  localAnnotationId: string | undefined,
+): ResourceMutation {
+  return {
+    op: "create",
+    resource: ENTITY_RESOURCE,
+    body: { id: entityId, record_id: ctx.recordId, parent_id: "", ...entityFields },
+    widgetId,
+    localAnnotationId,
+  };
+}
 
 /**
  * Build the (entity, bbox) create mutation pair for a new 2D box annotation.
@@ -64,16 +113,10 @@ const DEFAULT_SOURCE = {
 export function buildBBoxCreate(
   ctx: BuildContext,
   coordsNorm: CoordsNorm,
-  opts: { widgetId?: string; localAnnotationId?: string; entityId?: string; bboxId?: string } = {},
+  opts: BuildBBoxOpts = {},
 ): BuildBBoxResult {
   const entityId = opts.entityId ?? generateShortId();
   const bboxId = opts.bboxId ?? generateShortId();
-
-  const entityBody: Record<string, unknown> = {
-    id: entityId,
-    record_id: ctx.recordId,
-    parent_id: "",
-  };
 
   const bboxBody: Record<string, unknown> = {
     id: bboxId,
@@ -95,13 +138,11 @@ export function buildBBoxCreate(
   };
 
   const mutations: ResourceMutation[] = [
-    {
-      op: "create",
-      resource: ENTITY_RESOURCE,
-      body: entityBody,
-      widgetId: opts.widgetId,
-      localAnnotationId: opts.localAnnotationId,
-    },
+    // `linkExisting` attaches the box to an entity that already exists, so the
+    // entity-create is skipped (the chosen entityId is supplied in opts).
+    ...(opts.linkExisting
+      ? []
+      : [buildEntityCreateMutation(ctx, entityId, opts.entityFields, opts.widgetId, opts.localAnnotationId)]),
     {
       op: "create",
       resource: BBOX_RESOURCE,
@@ -169,22 +210,10 @@ export function buildBBox3DUpdate(
 export function buildBBox3DCreate(
   ctx: BuildContext,
   coordsLance: [number, number, number, number, number, number],
-  opts: {
-    widgetId?: string;
-    localAnnotationId?: string;
-    entityId?: string;
-    bboxId?: string;
-    rotation?: number[];
-  } = {},
+  opts: BuildBBoxOpts & { rotation?: number[] } = {},
 ): BuildBBoxResult {
   const entityId = opts.entityId ?? generateShortId();
   const bboxId = opts.bboxId ?? generateShortId();
-
-  const entityBody: Record<string, unknown> = {
-    id: entityId,
-    record_id: ctx.recordId,
-    parent_id: "",
-  };
 
   const bboxBody: Record<string, unknown> = {
     ...buildBBox3DUpdate(ctx, bboxId, entityId, coordsLance, opts.rotation),
@@ -195,13 +224,9 @@ export function buildBBox3DCreate(
   };
 
   const mutations: ResourceMutation[] = [
-    {
-      op: "create",
-      resource: ENTITY_RESOURCE,
-      body: entityBody,
-      widgetId: opts.widgetId,
-      localAnnotationId: opts.localAnnotationId,
-    },
+    ...(opts.linkExisting
+      ? []
+      : [buildEntityCreateMutation(ctx, entityId, opts.entityFields, opts.widgetId, opts.localAnnotationId)]),
     {
       op: "create",
       resource: BBOX3D_RESOURCE,

--- a/ui/apps/web/src/lib/annotations/entityFeatures.ts
+++ b/ui/apps/web/src/lib/annotations/entityFeatures.ts
@@ -1,0 +1,149 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import type { PendingEntityChoice } from "./types.js";
+import type { EntityRow } from "$lib/api/annotations.js";
+import type { FieldInfo } from "$lib/types/dataset.js";
+
+/**
+ * Generate and validate the per-field inputs of the "create entity" form from
+ * the dataset's entity table schema. This is the apps/web port of pixano's
+ * `getValidationSchemaAndFormInputs` (`apps/pixano/src/lib/utils/featureMapping.ts`)
+ * and `getDefaultDisplayFeat`, adapted to the workspace's `entitySchemaFields`.
+ */
+
+/** Editable scalar field types we render an input for. */
+export type EntityFeatureType = "str" | "int" | "float" | "bool" | "list";
+
+export interface EntityFeatureInput {
+  name: string;
+  label: string;
+  type: EntityFeatureType;
+  /** Allowed values for `list` fields (none known from the schema yet). */
+  options?: string[];
+}
+
+/**
+ * Entity columns that are structural/linkage rather than user-facing features.
+ * The apps/web analogue of pixano's `Entity.nonFeaturesFields()`.
+ */
+export const ENTITY_SYSTEM_FIELDS = new Set<string>([
+  "id",
+  "record_id",
+  "parent_id",
+  "item_id",
+  "logical_name",
+  "created_at",
+  "updated_at",
+]);
+
+const SUPPORTED_FEATURE_TYPES = new Set<EntityFeatureType>(["str", "int", "float", "bool", "list"]);
+
+/** Priority of fields treated as the entity's primary display label. */
+const LABEL_FIELD_PRIORITY = ["category", "label", "name", "class"] as const;
+
+const FALLBACK_LABEL_FIELD = "name";
+
+/**
+ * Build the ordered list of feature inputs for a new entity from its schema
+ * fields, skipping system/linkage columns and unsupported types.
+ */
+export function buildEntityFeatureInputs(
+  fields: Record<string, FieldInfo> | null | undefined,
+): EntityFeatureInput[] {
+  if (!fields) return [];
+  const inputs: EntityFeatureInput[] = [];
+  for (const [name, info] of Object.entries(fields)) {
+    if (ENTITY_SYSTEM_FIELDS.has(name)) continue;
+    if (info.collection) continue;
+    const type = info.type as EntityFeatureType;
+    if (!SUPPORTED_FEATURE_TYPES.has(type)) continue;
+    inputs.push({ name, label: name, type, ...(type === "list" ? { options: [] } : {}) });
+  }
+  return inputs;
+}
+
+/**
+ * Pick the field that holds an entity's human-readable label. Mirrors the read
+ * side (`pickEntityLabel` / `EntitiesPanel.resolveCategory`): a known label
+ * field if present as a string, else the first string field, else a fallback.
+ */
+export function resolveEntityLabelField(
+  fields: Record<string, FieldInfo> | null | undefined,
+): string {
+  if (!fields) return FALLBACK_LABEL_FIELD;
+  const isWritableString = (name: string): boolean =>
+    !ENTITY_SYSTEM_FIELDS.has(name) && fields[name]?.type === "str" && !fields[name]?.collection;
+
+  for (const candidate of LABEL_FIELD_PRIORITY) {
+    if (isWritableString(candidate)) return candidate;
+  }
+  for (const name of Object.keys(fields)) {
+    if (isWritableString(name)) return name;
+  }
+  return FALLBACK_LABEL_FIELD;
+}
+
+/**
+ * Distinct non-empty string values already used for `fieldName` across the
+ * record's entities. Powers free-text autocomplete suggestions — the apps/web
+ * substitute for pixano's `itemMetas.featuresList`.
+ */
+export function suggestionsForField(entities: EntityRow[], fieldName: string): string[] {
+  const seen = new Set<string>();
+  for (const entity of entities) {
+    const value = entity[fieldName];
+    if (typeof value === "string" && value.trim().length > 0) seen.add(value);
+  }
+  return Array.from(seen).sort((a, b) => a.localeCompare(b));
+}
+
+/** Default value for a freshly added feature input, by type. */
+export function defaultFieldValue(type: EntityFeatureType): string | number | boolean {
+  switch (type) {
+    case "bool":
+      return false;
+    case "int":
+    case "float":
+      return 0;
+    case "str":
+    case "list":
+      return "";
+  }
+}
+
+/** Coerce a raw form value into the type expected by the backend field. */
+export function coerceFieldValue(type: EntityFeatureType, raw: unknown): string | number | boolean {
+  switch (type) {
+    case "bool":
+      return Boolean(raw);
+    case "int": {
+      const n = Math.trunc(Number(raw));
+      return Number.isFinite(n) ? n : 0;
+    }
+    case "float": {
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : 0;
+    }
+    case "str":
+    case "list":
+      if (typeof raw === "string") return raw;
+      if (typeof raw === "number" || typeof raw === "boolean") return String(raw);
+      return "";
+  }
+}
+
+/**
+ * Light validity check for the entity form. Linking to an existing entity is
+ * always valid; a new entity must at least have a non-empty primary label so it
+ * is not anonymous. (The schema carries no `required` info — pixano has the same
+ * limitation, see its `required: false` TODO.)
+ */
+export function isEntityFormValid(choice: PendingEntityChoice, labelField: string): boolean {
+  if (choice.mode === "existing") return choice.entityId.length > 0;
+  const label = choice.entityFields[labelField];
+  return typeof label === "string" && label.trim().length > 0;
+}

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/drawBBoxTool.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/drawBBoxTool.test.ts
@@ -80,6 +80,9 @@ function makeHarness(opts: { image?: Konva.Image | null } = {}) {
     getKonvaImage: () => ("image" in opts ? (opts.image ?? null) : fakeImage()),
     setActiveTool: vi.fn(),
     requestRedraw: vi.fn(),
+    beginPendingAnnotation: vi.fn(),
+    findEntity: vi.fn(),
+    isEntityVisible: () => true,
   };
   return { ctx, collection, setPointer: (p: { x: number; y: number } | null) => (pointer = p) };
 }
@@ -115,21 +118,54 @@ describe("drawBBoxTool", () => {
     handler = drawBBoxTool.createHandler(harness.ctx);
   });
 
-  it("commits a normalized bbox + queues the entity/bbox create pair, then hands back to select", () => {
+  it("adds a draft (no entity yet), selects it, and opens the entity-assignment flow", () => {
     drag(handler, harness.setPointer, { x: 10, y: 20 }, { x: 60, y: 80 });
 
     expect(harness.collection.count).toBe(1);
     const bbox = harness.collection.items[0];
-    expect(bbox).toMatchObject({ kind: "bbox", viewId: "view-1", persisted: false });
+    expect(bbox).toMatchObject({ kind: "bbox", viewId: "view-1", persisted: false, entityId: "" });
     // (10,20)→(60,80) on a 100×100 frame at origin → x,y,w,h normalized.
     expect(bbox.geometry as CoordsNorm).toEqual([0.1, 0.2, 0.5, 0.6]);
 
-    // entity create + bbox create.
-    expect(harness.ctx.mutations.queue).toHaveBeenCalledTimes(2);
-    // The freshly drawn box is selected and the tool returns to select.
+    // The draft is shown immediately; nothing is queued until the user confirms.
+    expect(harness.ctx.mutations.queue).not.toHaveBeenCalled();
     expect(harness.collection.selectedId).toBe(bbox.id);
     expect(harness.ctx.setActiveTool).toHaveBeenCalledWith("select");
-    expect(harness.ctx.requestRedraw).toHaveBeenCalled();
+    expect(harness.ctx.beginPendingAnnotation).toHaveBeenCalledTimes(1);
+  });
+
+  it("on confirm with a new entity, sets the entityId and queues the entity + bbox creates", () => {
+    drag(handler, harness.setPointer, { x: 10, y: 20 }, { x: 60, y: 80 });
+    const pending = vi.mocked(harness.ctx.beginPendingAnnotation).mock.calls[0][0];
+
+    pending.onConfirm({ mode: "new", entityFields: { category: "car" } });
+
+    const bbox = harness.collection.items[0];
+    expect(bbox.entityId).not.toBe("");
+    expect(bbox.entity).toMatchObject({ category: "car" });
+    expect(harness.ctx.mutations.queue).toHaveBeenCalledTimes(2); // entity + bbox
+  });
+
+  it("on confirm linking an existing entity, reuses its id and queues only the bbox create", () => {
+    vi.mocked(harness.ctx.findEntity).mockReturnValue({ id: "ent-9", category: "bus" });
+    drag(handler, harness.setPointer, { x: 10, y: 20 }, { x: 60, y: 80 });
+    const pending = vi.mocked(harness.ctx.beginPendingAnnotation).mock.calls[0][0];
+
+    pending.onConfirm({ mode: "existing", entityId: "ent-9" });
+
+    const bbox = harness.collection.items[0];
+    expect(bbox.entityId).toBe("ent-9");
+    expect(harness.ctx.mutations.queue).toHaveBeenCalledTimes(1); // bbox only; entity already exists
+  });
+
+  it("on cancel, discards the draft", () => {
+    drag(handler, harness.setPointer, { x: 10, y: 20 }, { x: 60, y: 80 });
+    const pending = vi.mocked(harness.ctx.beginPendingAnnotation).mock.calls[0][0];
+
+    pending.onCancel();
+
+    expect(harness.collection.count).toBe(0);
+    expect(harness.ctx.mutations.queue).not.toHaveBeenCalled();
   });
 
   it("clamps a box drawn partly outside the image to the frame", () => {

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxPayloadBuilder.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxPayloadBuilder.ts
@@ -5,7 +5,12 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { BBoxGeometry, LocalAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
-import { buildBBoxCreate, buildBBoxUpdate, type BuildContext } from "$lib/annotations/buildPayloads.js";
+import {
+  buildBBoxCreate,
+  buildBBoxUpdate,
+  type BuildContext,
+  type EntityCreateChoice,
+} from "$lib/annotations/buildPayloads.js";
 import type { ResourceMutation } from "$lib/annotations/types.js";
 import { BBOX_RESOURCE } from "$lib/api/resourceNames.js";
 
@@ -24,12 +29,15 @@ export const bboxPayloadBuilder = {
     ctx: BuildContext,
     annotation: LocalAnnotation<BBoxGeometry>,
     widgetId: string,
+    entity: EntityCreateChoice = {},
   ): ResourceMutation[] {
     return buildBBoxCreate(ctx, annotation.geometry, {
       widgetId,
       localAnnotationId: annotation.id,
       entityId: annotation.entityId,
       bboxId: annotation.id,
+      entityFields: entity.entityFields,
+      linkExisting: entity.linkExisting,
     }).mutations;
   },
 

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxRenderer2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxRenderer2D.ts
@@ -43,6 +43,10 @@ class BBoxRenderer2D implements AnnotationRenderer2D {
     const activeIds = new Set<string>();
 
     for (const bbox of this.ctx.collection.byKind("bbox")) {
+      // Entity-driven visibility: a persisted box whose entity is hidden gets
+      // no node, so it is invisible AND non-clickable/non-editable. Drafts
+      // (still being created) are always shown.
+      if (bbox.persisted && !this.ctx.isEntityVisible(bbox.entityId)) continue;
       activeIds.add(bbox.id);
       let rect = this.rectByBBoxId.get(bbox.id);
       if (!rect) {

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/drawBBoxTool.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/drawBBoxTool.ts
@@ -7,7 +7,9 @@ License: CECILL-C
 import Konva from "konva";
 import { Square } from "lucide-svelte";
 
-import { commitNewAnnotation } from "$lib/annotations/payloadBuilders.js";
+import type { LocalBBox } from "$lib/annotations/annotationCollection.svelte.js";
+import { generateShortId } from "$lib/annotations/buildPayloads.js";
+import { commitDraftWithEntity } from "$lib/annotations/payloadBuilders.js";
 import {
   BBOX_COLOR_DRAFT,
   getPixelFrame,
@@ -15,11 +17,7 @@ import {
   pixelToNormalized,
 } from "$lib/annotations/scene/scene2dGeometry.js";
 import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
-import {
-  DEFAULT_TOOL_2D,
-  type Tool2D,
-  type ToolHandler2D,
-} from "$lib/annotations/scene/tool.js";
+import { DEFAULT_TOOL_2D, type Tool2D, type ToolHandler2D } from "$lib/annotations/scene/tool.js";
 
 /**
  * Rubber-band bbox drawing. Pointer down anchors a corner, move stretches
@@ -97,10 +95,31 @@ class DrawBBoxHandler implements ToolHandler2D {
 
     const coordsNorm = pixelToNormalized(clampedLeft, clampedTop, clampedW, clampedH, frame);
 
-    const bbox = commitNewAnnotation(this.ctx, "bbox", coordsNorm);
-
+    // Show the box right away as an unsaved draft; its entity (and the create
+    // mutations) are assigned once the user confirms in the Inspector form.
+    const bbox: LocalBBox = {
+      id: generateShortId(),
+      entityId: "",
+      kind: "bbox",
+      viewId: this.ctx.buildContext.viewId,
+      geometry: coordsNorm,
+      persisted: false,
+    };
+    this.ctx.collection.add(bbox);
     this.ctx.setActiveTool(DEFAULT_TOOL_2D);
     this.ctx.collection.select(bbox.id);
+    this.ctx.requestRedraw();
+
+    this.ctx.beginPendingAnnotation({
+      label: "box",
+      onConfirm: (choice) => commitDraftWithEntity(bbox, choice, this.ctx),
+      onCancel: () => this._discardDraft(bbox.id),
+    });
+  }
+
+  /** Remove an unconfirmed draft box (user cancelled the entity form). */
+  private _discardDraft(localId: string): void {
+    this.ctx.collection.remove(localId);
     this.ctx.requestRedraw();
   }
 

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DHud.svelte
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DHud.svelte
@@ -7,10 +7,9 @@ License: CECILL-C
 <script lang="ts">
   import { Move, Orbit, Scaling } from "lucide-svelte";
 
-  import type { ToolHudProps } from "$lib/annotations/scene/tool.js";
-
   import type { BBox3DSession } from "./bbox3dSession.svelte.js";
   import type { GizmoVisibility } from "./bbox3dTypes.js";
+  import type { ToolHudProps } from "$lib/annotations/scene/tool.js";
 
   // The host forwards the session opaquely (it names no kind); downcast here.
   // The prop is a stable per-widget instance, so capturing it once is intended.
@@ -45,13 +44,38 @@ License: CECILL-C
       >
         Cancel
       </button>
+      {#if session.editingPersisted}
+        <button
+          type="button"
+          onclick={() => session.changeEntity()}
+          title="Attach this 3D box to a different entity"
+          class="rounded border border-border px-2.5 py-1 text-xs hover:bg-accent"
+        >
+          Change entity
+        </button>
+      {/if}
+      {#if session.confirm.editingId}
+        <button
+          type="button"
+          onclick={() => session.deleteBox()}
+          title="Delete this 3D box"
+          class="rounded border border-destructive/40 px-2.5 py-1 text-xs text-destructive hover:bg-destructive hover:text-destructive-foreground"
+        >
+          Delete
+        </button>
+      {/if}
       <div class="mx-1 h-4 w-px bg-border"></div>
       {#each GIZMO_TOGGLES as toggle (toggle.key)}
         <button
           type="button"
           onclick={() => session.toggleGizmo(toggle.key)}
-          title={session.gizmoVisibility[toggle.key] ? `Hide ${toggle.label}` : `Show ${toggle.label}`}
-          class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {session.gizmoVisibility[toggle.key] ? 'bg-accent text-accent-foreground' : ''}"
+          title={session.gizmoVisibility[toggle.key]
+            ? `Hide ${toggle.label}`
+            : `Show ${toggle.label}`}
+          class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {session
+            .gizmoVisibility[toggle.key]
+            ? 'bg-accent text-accent-foreground'
+            : ''}"
         >
           <toggle.icon class="h-3.5 w-3.5" />
         </button>

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DRenderer.svelte
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DRenderer.svelte
@@ -35,6 +35,10 @@ License: CECILL-C
     ctx.collection
       .byKind("bbox3d")
       .filter((a) => a.id !== ctx.editingId)
+      // Entity-driven visibility: a persisted box whose entity is hidden gets no
+      // wireframe; drafts (still being created) always show. Same filter the 2D
+      // bbox renderer applies.
+      .filter((a) => !a.persisted || ctx.isEntityVisible(a.entityId))
       .map((a) => {
         const t = bboxTransform(a.geometry);
         const q = t.quaternion;
@@ -43,11 +47,11 @@ License: CECILL-C
           position: t.position,
           quaternionArr: [q.x, q.y, q.z, q.w] as [number, number, number, number],
           size: t.size,
-          labelPos: [t.position[0], t.position[1] + t.size[1] / 2 + LABEL_OFFSET, t.position[2]] as [
-            number,
-            number,
-            number,
-          ],
+          labelPos: [
+            t.position[0],
+            t.position[1] + t.size[1] / 2 + LABEL_OFFSET,
+            t.position[2],
+          ] as [number, number, number],
           label: pickEntityLabel(a.entity),
         };
       }),

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSession.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSession.test.ts
@@ -6,14 +6,13 @@ License: CECILL-C
 
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { BBox3DSession } from "../bbox3dSession.svelte.js";
 import {
   AnnotationCollection,
   type BBox3DGeometry,
 } from "$lib/annotations/annotationCollection.svelte.js";
 import type { SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
-import type { ResourceMutation } from "$lib/annotations/types.js";
-
-import { BBox3DSession } from "../bbox3dSession.svelte.js";
+import type { PendingAnnotation, ResourceMutation } from "$lib/annotations/types.js";
 
 const COORDS: [number, number, number, number, number, number] = [1, 2, 3, 4, 5, 6];
 const ROTATION = [1, 0, 0, 0, 1, 0, 0, 0, 1];
@@ -22,6 +21,8 @@ function makeSeam() {
   const collection = new AnnotationCollection();
   const queued: ResourceMutation[] = [];
   const updates: Extract<ResourceMutation, { op: "update" }>[] = [];
+  const entities: Record<string, Record<string, unknown>> = {};
+  let pending: PendingAnnotation | null = null;
   const seam: SceneContextBase = {
     widgetId: "w1",
     buildContext: { datasetId: "ds", recordId: "rec", viewId: "v1" },
@@ -37,8 +38,11 @@ function makeSeam() {
     },
     setActiveTool: () => {},
     requestRedraw: () => {},
+    beginPendingAnnotation: (p) => (pending = p),
+    findEntity: (id) => entities[id],
+    isEntityVisible: () => true,
   };
-  return { seam, collection, queued, updates };
+  return { seam, collection, queued, updates, entities, getPending: () => pending };
 }
 
 describe("BBox3DSession", () => {
@@ -59,16 +63,23 @@ describe("BBox3DSession", () => {
     expect(session.confirm).toBeNull();
   });
 
-  it("save() on a new draft commits a create, clears confirm and resets the editor", () => {
+  it("save() on a new draft stages an unsaved box and defers the create to entity confirm", () => {
     session.reportReady(COORDS, ROTATION);
     session.save();
 
+    // The box is shown right away as an unsaved draft with no entity yet, but no
+    // mutations are queued until the user confirms the entity in the Inspector.
     expect(env.collection.count).toBe(1);
     expect(env.collection.items[0].kind).toBe("bbox3d");
     expect(env.collection.items[0].persisted).toBe(false);
-    expect(env.queued.map((m) => m.resource)).toEqual(["entities", "bbox3ds"]);
+    expect(env.collection.items[0].entityId).toBe("");
+    expect(env.queued).toHaveLength(0);
     expect(session.confirm).toBeNull();
     expect(resetCalls).toBe(1);
+
+    // Confirming with a new entity queues the entity + bbox creates.
+    env.getPending()!.onConfirm({ mode: "new", entityFields: { category: "car" } });
+    expect(env.queued.map((m) => m.resource)).toEqual(["entities", "bbox3ds"]);
   });
 
   it("save() on an edit commits an update to the existing box", () => {
@@ -77,7 +88,11 @@ describe("BBox3DSession", () => {
       entityId: "e1",
       kind: "bbox3d",
       viewId: "v1",
-      geometry: { coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd", rotation: ROTATION } as BBox3DGeometry,
+      geometry: {
+        coords: [0, 0, 0, 1, 1, 1],
+        format: "xyzwhd",
+        rotation: ROTATION,
+      } as BBox3DGeometry,
       persisted: true,
     });
     session.reportReady(COORDS, ROTATION, "b1");

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dPayloadBuilder.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dPayloadBuilder.ts
@@ -9,6 +9,7 @@ import {
   buildBBox3DCreate,
   buildBBox3DUpdate,
   type BuildContext,
+  type EntityCreateChoice,
 } from "$lib/annotations/buildPayloads.js";
 import type { ResourceMutation } from "$lib/annotations/types.js";
 import { BBOX3D_RESOURCE } from "$lib/api/resourceNames.js";
@@ -28,6 +29,7 @@ export const bbox3dPayloadBuilder = {
     ctx: BuildContext,
     annotation: LocalAnnotation<BBox3DGeometry>,
     widgetId: string,
+    entity: EntityCreateChoice = {},
   ): ResourceMutation[] {
     return buildBBox3DCreate(ctx, annotation.geometry.coords, {
       widgetId,
@@ -35,6 +37,8 @@ export const bbox3dPayloadBuilder = {
       entityId: annotation.entityId,
       bboxId: annotation.id,
       rotation: annotation.geometry.rotation,
+      entityFields: entity.entityFields,
+      linkExisting: entity.linkExisting,
     }).mutations;
   },
 

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dSession.svelte.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dSession.svelte.ts
@@ -4,11 +4,19 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { BBox3DGeometry } from "$lib/annotations/annotationCollection.svelte.js";
-import { commitGeometryEdit, commitNewAnnotation } from "$lib/annotations/payloadBuilders.js";
-import type { SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
-
 import type { GizmoVisibility } from "./bbox3dTypes.js";
+import type {
+  BBox3DGeometry,
+  LocalBBox3DAnnotation,
+} from "$lib/annotations/annotationCollection.svelte.js";
+import { generateShortId } from "$lib/annotations/buildPayloads.js";
+import {
+  commitDraftWithEntity,
+  commitGeometryEdit,
+  deleteLocalAnnotation,
+  reassignEntity,
+} from "$lib/annotations/payloadBuilders.js";
+import type { SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
 
 /** A 3D box the editor has staged and is waiting for the user to confirm. */
 export interface PendingConfirm {
@@ -55,6 +63,17 @@ export class BBox3DSession {
     this.confirm = null;
   }
 
+  /**
+   * The persisted annotation the confirm currently targets, if any. The HUD
+   * consults it to offer entity reassignment (only meaningful once the box has
+   * been saved and thus has an entity to move away from).
+   */
+  get editingPersisted(): boolean {
+    const editingId = this.confirm?.editingId;
+    if (!editingId) return false;
+    return this.seam.collection.find(editingId)?.persisted ?? false;
+  }
+
   /** Commit the pending draft (create or edit) through the shared helpers. */
   save(): void {
     const pending = this.confirm;
@@ -66,9 +85,67 @@ export class BBox3DSession {
       format: "xyzwhd",
       rotation: pending.rotation,
     };
-    if (pending.editingId) commitGeometryEdit(this.seam, pending.editingId, geometry);
-    else commitNewAnnotation(this.seam, "bbox3d", geometry);
 
+    if (pending.editingId) {
+      commitGeometryEdit(this.seam, pending.editingId, geometry);
+      this.resetEditor();
+      return;
+    }
+
+    // New box: show it right away as an unsaved draft, but defer its entity (and
+    // the create mutations) until the user confirms the entity in the Inspector
+    // form. Mirrors the 2D draw tool so both kinds share one commit path.
+    const draft: LocalBBox3DAnnotation = {
+      id: generateShortId(),
+      entityId: "",
+      kind: "bbox3d",
+      viewId: this.seam.buildContext.viewId,
+      geometry,
+      persisted: false,
+    };
+    this.seam.collection.add(draft);
+    this.seam.requestRedraw();
+    this.seam.beginPendingAnnotation({
+      label: "3D box",
+      onConfirm: (choice) => commitDraftWithEntity(draft, choice, this.seam),
+      onCancel: () => this.seam.collection.remove(draft.id),
+    });
+    this.resetEditor();
+  }
+
+  /**
+   * Reassign the box currently being edited to a different entity: reuse the
+   * Inspector's entity picker, then move the box on confirm. The backend prunes
+   * the previously attached entity if this leaves it orphaned.
+   */
+  changeEntity(): void {
+    const editingId = this.confirm?.editingId;
+    if (!editingId) return;
+    const annotation = this.seam.collection.find(editingId);
+    if (!annotation || !annotation.persisted) return;
+    this.confirm = null;
+    this.seam.beginPendingAnnotation({
+      label: "3D box entity",
+      onConfirm: (choice) => reassignEntity(annotation, choice, this.seam),
+      onCancel: () => {},
+    });
+    this.resetEditor();
+  }
+
+  /** Delete the box currently being edited (its orphaned entity is pruned server-side). */
+  deleteBox(): void {
+    const editingId = this.confirm?.editingId;
+    if (!editingId) return;
+    const annotation = this.seam.collection.find(editingId);
+    if (annotation) {
+      deleteLocalAnnotation(
+        annotation,
+        this.seam.collection,
+        this.seam.mutations,
+        this.seam.widgetId,
+      );
+    }
+    this.confirm = null;
     this.resetEditor();
   }
 

--- a/ui/apps/web/src/lib/annotations/payloadBuilders.ts
+++ b/ui/apps/web/src/lib/annotations/payloadBuilders.ts
@@ -4,18 +4,17 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { ENTITY_RESOURCE } from "$lib/api/resourceNames.js";
-
 import type {
   AnnotationKind,
   AnnotationStore,
   LocalAnnotation,
 } from "./annotationCollection.svelte.js";
-import { generateShortId, type BuildContext } from "./buildPayloads.js";
+import { buildEntityCreateMutation, generateShortId } from "./buildPayloads.js";
+import type { BuildContext, EntityCreateChoice } from "./buildPayloads.js";
 import { bboxPayloadBuilder } from "./kinds/2d/bbox/bboxPayloadBuilder.js";
 import { bbox3dPayloadBuilder } from "./kinds/3d/bbox3d/bbox3dPayloadBuilder.js";
 import type { MutationSink } from "./scene/sceneContext.js";
-import type { ResourceMutation } from "./types.js";
+import type { PendingEntityChoice, ResourceMutation } from "./types.js";
 
 /**
  * Per-kind knowledge of how a `LocalAnnotation` becomes backend payloads.
@@ -26,8 +25,17 @@ export interface PayloadBuilder<G = unknown> {
   kind: AnnotationKind;
   /** Backend collection name, e.g. "bboxes". */
   resource: string;
-  /** Mutations creating the annotation and its parent entity. */
-  buildCreate(ctx: BuildContext, annotation: LocalAnnotation<G>, widgetId: string): ResourceMutation[];
+  /**
+   * Mutations creating the annotation and its parent entity. `entity` carries
+   * the user's entity choice (new fields, or link-existing to skip the
+   * entity-create); omitted means a new anonymous entity.
+   */
+  buildCreate(
+    ctx: BuildContext,
+    annotation: LocalAnnotation<G>,
+    widgetId: string,
+    entity?: EntityCreateChoice,
+  ): ResourceMutation[];
   /** Update body for an existing annotation whose geometry changed. */
   buildUpdate(ctx: BuildContext, annotation: LocalAnnotation<G>): Record<string, unknown>;
 }
@@ -92,11 +100,7 @@ export function commitNewAnnotation<G>(
  * which is a superset of the create body's geometry fields, so patching a
  * pending create with it only changes the geometry.
  */
-export function commitGeometryEdit<G>(
-  ctx: CommitContext,
-  annotationId: string,
-  geometry: G,
-): void {
+export function commitGeometryEdit<G>(ctx: CommitContext, annotationId: string, geometry: G): void {
   const annotation = ctx.collection.find(annotationId);
   if (!annotation) return;
   ctx.collection.setGeometry(annotationId, geometry);
@@ -123,9 +127,11 @@ export function commitGeometryEdit<G>(
 }
 
 /**
- * Delete mutations for a persisted annotation: the annotation row plus its
- * parent entity. Kind-agnostic — only the resource name comes from the
- * kind's builder.
+ * Delete mutation for a persisted annotation: just the annotation row. The
+ * parent entity is pruned server-side when this was its last annotation (the
+ * backend is the only place that sees every annotation referencing the
+ * entity); the API delete opts in via `?prune_orphan_entity=true`. Kind-agnostic
+ * — only the resource name comes from the kind's builder.
  */
 export function buildDeleteMutations(
   annotation: LocalAnnotation,
@@ -134,13 +140,6 @@ export function buildDeleteMutations(
   const { resource } = payloadBuilderFor(annotation.kind);
   return [
     { op: "delete", resource, id: annotation.id, widgetId, localAnnotationId: annotation.id },
-    {
-      op: "delete",
-      resource: ENTITY_RESOURCE,
-      id: annotation.entityId,
-      widgetId,
-      localAnnotationId: annotation.id,
-    },
   ];
 }
 
@@ -161,4 +160,113 @@ export function deleteLocalAnnotation(
     mutations.dropForLocalAnnotation(annotation.id);
   }
   collection.remove(annotation.id);
+}
+
+/**
+ * The dependencies a draft-commit needs, satisfied as-is by `Scene2DContext`
+ * (the 2D tool passes itself) and assembled from the manager by 3D widgets.
+ */
+export interface DraftCommitContext {
+  readonly collection: AnnotationStore;
+  readonly mutations: Pick<MutationSink, "queue">;
+  readonly buildContext: BuildContext;
+  readonly widgetId: string;
+  /** Resolve an existing entity row for the annotation's label snapshot. */
+  findEntity(entityId: string): Record<string, unknown> | undefined;
+  /** Optional: nudge the renderer after the entity/label changes (2D). */
+  requestRedraw?(): void;
+}
+
+/**
+ * Kind-agnostic commit of a freshly drawn draft once the user has picked its
+ * entity in the Inspector form: assign the entity (new id + snapshot, or link
+ * an existing one), then queue the kind's create mutations. Mirrors
+ * `deleteLocalAnnotation` so every drawable kind shares one commit path
+ * instead of re-implementing it in its tool/widget.
+ */
+export function commitDraftWithEntity(
+  annotation: LocalAnnotation,
+  choice: PendingEntityChoice,
+  ctx: DraftCommitContext,
+): void {
+  const builder = payloadBuilderFor(annotation.kind);
+
+  if (choice.mode === "existing") {
+    ctx.collection.setEntity(annotation.id, choice.entityId, ctx.findEntity(choice.entityId));
+  } else {
+    const entityId = generateShortId();
+    ctx.collection.setEntity(annotation.id, entityId, { id: entityId, ...choice.entityFields });
+  }
+
+  // Re-read so the builder sees the just-assigned entityId.
+  const committed = ctx.collection.find(annotation.id);
+  if (!committed) return;
+
+  const entityOpts =
+    choice.mode === "existing" ? { linkExisting: true } : { entityFields: choice.entityFields };
+  for (const m of builder.buildCreate(ctx.buildContext, committed, ctx.widgetId, entityOpts)) {
+    ctx.mutations.queue(m);
+  }
+  ctx.requestRedraw?.();
+}
+
+/**
+ * Dependencies for reassigning a *persisted* annotation's entity. Like
+ * `DraftCommitContext` but the annotation mutation is an update (not a create),
+ * so the queue must expose `upsertUpdate` too.
+ */
+export interface ReassignEntityContext {
+  readonly collection: AnnotationStore;
+  readonly mutations: Pick<MutationSink, "queue" | "upsertUpdate">;
+  readonly buildContext: BuildContext;
+  readonly widgetId: string;
+  findEntity(entityId: string): Record<string, unknown> | undefined;
+  requestRedraw?(): void;
+}
+
+/**
+ * Kind-agnostic reassignment of an existing annotation's entity: point it at a
+ * different entity (an existing one, or a freshly created one), then queue the
+ * annotation update carrying the new `entity_id`. The previously attached
+ * entity is pruned server-side when this leaves it with no annotations — the
+ * update is sent with `?prune_orphan_entity=true` (see `updateAnnotation`).
+ * Mirrors `commitDraftWithEntity` for the edit lifecycle.
+ */
+export function reassignEntity(
+  annotation: LocalAnnotation,
+  choice: PendingEntityChoice,
+  ctx: ReassignEntityContext,
+): void {
+  if (!annotation.persisted) return;
+  const builder = payloadBuilderFor(annotation.kind);
+
+  if (choice.mode === "existing") {
+    ctx.collection.setEntity(annotation.id, choice.entityId, ctx.findEntity(choice.entityId));
+  } else {
+    const entityId = generateShortId();
+    ctx.collection.setEntity(annotation.id, entityId, { id: entityId, ...choice.entityFields });
+    ctx.mutations.queue(
+      buildEntityCreateMutation(
+        ctx.buildContext,
+        entityId,
+        choice.entityFields,
+        ctx.widgetId,
+        annotation.id,
+      ),
+    );
+  }
+
+  // Re-read so the update body carries the just-assigned entityId.
+  const updated = ctx.collection.find(annotation.id);
+  if (!updated) return;
+
+  ctx.mutations.upsertUpdate({
+    op: "update",
+    resource: builder.resource,
+    id: annotation.id,
+    body: builder.buildUpdate(ctx.buildContext, updated),
+    widgetId: ctx.widgetId,
+    localAnnotationId: annotation.id,
+  });
+  ctx.requestRedraw?.();
 }

--- a/ui/apps/web/src/lib/annotations/scene/__tests__/selectTool2D.test.ts
+++ b/ui/apps/web/src/lib/annotations/scene/__tests__/selectTool2D.test.ts
@@ -8,12 +8,19 @@ import type Konva from "konva";
 import { describe, expect, it, vi } from "vitest";
 
 import { AnnotationCollection, type LocalBBox } from "../../annotationCollection.svelte.js";
-import { selectTool2D } from "../selectTool2D.js";
 import type { Scene2DContext } from "../sceneContext.js";
+import { selectTool2D } from "../selectTool2D.js";
 import { DEFAULT_TOOL_2D } from "../tool.js";
 
 function makeBBox(id: string, persisted = true): LocalBBox {
-  return { id, entityId: `e-${id}`, kind: "bbox", viewId: "view", geometry: [0.1, 0.1, 0.2, 0.2], persisted };
+  return {
+    id,
+    entityId: `e-${id}`,
+    kind: "bbox",
+    viewId: "view",
+    geometry: [0.1, 0.1, 0.2, 0.2],
+    persisted,
+  };
 }
 
 function makeContext(collection: AnnotationCollection) {
@@ -35,6 +42,9 @@ function makeContext(collection: AnnotationCollection) {
     getKonvaImage: () => null,
     setActiveTool: vi.fn(),
     requestRedraw: vi.fn(),
+    beginPendingAnnotation: vi.fn(),
+    findEntity: vi.fn(),
+    isEntityVisible: () => true,
   };
   return { ctx, stage };
 }
@@ -50,7 +60,9 @@ describe("selectTool2D", () => {
     const { ctx, stage } = makeContext(collection);
     const handler = selectTool2D.createHandler(ctx);
 
-    handler.onPointerDown!({ target: stage } as Parameters<NonNullable<typeof handler.onPointerDown>>[0]);
+    handler.onPointerDown!({ target: stage } as Parameters<
+      NonNullable<typeof handler.onPointerDown>
+    >[0]);
 
     expect(collection.selectedId).toBeNull();
     expect(ctx.requestRedraw).toHaveBeenCalled();
@@ -79,7 +91,7 @@ describe("selectTool2D", () => {
     expect(collection.selectedId).toBeNull();
   });
 
-  it("Delete queues backend deletes for a persisted selection and removes it", () => {
+  it("Delete queues the backend delete for a persisted selection and removes it", () => {
     const collection = new AnnotationCollection([makeBBox("a", true)]);
     collection.select("a");
     const { ctx } = makeContext(collection);
@@ -88,13 +100,10 @@ describe("selectTool2D", () => {
     expect(handler.onKeyDown!(new KeyboardEvent("keydown", { key: "Delete" }))).toBe(true);
 
     expect(collection.find("a")).toBeUndefined();
-    // One delete for the bbox row, one for its parent entity.
-    expect(ctx.mutations.queue).toHaveBeenCalledTimes(2);
+    // Only the bbox row; the parent entity is pruned server-side if now orphaned.
+    expect(ctx.mutations.queue).toHaveBeenCalledTimes(1);
     expect(ctx.mutations.queue).toHaveBeenCalledWith(
       expect.objectContaining({ op: "delete", resource: "bboxes", id: "a" }),
-    );
-    expect(ctx.mutations.queue).toHaveBeenCalledWith(
-      expect.objectContaining({ op: "delete", resource: "entities", id: "e-a" }),
     );
   });
 

--- a/ui/apps/web/src/lib/annotations/scene/sceneContext.ts
+++ b/ui/apps/web/src/lib/annotations/scene/sceneContext.ts
@@ -10,7 +10,7 @@ import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/con
 
 import type { AnnotationStore } from "../annotationCollection.svelte.js";
 import type { BuildContext } from "../buildPayloads.js";
-import type { CameraCalibration, ResourceMutation } from "../types.js";
+import type { CameraCalibration, PendingAnnotation, ResourceMutation } from "../types.js";
 
 /**
  * Narrow view of the mutation queue handed to tools and renderers: enough to
@@ -23,7 +23,11 @@ export interface MutationSink {
   /** Queue an update, or replace the body of a pending update for the same resource+id. */
   upsertUpdate(mutation: Extract<ResourceMutation, { op: "update" }>): void;
   /** Merge a patch into a still-pending create's body for the given local annotation. */
-  patchPendingCreate(localAnnotationId: string, resource: string, patch: Record<string, unknown>): void;
+  patchPendingCreate(
+    localAnnotationId: string,
+    resource: string,
+    patch: Record<string, unknown>,
+  ): void;
   dropForLocalAnnotation(localAnnotationId: string): void;
 }
 
@@ -46,6 +50,15 @@ export interface SceneContextBase {
   setActiveTool(id: string): void;
   /** Ask the host to re-sync annotation rendering. */
   requestRedraw(): void;
+  /**
+   * Register a freshly drawn annotation awaiting its entity choice: the host
+   * surfaces the Inspector's entity form, then calls back to commit or discard.
+   */
+  beginPendingAnnotation(pending: PendingAnnotation): void;
+  /** Resolve an existing entity row, for the label snapshot on entity assignment. */
+  findEntity(entityId: string): Record<string, unknown> | undefined;
+  /** Whether an entity's persisted annotations should currently be shown. */
+  isEntityVisible(entityId: string): boolean;
 }
 
 /**
@@ -75,6 +88,8 @@ export interface Scene2DReadContext {
   readonly camera: Scene2DCamera;
   getKonvaImage(): Konva.Image | null;
   requestRedraw(): void;
+  /** Whether an entity's persisted annotations should currently be shown. */
+  isEntityVisible(entityId: string): boolean;
 }
 
 /**

--- a/ui/apps/web/src/lib/annotations/types.ts
+++ b/ui/apps/web/src/lib/annotations/types.ts
@@ -87,6 +87,28 @@ export interface PointCloudWidgetStorage {
 }
 
 /**
+ * The user's entity decision for a freshly drawn box, collected by the
+ * Inspector's SaveAnnotationForm: either link to an existing entity or create
+ * a new one with the given (schema-derived) feature fields.
+ */
+export type PendingEntityChoice =
+  | { mode: "existing"; entityId: string }
+  | { mode: "new"; entityFields: Record<string, unknown> };
+
+/**
+ * A box that has been drawn but not yet committed: it waits for the user to
+ * pick or create its entity in the Inspector. The originating widget supplies
+ * the callbacks so the domain logic (building mutations) stays widget-local
+ * while the form stays presentational. Mirrors pixano's `newShape("saving")`.
+ */
+export interface PendingAnnotation {
+  /** Human label for the form header, e.g. "box" or "3D box". */
+  label: string;
+  onConfirm: (choice: PendingEntityChoice) => void;
+  onCancel: () => void;
+}
+
+/**
  * A pending mutation to be flushed to the backend by WorkspaceManager.flushSave.
  * Modeled after pixano's ResourceMutation in apps/pixano/src/lib/api/resourcePayloads.ts.
  */

--- a/ui/apps/web/src/lib/api/__tests__/annotations.test.ts
+++ b/ui/apps/web/src/lib/api/__tests__/annotations.test.ts
@@ -225,7 +225,7 @@ describe("updateAnnotation", () => {
     await updateAnnotation(DS, "bboxes", "b1", { id: "b1", coords: [0, 0, 0.5, 0.5] });
 
     const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(`/datasets/${DS}/bboxes/b1`);
+    expect(url).toBe(`/datasets/${DS}/bboxes/b1?prune_orphan_entity=true`);
     expect(init.method).toBe("PUT");
     const sent = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(sent).not.toHaveProperty("id");
@@ -245,13 +245,13 @@ describe("updateAnnotation", () => {
 // ─── deleteAnnotation ────────────────────────────────────────────────────────
 
 describe("deleteAnnotation", () => {
-  it("DELETEs the annotation by resource and id", async () => {
+  it("DELETEs the annotation by resource and id, asking the backend to prune an orphan entity", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
 
     await deleteAnnotation(DS, "bboxes", "b1");
 
     const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(`/datasets/${DS}/bboxes/b1`);
+    expect(url).toBe(`/datasets/${DS}/bboxes/b1?prune_orphan_entity=true`);
     expect((init as RequestInit).method).toBe("DELETE");
   });
 

--- a/ui/apps/web/src/lib/api/annotations.ts
+++ b/ui/apps/web/src/lib/api/annotations.ts
@@ -195,8 +195,11 @@ export function updateAnnotation(
 ): Promise<Record<string, unknown>> {
   const { id: _ignored, ...patch } = body;
   void _ignored;
+  // Ask the backend to prune the previously attached entity when an entity_id
+  // change leaves it orphaned (no-op for geometry-only edits).
+  const url = `${resourceUrl(datasetId, resource, id)}?prune_orphan_entity=true`;
   return requestJson<Record<string, unknown>>(
-    resourceUrl(datasetId, resource, id),
+    url,
     { headers: JSON_HEADERS, method: "PUT", body: JSON.stringify(patch) },
     `updateAnnotation(${resource})`,
   );
@@ -207,7 +210,10 @@ export async function deleteAnnotation(
   resource: string,
   id: string,
 ): Promise<void> {
-  const res = await fetch(resourceUrl(datasetId, resource, id), { method: "DELETE" });
+  // Ask the backend to also delete the parent entity when this was its last
+  // annotation — the server is the only place that sees every reference.
+  const url = `${resourceUrl(datasetId, resource, id)}?prune_orphan_entity=true`;
+  const res = await fetch(url, { method: "DELETE" });
   if (!res.ok && res.status !== 404) {
     throw new Error(`deleteAnnotation(${resource}) failed with ${res.status} ${res.statusText}`);
   }

--- a/ui/apps/web/src/lib/components/shell/EntitiesPanel.svelte
+++ b/ui/apps/web/src/lib/components/shell/EntitiesPanel.svelte
@@ -5,21 +5,32 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
+  import { Eye } from "lucide-svelte";
+
   import type { EntityRow } from "$lib/api/annotations.js";
+  import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
   interface Props {
-    entities: EntityRow[];
-    entitySchemaName: string | null;
+    manager: WorkspaceManager;
   }
 
-  let { entities, entitySchemaName }: Props = $props();
+  let { manager }: Props = $props();
+
+  const entities = $derived<EntityRow[]>(manager.entities);
+  // null = all visible; otherwise an entity is "isolated" when it is the only id.
+  const showingAll = $derived(manager.visibleEntityIds === null);
+
+  function isIsolated(entityId: string): boolean {
+    const visible = manager.visibleEntityIds;
+    return visible !== null && visible.size === 1 && visible.has(entityId);
+  }
 
   function resolveCategory(entity: EntityRow): string {
     for (const key of ["category", "label", "class", "name"]) {
       const value = entity[key];
       if (typeof value === "string" && value.length > 0) return value;
     }
-    return entitySchemaName ?? "Entity";
+    return manager.entitySchemaName ?? "Entity";
   }
 
   function shortenId(id: string): string {
@@ -31,10 +42,33 @@ License: CECILL-C
   {#if entities.length === 0}
     <p class="text-xs text-muted-foreground">No entities in this record.</p>
   {:else}
-    <p class="mb-2 text-xs text-muted-foreground">{entities.length} entit{entities.length === 1 ? "y" : "ies"}</p>
+    <div class="mb-2 flex items-center justify-between">
+      <p class="text-xs text-muted-foreground">
+        {entities.length} entit{entities.length === 1 ? "y" : "ies"}
+      </p>
+      <button
+        type="button"
+        onclick={() => manager.showAllEntities()}
+        title="Show every entity's annotations"
+        class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] transition-colors {showingAll
+          ? 'bg-accent text-accent-foreground'
+          : 'text-muted-foreground hover:bg-accent/50'}"
+      >
+        <Eye class="h-3 w-3" />
+        Show all
+      </button>
+    </div>
     <div class="space-y-1.5">
       {#each entities as entity (entity.id)}
-        <div class="rounded-md border border-border bg-card px-2.5 py-2">
+        {@const isolated = isIsolated(entity.id)}
+        <button
+          type="button"
+          onclick={() => manager.toggleEntityVisible(entity.id)}
+          title={isolated ? "Click to show all entities" : "Click to show only this entity"}
+          class="w-full rounded-md border px-2.5 py-2 text-left transition-colors {isolated
+            ? 'border-primary bg-primary/10'
+            : 'border-border bg-card hover:bg-accent/40'}"
+        >
           <div class="flex items-center gap-2">
             <span
               class="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary"
@@ -45,7 +79,7 @@ License: CECILL-C
               {shortenId(entity.id)}
             </span>
           </div>
-        </div>
+        </button>
       {/each}
     </div>
   {/if}

--- a/ui/apps/web/src/lib/components/shell/RightPanel.svelte
+++ b/ui/apps/web/src/lib/components/shell/RightPanel.svelte
@@ -8,6 +8,7 @@ License: CECILL-C
   import { Eye, EyeOff, Layers, MessageSquare, ScanSearch } from "lucide-svelte";
 
   import EntitiesPanel from "./EntitiesPanel.svelte";
+  import SaveAnnotationForm from "./SaveAnnotationForm.svelte";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
   interface Props {
@@ -17,6 +18,11 @@ License: CECILL-C
   let { manager }: Props = $props();
 
   let activeTab = $state<"inspector" | "entities" | "agent">("inspector");
+
+  // Surface the entity form as soon as a drawn box is awaiting its entity.
+  $effect(() => {
+    if (manager.pendingAnnotation) activeTab = "entities";
+  });
 
   const tabs = [
     { id: "inspector" as const, label: "Inspector", icon: ScanSearch },
@@ -46,8 +52,9 @@ License: CECILL-C
   <!-- Tab content -->
   <div class="flex-1 overflow-y-auto">
     {#if activeTab === "entities"}
+      <SaveAnnotationForm {manager} />
       {#if manager.recordId !== null}
-        <EntitiesPanel entities={manager.entities} entitySchemaName={manager.entitySchemaName} />
+        <EntitiesPanel {manager} />
       {:else}
         <div class="p-3">
           <p class="text-xs text-muted-foreground">Open a record to inspect its entities.</p>
@@ -86,7 +93,9 @@ License: CECILL-C
                   >
                     {widget.title}
                   </span>
-                  <span class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                  <span
+                    class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                  >
                     {widget.extensionName}
                   </span>
                 </div>

--- a/ui/apps/web/src/lib/components/shell/SaveAnnotationForm.svelte
+++ b/ui/apps/web/src/lib/components/shell/SaveAnnotationForm.svelte
@@ -1,0 +1,173 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import {
+    buildEntityFeatureInputs,
+    coerceFieldValue,
+    defaultFieldValue,
+    isEntityFormValid,
+    resolveEntityLabelField,
+    suggestionsForField,
+    type EntityFeatureInput,
+  } from "$lib/annotations/entityFeatures.js";
+  import { pickEntityLabel, type PendingEntityChoice } from "$lib/annotations/types.js";
+  import type { EntityRow } from "$lib/api/annotations.js";
+  import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
+
+  interface Props {
+    manager: WorkspaceManager;
+  }
+
+  let { manager }: Props = $props();
+
+  const NEW_ENTITY_OPTION = "new";
+
+  const pending = $derived(manager.pendingAnnotation);
+  const featureInputs = $derived(buildEntityFeatureInputs(manager.entitySchemaFields));
+  const labelField = $derived(resolveEntityLabelField(manager.entitySchemaFields));
+
+  let selectedEntityId = $state<string>(NEW_ENTITY_OPTION);
+  let fieldValues = $state<Record<string, string | number | boolean>>({});
+
+  // Start each newly drawn box with a clean form ("New entity" + default values).
+  let lastPending = $state<unknown>(null);
+  $effect(() => {
+    if (pending === lastPending) return;
+    lastPending = pending;
+    selectedEntityId = NEW_ENTITY_OPTION;
+    const initial: Record<string, string | number | boolean> = {};
+    for (const input of featureInputs) initial[input.name] = defaultFieldValue(input.type);
+    fieldValues = initial;
+  });
+
+  function shortenId(id: string): string {
+    return id.length > 12 ? `${id.slice(0, 6)}…${id.slice(-4)}` : id;
+  }
+
+  function entityOptionLabel(entity: EntityRow): string {
+    const label = pickEntityLabel(entity);
+    return label ? `${label} (${shortenId(entity.id)})` : shortenId(entity.id);
+  }
+
+  const choice = $derived<PendingEntityChoice>(
+    selectedEntityId === NEW_ENTITY_OPTION
+      ? {
+          mode: "new",
+          entityFields: Object.fromEntries(
+            featureInputs.map((input) => [
+              input.name,
+              coerceFieldValue(input.type, fieldValues[input.name]),
+            ]),
+          ),
+        }
+      : { mode: "existing", entityId: selectedEntityId },
+  );
+
+  const valid = $derived(isEntityFormValid(choice, labelField));
+
+  function handleNumberInput(input: EntityFeatureInput, raw: string): void {
+    fieldValues[input.name] = raw === "" ? "" : Number(raw);
+  }
+</script>
+
+{#if pending}
+  <div class="border-b border-border bg-muted/30 p-3">
+    <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+      Save {pending.label}
+    </h4>
+
+    <div class="flex flex-col gap-3">
+      <label class="flex flex-col gap-1 text-xs">
+        <span class="text-muted-foreground">Entity</span>
+        <select
+          bind:value={selectedEntityId}
+          class="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <option value={NEW_ENTITY_OPTION}>New entity</option>
+          {#each manager.entities as entity (entity.id)}
+            <option value={entity.id}>{entityOptionLabel(entity)}</option>
+          {/each}
+        </select>
+      </label>
+
+      {#if selectedEntityId === NEW_ENTITY_OPTION}
+        {#each featureInputs as input (input.name)}
+          {#if input.type === "bool"}
+            <label class="flex items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={fieldValues[input.name] === true}
+                onchange={(e) => (fieldValues[input.name] = e.currentTarget.checked)}
+                class="h-3.5 w-3.5 rounded border-input"
+              />
+              <span class="capitalize text-foreground">{input.label}</span>
+            </label>
+          {:else if input.type === "list"}
+            <label class="flex flex-col gap-1 text-xs">
+              <span class="capitalize text-muted-foreground">{input.label}</span>
+              <select
+                value={fieldValues[input.name]}
+                onchange={(e) => (fieldValues[input.name] = e.currentTarget.value)}
+                class="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="">—</option>
+                {#each input.options ?? [] as option (option)}
+                  <option value={option}>{option}</option>
+                {/each}
+              </select>
+            </label>
+          {:else if input.type === "str"}
+            <label class="flex flex-col gap-1 text-xs">
+              <span class="capitalize text-muted-foreground">{input.label}</span>
+              <input
+                type="text"
+                list="entity-feature-{input.name}"
+                value={fieldValues[input.name]}
+                oninput={(e) => (fieldValues[input.name] = e.currentTarget.value)}
+                class="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <datalist id="entity-feature-{input.name}">
+                {#each suggestionsForField(manager.entities, input.name) as suggestion (suggestion)}
+                  <option value={suggestion}></option>
+                {/each}
+              </datalist>
+            </label>
+          {:else}
+            <label class="flex flex-col gap-1 text-xs">
+              <span class="capitalize text-muted-foreground">{input.label}</span>
+              <input
+                type="number"
+                step={input.type === "int" ? "1" : "any"}
+                value={fieldValues[input.name]}
+                oninput={(e) => handleNumberInput(input, e.currentTarget.value)}
+                class="rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </label>
+          {/if}
+        {/each}
+      {/if}
+
+      <div class="flex gap-2 pt-1">
+        <button
+          type="button"
+          onclick={() => manager.confirmPendingAnnotation(choice)}
+          disabled={!valid}
+          class="rounded bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Confirm
+        </button>
+        <button
+          type="button"
+          onclick={() => manager.cancelPendingAnnotation()}
+          class="rounded border border-border px-2.5 py-1 text-xs hover:bg-accent"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/ui/apps/web/src/lib/components/widgets/image/ImageWidget.svelte
+++ b/ui/apps/web/src/lib/components/widgets/image/ImageWidget.svelte
@@ -9,6 +9,8 @@ License: CECILL-C
   import { Trash2 } from "lucide-svelte";
   import { getContext, onMount } from "svelte";
 
+  import AnnotationToolbar from "../AnnotationToolbar.svelte";
+  import { buildSeam } from "../sceneSeam.js";
   import { deleteLocalAnnotation } from "$lib/annotations/payloadBuilders.js";
   import {
     DEFAULT_TOOL_2D,
@@ -16,14 +18,14 @@ License: CECILL-C
     RENDERER_FACTORIES_2D,
     TOOLS_2D,
   } from "$lib/annotations/scene/registry2d.js";
-  import type { AnnotationEditor2D, AnnotationRenderer2D } from "$lib/annotations/scene/renderer.js";
+  import type {
+    AnnotationEditor2D,
+    AnnotationRenderer2D,
+  } from "$lib/annotations/scene/renderer.js";
   import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
   import type { ToolHandler2D } from "$lib/annotations/scene/tool.js";
   import type { ImageWidgetOptions, ImageWidgetStorage } from "$lib/annotations/types.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
-
-  import AnnotationToolbar from "../AnnotationToolbar.svelte";
-  import { buildSeam } from "../sceneSeam.js";
 
   interface Props {
     widgetId: string;
@@ -100,29 +102,50 @@ License: CECILL-C
 
   function drawPlaceholder(layer: Konva.Layer, width: number, height: number) {
     const gridSize = 30;
-    const add = (node: Konva.Node) => { layer.add(node as Konva.Shape); placeholderShapes.push(node); };
+    const add = (node: Konva.Node) => {
+      layer.add(node as Konva.Shape);
+      placeholderShapes.push(node);
+    };
     for (let x = 0; x < width; x += gridSize) {
-      add(new Konva.Line({ points: [x, 0, x, height], stroke: "rgba(255,255,255,0.05)", strokeWidth: 1 }));
+      add(
+        new Konva.Line({
+          points: [x, 0, x, height],
+          stroke: "rgba(255,255,255,0.05)",
+          strokeWidth: 1,
+        }),
+      );
     }
     for (let y = 0; y < height; y += gridSize) {
-      add(new Konva.Line({ points: [0, y, width, y], stroke: "rgba(255,255,255,0.05)", strokeWidth: 1 }));
+      add(
+        new Konva.Line({
+          points: [0, y, width, y],
+          stroke: "rgba(255,255,255,0.05)",
+          strokeWidth: 1,
+        }),
+      );
     }
-    add(new Konva.Text({
-      text: "Image Canvas",
-      x: 0,
-      y: height / 2 - 12,
-      width,
-      align: "center",
-      fontSize: 16,
-      fill: "rgba(255,255,255,0.3)",
-      fontFamily: "system-ui, sans-serif",
-    }));
+    add(
+      new Konva.Text({
+        text: "Image Canvas",
+        x: 0,
+        y: height / 2 - 12,
+        width,
+        align: "center",
+        fontSize: 16,
+        fill: "rgba(255,255,255,0.3)",
+        fontFamily: "system-ui, sans-serif",
+      }),
+    );
     layer.draw();
   }
 
   function onWindowKeyDown(e: KeyboardEvent) {
     const target = e.target as HTMLElement | null;
-    if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) return;
+    if (
+      target &&
+      (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+    )
+      return;
     if (activeHandler?.onKeyDown?.(e)) e.preventDefault();
   }
 
@@ -171,7 +194,9 @@ License: CECILL-C
         imageLoaded = true;
         syncRenderers();
       };
-      img.onerror = () => { imageError = true; };
+      img.onerror = () => {
+        imageError = true;
+      };
       img.src = imageUrl;
     } else {
       drawPlaceholder(imageLayer, stage.width(), stage.height());
@@ -231,6 +256,8 @@ License: CECILL-C
   $effect(() => {
     void annotations.items.length;
     void annotations.selectedId;
+    // Re-render when the visible-entity filter changes (show/hide annotations).
+    void manager.visibleEntityIds;
     if (imageLoaded) syncRenderers();
   });
 

--- a/ui/apps/web/src/lib/components/widgets/sceneSeam.ts
+++ b/ui/apps/web/src/lib/components/widgets/sceneSeam.ts
@@ -53,5 +53,8 @@ export function buildSeam(
       opts.storage.activeToolId = id;
     },
     requestRedraw: opts.requestRedraw ?? (() => {}),
+    beginPendingAnnotation: (pending) => manager.beginPendingAnnotation(pending),
+    findEntity: (entityId) => manager.entities.find((e) => e.id === entityId),
+    isEntityVisible: (entityId) => manager.isEntityVisible(entityId),
   };
 }

--- a/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
@@ -398,3 +398,60 @@ describe("RecordLoader.load", () => {
     expect(capturedEntitiesById?.get("e1")).toEqual(entity);
   });
 });
+
+describe("RecordLoader.reloadEntities", () => {
+  it("refreshes session.entities for the current record", async () => {
+    const dataset = makeDataset({ cam: { base: "Image" } });
+    const session = new WorkspaceSession();
+    let call = 0;
+    const gateway = makeGateway({ dataset });
+    gateway.listEntities = () => {
+      call++;
+      return Promise.resolve(
+        call === 1 ? [{ id: "e-old", record_id: "rec-1" }] : [{ id: "e-new", record_id: "rec-1" }],
+      );
+    };
+    const loader = new RecordLoader({
+      workspace: makeSink().sink,
+      registry: makeRegistry(makeImageExtension()),
+      gateway,
+      session,
+    });
+
+    await loader.load("ds-1", "rec-1", VIEWPORT);
+    expect(session.entities.map((e) => e.id)).toEqual(["e-old"]);
+
+    await loader.reloadEntities();
+    expect(session.entities.map((e) => e.id)).toEqual(["e-new"]);
+  });
+
+  it("discards a stale reload when a newer record load started during the fetch", async () => {
+    const dataset = makeDataset({ cam: { base: "Image" } });
+    const session = new WorkspaceSession();
+
+    let call = 0;
+    let resolveReload!: (rows: EntityRow[]) => void;
+    const gateway = makeGateway({ dataset });
+    gateway.listEntities = () => {
+      call++;
+      // 1: load rec-A, 2: the reload (held in-flight), 3: load rec-B.
+      if (call === 2) return new Promise<EntityRow[]>((res) => (resolveReload = res));
+      return Promise.resolve(call === 1 ? [{ id: "e-A", record_id: "rec-A" }] : [{ id: "e-B", record_id: "rec-B" }]);
+    };
+    const loader = new RecordLoader({
+      workspace: makeSink().sink,
+      registry: makeRegistry(makeImageExtension()),
+      gateway,
+      session,
+    });
+
+    await loader.load("ds-1", "rec-A", VIEWPORT);
+    const reloadPromise = loader.reloadEntities(); // captures the current token, then awaits
+    await loader.load("ds-1", "rec-B", VIEWPORT); // bumps loadToken, sets entities to rec-B
+    resolveReload([{ id: "e-A", record_id: "rec-A" }]); // stale fetch resolves last
+    await reloadPromise;
+
+    // The stale reload must NOT clobber record B's entities.
+    expect(session.entities.map((e) => e.id)).toEqual(["e-B"]);
+  });
+});

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
@@ -208,6 +208,144 @@ describe("WorkspaceManager.toggleWidgetVisibility", () => {
   });
 });
 
+describe("WorkspaceManager entity visibility", () => {
+  it("defaults to all entities visible (null filter)", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    expect(manager.visibleEntityIds).toBeNull();
+    expect(manager.isEntityVisible("any")).toBe(true);
+  });
+
+  it("toggleEntityVisible isolates a single entity", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleEntityVisible("e1");
+
+    expect(manager.isEntityVisible("e1")).toBe(true);
+    expect(manager.isEntityVisible("e2")).toBe(false);
+    expect([...(manager.visibleEntityIds ?? [])]).toEqual(["e1"]);
+  });
+
+  it("toggling a different entity switches the isolation", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleEntityVisible("e1");
+    manager.toggleEntityVisible("e2");
+
+    expect(manager.isEntityVisible("e1")).toBe(false);
+    expect(manager.isEntityVisible("e2")).toBe(true);
+  });
+
+  it("toggling the already-isolated entity returns to show-all", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleEntityVisible("e1");
+    manager.toggleEntityVisible("e1");
+
+    expect(manager.visibleEntityIds).toBeNull();
+    expect(manager.isEntityVisible("anything")).toBe(true);
+  });
+
+  it("showAllEntities clears any isolation", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleEntityVisible("e1");
+    manager.showAllEntities();
+
+    expect(manager.visibleEntityIds).toBeNull();
+    expect(manager.isEntityVisible("e2")).toBe(true);
+  });
+
+  it("clears a selection that isolation has just hidden (no delete on an unseen box)", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    manager.annotations.add({
+      id: "b-eB",
+      entityId: "eB",
+      kind: "bbox",
+      viewId: "v1",
+      geometry: [0, 0, 1, 1],
+      persisted: true,
+    });
+    manager.annotations.select("b-eB");
+
+    // Isolate a different entity → the selected box is now hidden.
+    manager.toggleEntityVisible("eA");
+
+    expect(manager.annotations.selectedId).toBeNull();
+  });
+
+  it("keeps a selection that stays visible after isolation", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    manager.annotations.add({
+      id: "b-eA",
+      entityId: "eA",
+      kind: "bbox",
+      viewId: "v1",
+      geometry: [0, 0, 1, 1],
+      persisted: true,
+    });
+    manager.annotations.select("b-eA");
+
+    manager.toggleEntityVisible("eA");
+
+    expect(manager.annotations.selectedId).toBe("b-eA");
+  });
+
+  it("keeps a draft selected even when its entity isn't in the visible set", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    manager.annotations.add({
+      id: "draft",
+      entityId: "",
+      kind: "bbox",
+      viewId: "v1",
+      geometry: [0, 0, 1, 1],
+      persisted: false,
+    });
+    manager.annotations.select("draft");
+
+    manager.toggleEntityVisible("eA");
+
+    expect(manager.annotations.selectedId).toBe("draft");
+  });
+});
+
+describe("WorkspaceManager.deleteAnnotation", () => {
+  it("queues a single backend delete for a persisted annotation and removes it", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    manager.annotations.add({
+      id: "b1",
+      entityId: "e1",
+      kind: "bbox3d",
+      viewId: "",
+      geometry: { coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd" },
+      persisted: true,
+    });
+
+    manager.deleteAnnotation(manager.annotations.find("b1")!, "w1");
+
+    expect(manager.annotations.find("b1")).toBeUndefined();
+    // Only the annotation row; the orphan entity is pruned server-side.
+    expect(manager.pendingMutations).toHaveLength(1);
+    expect(manager.pendingMutations[0]).toMatchObject({ op: "delete", resource: "bbox3ds", id: "b1" });
+  });
+
+  it("drops pending creates for an unsaved annotation instead of queueing a delete", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    manager.annotations.add({
+      id: "draft",
+      entityId: "",
+      kind: "bbox3d",
+      viewId: "",
+      geometry: { coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd" },
+      persisted: false,
+    });
+
+    manager.deleteAnnotation(manager.annotations.find("draft")!, "w1");
+
+    expect(manager.annotations.find("draft")).toBeUndefined();
+    expect(manager.pendingMutations).toHaveLength(0);
+  });
+});
+
 describe("WorkspaceManager.selectRecordInDataset", () => {
   it("creates one widget per renderable view, in dataset order", async () => {
     const dataset = makeDataset({
@@ -326,6 +464,34 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
     // Svelte 5 wraps session state in a $state proxy, so we compare by value
     // rather than reference identity.
     expect(annotation!.entity).toStrictEqual(entity);
+  });
+
+  it("refreshes the entity list after a successful flushSave", async () => {
+    const dataset = makeDataset({ cam_front: { base: "Image" } });
+    const state = {
+      dataset,
+      entities: [{ id: "ent-old", record_id: "rec-1" } as EntityRow],
+      imagesByLogicalName: new Map([
+        ["cam_front", { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse],
+      ]),
+      pointCloudsByLogicalName: new Map(),
+      bboxes: [],
+      bboxes3d: [],
+    };
+    const { gateway, calls } = makeGateway(state);
+
+    const manager = new WorkspaceManager(makeRegistry(), gateway);
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    expect(manager.entities.map((e) => e.id)).toEqual(["ent-old"]);
+
+    // Simulate the backend having created one entity and pruned the old one
+    // during the flush; the post-save refetch should pick this up.
+    state.entities = [{ id: "ent-new", record_id: "rec-1" } as EntityRow];
+    manager.queueMutation({ op: "delete", resource: "bbox3ds", id: "x", widgetId: "w" });
+    await manager.flushSave();
+
+    expect(calls.listEntities).toBe(2); // once on load, once after save
+    expect(manager.entities.map((e) => e.id)).toEqual(["ent-new"]);
   });
 
   it("throws when the dataset has no renderable views", async () => {

--- a/ui/apps/web/src/lib/workspace/recordLoader.ts
+++ b/ui/apps/web/src/lib/workspace/recordLoader.ts
@@ -11,11 +11,7 @@ import type { WidgetInstance } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 
 import type { DatasetGateway, RecordReadGateway } from "./datasetGateway.js";
-import {
-  measureGridViewport,
-  planViewportLayouts,
-  type Viewport,
-} from "./layoutPlanner.js";
+import { measureGridViewport, planViewportLayouts, type Viewport } from "./layoutPlanner.js";
 import type { RecordWidgetSeed } from "./recordSeed.js";
 import type { WorkspaceSession } from "./workspaceSession.svelte.js";
 
@@ -67,6 +63,28 @@ export class RecordLoader {
     this.session = deps.session;
   }
 
+  /**
+   * Refetch the current record's entities and refresh `session.entities`.
+   * Called after a save so the entity list (right-panel list + picker) reflects
+   * entities the flush created or the backend pruned, without a full reload.
+   */
+  async reloadEntities(): Promise<void> {
+    const datasetId = this.session.datasetId;
+    const recordId = this.session.recordId;
+    if (!datasetId || !recordId) return;
+    // Observe (don't bump) the load token: if a record switch starts while we're
+    // fetching, discard our result so a stale list can't overwrite the newer
+    // record's entities — same guard load() uses for its async writes.
+    const token = this.loadToken;
+    try {
+      const entities = await this.readGateway.listEntities(datasetId, { recordId });
+      if (token !== this.loadToken) return;
+      this.session.entities = entities;
+    } catch (err) {
+      console.error("Failed to reload entities:", err);
+    }
+  }
+
   async load(
     datasetId: string,
     recordId: string,
@@ -82,7 +100,9 @@ export class RecordLoader {
     this.session.recordId = recordId;
     this.session.entities = [];
     this.session.entitySchemaName = null;
+    this.session.entitySchemaFields = null;
     this.session.annotations = new AnnotationCollection();
+    this.session.visibleEntityIds = null;
 
     // Kick off both the dataset metadata fetch and the entities listing in
     // parallel — they don't depend on each other and the entities call is
@@ -105,9 +125,11 @@ export class RecordLoader {
     const entitiesById = new Map<string, EntityRow>();
     for (const entity of entityRows) entitiesById.set(entity.id, entity);
 
-    // Expose entities and their schema name to consumers (e.g. the right panel).
+    // Expose entities and their schema (name + fields) to consumers (e.g. the
+    // right panel's entity form, which generates inputs from the fields).
     this.session.entities = entityRows;
     this.session.entitySchemaName = dataset.schema.schemas?.["entities"]?.schema ?? null;
+    this.session.entitySchemaFields = dataset.schema.schemas?.["entities"]?.fields ?? null;
 
     const candidates = Object.entries(dataset.info.views ?? {});
     const extensions = this.registry.getAll();

--- a/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
@@ -4,11 +4,17 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { AnnotationCollection } from "$lib/annotations/annotationCollection.svelte.js";
-import type { ResourceMutation } from "$lib/annotations/types.js";
+import type { AnnotationCollection, LocalAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
+import { deleteLocalAnnotation } from "$lib/annotations/payloadBuilders.js";
+import type {
+  PendingAnnotation,
+  PendingEntityChoice,
+  ResourceMutation,
+} from "$lib/annotations/types.js";
 import type { EntityRow } from "$lib/api/annotations.js";
 import type { WidgetInstance, WidgetLayout, WorkspacePreset } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
+import type { FieldInfo } from "$lib/types/dataset.js";
 
 import { httpDatasetGateway, type DatasetGateway } from "./datasetGateway.js";
 import type { Viewport } from "./layoutPlanner.js";
@@ -42,6 +48,12 @@ export class WorkspaceManager {
   editMode = $state(true);
   presetName = $state("Default");
   widgetCount = $derived(this.widgets.length);
+
+  /**
+   * A box drawn but awaiting its entity choice in the Inspector. `null` when no
+   * box is pending. Set by widgets via `beginPendingAnnotation`.
+   */
+  pendingAnnotation = $state<PendingAnnotation | null>(null);
 
   private registry: WidgetRegistry;
   private storageMap: Map<string, Record<string, unknown>> = new Map();
@@ -94,6 +106,69 @@ export class WorkspaceManager {
     return this.session.annotations;
   }
 
+  get entitySchemaFields(): Record<string, FieldInfo> | null {
+    return this.session.entitySchemaFields;
+  }
+
+  // ─── Entity-driven annotation visibility ──────────────────────────────────
+  // `null` = all entities visible (default). A set isolates the listed entities.
+  // Display-only: renderers/derived lists consult `isEntityVisible`; the
+  // annotation collection's lifecycle (find/drafts/save) is never filtered.
+
+  get visibleEntityIds(): ReadonlySet<string> | null {
+    return this.session.visibleEntityIds;
+  }
+
+  /** Whether an entity's persisted annotations should be shown right now. */
+  isEntityVisible(entityId: string): boolean {
+    const visible = this.session.visibleEntityIds;
+    return visible === null || visible.has(entityId);
+  }
+
+  /** Isolate a single entity, or — if it is already the sole isolated one — show all. */
+  toggleEntityVisible(entityId: string): void {
+    const visible = this.session.visibleEntityIds;
+    const isolated = visible !== null && visible.size === 1 && visible.has(entityId);
+    this.session.visibleEntityIds = isolated ? null : new Set([entityId]);
+    // Keep the shared selection coherent with what's now displayed: a selection
+    // pointing at an annotation this filter just hid would otherwise leave the
+    // delete button/key acting on something no widget shows.
+    const selected = this.session.annotations.selected;
+    if (selected && selected.persisted && !this.isEntityVisible(selected.entityId)) {
+      this.session.annotations.select(null);
+    }
+  }
+
+  /** Reveal every entity's annotations (the "Show all" control). */
+  showAllEntities(): void {
+    this.session.visibleEntityIds = null;
+  }
+
+  // ─── Pending annotation (entity assignment) ───────────────────────────────
+
+  /**
+   * Register a freshly drawn box that is awaiting its entity choice. Any box
+   * already pending is cancelled first so only one form is ever shown.
+   */
+  beginPendingAnnotation(pending: PendingAnnotation): void {
+    this.pendingAnnotation?.onCancel();
+    this.pendingAnnotation = pending;
+  }
+
+  /** Confirm the pending box with the user's entity choice. */
+  confirmPendingAnnotation(choice: PendingEntityChoice): void {
+    const pending = this.pendingAnnotation;
+    this.pendingAnnotation = null;
+    pending?.onConfirm(choice);
+  }
+
+  /** Discard the pending box. */
+  cancelPendingAnnotation(): void {
+    const pending = this.pendingAnnotation;
+    this.pendingAnnotation = null;
+    pending?.onCancel();
+  }
+
   // ─── Mutation queue forwarders ────────────────────────────────────────────
 
   get pendingMutations(): ResourceMutation[] {
@@ -117,6 +192,16 @@ export class WorkspaceManager {
     this.mutations.queue(mutation);
   }
 
+  /**
+   * Delete an annotation (any kind) from the shared record: queues the backend
+   * delete for a persisted one, or drops its not-yet-flushed creates, then
+   * removes it from the collection. The parent entity is pruned server-side
+   * when this was its last annotation. One path for 2D tools and 3D widgets.
+   */
+  deleteAnnotation(annotation: LocalAnnotation, widgetId: string): void {
+    deleteLocalAnnotation(annotation, this.session.annotations, this.mutations, widgetId);
+  }
+
   /** Queue an update, or replace the body of a pending update for the same resource+id. */
   upsertUpdateMutation(mutation: Extract<ResourceMutation, { op: "update" }>): void {
     this.mutations.upsertUpdate(mutation);
@@ -137,18 +222,19 @@ export class WorkspaceManager {
   }
 
   /** Flush every queued mutation to the backend. */
-  flushSave(): Promise<void> {
-    return this.mutations.flush();
+  async flushSave(): Promise<void> {
+    await this.mutations.flush();
+    // Entity creates/prunes happen backend-side; refresh the local entity list
+    // so the panel and picker reflect them. Skip if the flush errored.
+    if (!this.mutations.saveError) await this.loader.reloadEntities();
   }
 
   // ─── Record loader forwarder ──────────────────────────────────────────────
 
   /** Load a record's widgets via the registered extensions' `addRecordSeed` hooks. */
-  selectRecordInDataset(
-    datasetId: string,
-    recordId: string,
-    viewport?: Viewport,
-  ): Promise<void> {
+  selectRecordInDataset(datasetId: string, recordId: string, viewport?: Viewport): Promise<void> {
+    // A box drawn on the previous record must not carry over to the next one.
+    this.pendingAnnotation = null;
     return this.loader.load(datasetId, recordId, viewport);
   }
 
@@ -170,7 +256,6 @@ export class WorkspaceManager {
     const config = this.registry.get(extensionName);
     if (!config) {
       throw new Error(`Extension "${extensionName}" not found in registry`);
-
     }
 
     const options = config.addOptions?.() ?? {};
@@ -225,6 +310,7 @@ export class WorkspaceManager {
    * still targets whatever record the user last opened.
    */
   clearWorkspace(): void {
+    this.pendingAnnotation = null;
     this.storageMap.clear();
     this.widgets = [];
     this.mutations.reset();

--- a/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
@@ -6,6 +6,7 @@ License: CECILL-C
 
 import { AnnotationCollection } from "$lib/annotations/annotationCollection.svelte.js";
 import type { EntityRow } from "$lib/api/annotations.js";
+import type { FieldInfo } from "$lib/types/dataset.js";
 
 /**
  * Reactive "what record is currently loaded?" state, shared by the
@@ -28,8 +29,16 @@ export class WorkspaceSession {
   recordId = $state<string | null>(null);
   entities = $state<EntityRow[]>([]);
   entitySchemaName = $state<string | null>(null);
+  /** Field definitions of the dataset's entity table, used to generate the entity form. */
+  entitySchemaFields = $state<Record<string, FieldInfo> | null>(null);
   /** Shared annotations of the loaded record; replaced on every load. */
   annotations = $state(new AnnotationCollection());
+  /**
+   * Entity ids whose annotations are currently shown. `null` means "all
+   * visible" (the default). A set isolates the listed entities. Record-scoped
+   * shared state so every widget viewing the record filters identically.
+   */
+  visibleEntityIds = $state<Set<string> | null>(null);
 
   /** Reset the selection (e.g. on `clearWorkspace`). */
   reset(): void {
@@ -37,6 +46,8 @@ export class WorkspaceSession {
     this.recordId = null;
     this.entities = [];
     this.entitySchemaName = null;
+    this.entitySchemaFields = null;
     this.annotations = new AnnotationCollection();
+    this.visibleEntityIds = null;
   }
 }


### PR DESCRIPTION
## Why

Ports the `create-link_entities_to_3DBoxes` feature onto the new plugin annotation architecture (already merged into `frontend/next-ui-init` via #660), so linking entities to 2D/3D boxes works within the shared, record-scoped model instead of the old widget-bound flow.

## What

- **Deferred entity choice.** Drawing a 2D/3D box now stages an unsaved draft and defers its entity selection to the Inspector form (`commitDraftWithEntity`), instead of committing an anonymous entity immediately.
- **Reassign & delete.** Reassign a persisted box to a different entity (`reassignEntity`) and delete 3D boxes, both routed through the shared kind-agnostic helpers.
- **Entity-driven visibility.** Renderers skip persisted annotations whose entity is hidden (2D bbox + 3D bbox renderers).
- **Backend.** Orphan parent entities are pruned server-side on annotation delete/reassign via `?prune_orphan_entity=true`; `entity_id` validated on update.
- **Seam.** `SceneContextBase` gains `beginPendingAnnotation` / `findEntity` / `isEntityVisible`, wired once in `buildSeam` so every widget and the bbox3d session share it; the 3D entity logic lives in `BBox3DSession` (widget stays kind-agnostic).

## Notes

- Single commit, rebased onto the current `frontend/next-ui-init` tip; the annotation-tooling refactor it builds on is already in the base (#660).
