### PR TITLE
fix(web): correct 3D bbox axis swap for xyzwhd format

### DIFF
--- a/ui/apps/web/src/lib/annotations/__tests__/coordinateTransforms.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/coordinateTransforms.test.ts
@@ -90,10 +90,12 @@ describe("bboxTransform — xyzwhd", () => {
     expect(position).toEqual([1, 3, -2]);
   });
 
-  it("passes w/h/d extents through unchanged as Three.js size", () => {
+  it("applies the Lance→Three axis swap to extents: [w, d, h]", () => {
+    // coords size = [Lance X-ext=4, Lance Y-ext=5, Lance Z-ext=6].
+    // Three.js size: [Lance X-ext, Lance Z-ext, Lance Y-ext] = [4, 6, 5].
     const bbox = makeBbox({ coords: [0, 0, 0, 4, 5, 6], format: "xyzwhd" });
     const { size } = bboxTransform(bbox);
-    expect(size).toEqual([4, 5, 6]);
+    expect(size).toEqual([4, 6, 5]);
   });
 });
 
@@ -159,11 +161,12 @@ describe("threeBoxToLanceXYZWHD", () => {
     expect(lz).toBeCloseTo(3);
   });
 
-  it("passes size through unchanged as Lance w/h/d", () => {
+  it("swaps Three.js Y/Z extents back to Lance size_y/size_z", () => {
+    // Three.js size [X=4, Y=5, Z=6] → Lance [X-ext=4, Y-ext=Three Z=6, Z-ext=Three Y=5].
     const coords = threeBoxToLanceXYZWHD([0, 0, 0], [4, 5, 6]);
-    expect(coords[3]).toBeCloseTo(4); // w
-    expect(coords[4]).toBeCloseTo(5); // h
-    expect(coords[5]).toBeCloseTo(6); // d
+    expect(coords[3]).toBeCloseTo(4); // Lance X-extent
+    expect(coords[4]).toBeCloseTo(6); // Lance Y-extent (Three.js Z)
+    expect(coords[5]).toBeCloseTo(5); // Lance Z-extent (Three.js Y, up)
   });
 
   it("round-trips with bboxTransform xyzwhd", () => {

--- a/ui/apps/web/src/lib/annotations/coordinateTransforms.ts
+++ b/ui/apps/web/src/lib/annotations/coordinateTransforms.ts
@@ -47,10 +47,13 @@ export function bboxTransform(bbox: BBox3DGeometry): {
       quaternion: lanceRotationToThree(bbox.rotation),
     };
   }
-  // xyzwhd: center (x,y,z) + extents (w,h,d) where h=LanceZ-extent = Three.js Y-extent.
+  // xyzwhd: center (x,y,z) + extents (w,h,d) along Lance axes X, Y, Z — the
+  // exact convention the backend uses to build the box corners
+  // (BBox3D.get_3dbbox_corners). Same axis swap as xyzxyz: the Lance Z-extent
+  // (c[5]) is the up direction and must land on Three.js Y.
   return {
     position: lanceToThree(c[0], c[1], c[2]),
-    size: [c[3], c[4], c[5]],
+    size: [c[3], c[5], c[4]],
     quaternion: lanceRotationToThree(bbox.rotation),
   };
 }
@@ -79,8 +82,10 @@ export function threeQuaternionToLanceRotation(q: THREE.Quaternion): number[] {
  * lanceToThree(lx, ly, lz) = [lx, lz, -ly]
  * Inverse:  lx = three.x,  ly = -three.z,  lz = three.y
  *
- * Size mapping (xyzwhd, no axis swap):
- *   w = Three.js X-extent,  h = Three.js Y-extent,  d = Three.js Z-extent
+ * Size mapping (inverse of bboxTransform's xyzwhd axis swap [c3, c5, c4]):
+ *   Lance X-extent = Three.js X-extent, Lance Y-extent = Three.js Z-extent,
+ *   Lance Z-extent = Three.js Y-extent. Stored as [w, d, h] so the Lance
+ *   coords match the backend's own [size_x, size_y, size_z] convention.
  */
 export function threeBoxToLanceXYZWHD(
   center: [number, number, number],
@@ -88,5 +93,5 @@ export function threeBoxToLanceXYZWHD(
 ): [number, number, number, number, number, number] {
   const [tx, ty, tz] = center;
   const [w, h, d] = size;
-  return [tx, -tz, ty, w, h, d];
+  return [tx, -tz, ty, w, d, h];
 }


### PR DESCRIPTION
3D boxes stored as `xyzwhd` (e.g. nuScenes, produced by the backend) rendered lying down instead of upright. The backend's ground-truth convention (BBox3D.get_3dbbox_corners) stores extents along Lance axes X, Y, Z, where Z is up. The frontend maps Lance Z to Three.js Y (up), and the `xyzxyz` path applies that swap — but the `xyzwhd` path passed extents through unchanged, sending the Z-extent (height) to a horizontal axis. For a pedestrian, the ~1.7m height landed sideways → box couché.

Apply the same [x, z, y] extent swap on the `xyzwhd` read path (bboxTransform) and its inverse on the write path
(threeBoxToLanceXYZWHD), so drawn boxes are stored in the backend's convention and round-trip correctly. Update the transform unit tests to assert against the true backend convention instead of the passthrough.

No data migration needed: no boxes were persisted under the old frontend convention.
