### PR TITLE
feat: add Video time-window fields and spec_version storage migration

### DIFF
--- a/src/pixano/datasets/dataset.py
+++ b/src/pixano/datasets/dataset.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import io
+import json
+import logging
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -38,6 +40,7 @@ from pixano.schemas import (
     ViewEmbedding,
     is_image,
     is_sequence_frame,
+    is_video,
     is_view_embedding,
     validate_canonical_table_map,
 )
@@ -50,6 +53,9 @@ from .dataset_stat import DatasetStatistic
 
 if TYPE_CHECKING:
     pass
+
+
+logger = logging.getLogger(__name__)
 
 
 def _combine_where_clauses(*clauses: str | None) -> str | None:
@@ -139,7 +145,59 @@ class Dataset:
         self.previews_path = self.path / self._PREVIEWS_PATH
 
         self._db_connection = self._connect()
+        if self.info.spec_version < self._CURRENT_SPEC_VERSION:
+            try:
+                self._migrate_storage_to_spec_version_2()
+            except Exception as exc:
+                # A read-only dataset stays readable at the old layout; writes will
+                # surface the missing columns explicitly.
+                logger.warning(
+                    "Dataset %s: spec version %d migration failed, continuing unmigrated: %s",
+                    self.path,
+                    self._CURRENT_SPEC_VERSION,
+                    exc,
+                )
         self._num_rows_cache: int | None = None
+
+    # ------------------------------------------------------------------
+    # Storage-layout migrations
+    # ------------------------------------------------------------------
+
+    _CURRENT_SPEC_VERSION: int = 2
+
+    def _migrate_storage_to_spec_version_2(self) -> None:
+        """Backfill the ``Video`` time-window columns introduced in spec version 2.
+
+        Concurrency-safe: when several processes open the same pre-migration
+        dataset, losers of the ``add_columns`` race converge by re-reading the
+        table schema, and the ``info.json`` rewrite is atomic and idempotent
+        (all writers produce identical content).
+        """
+        window_columns = {"from_timestamp": "0.0", "to_timestamp": "-1.0"}
+        for table_name, schema_cls in self.info.tables.items():
+            if not is_video(schema_cls):
+                continue
+            table = self.open_table(table_name)
+            missing = {column: expr for column, expr in window_columns.items() if column not in table.schema.names}
+            if not missing:
+                continue
+            try:
+                table.add_columns(missing)
+            except Exception:
+                still_missing = [
+                    column for column in missing if column not in self.open_table(table_name).schema.names
+                ]
+                if still_missing:
+                    raise
+
+        # Patch the raw JSON rather than re-serializing self.info: from_json drops
+        # views it cannot deserialize, and a re-serialization would persist that loss.
+        info_json = json.loads(self._info_file.read_text(encoding="utf-8"))
+        info_json["spec_version"] = self._CURRENT_SPEC_VERSION
+        tmp_file = self._info_file.with_name(self._info_file.name + ".tmp")
+        tmp_file.write_text(json.dumps(info_json, indent=4), encoding="utf-8")
+        tmp_file.replace(self._info_file)
+        self.info.spec_version = self._CURRENT_SPEC_VERSION
 
     # ------------------------------------------------------------------
     # Factory

--- a/src/pixano/datasets/dataset_info.py
+++ b/src/pixano/datasets/dataset_info.py
@@ -83,6 +83,8 @@ class DatasetInfo(BaseModel):
         preview: Path to a preview thumbnail.
         workspace: Workspace type.
         storage_mode: How media data is stored.
+        spec_version: Version of the on-disk dataset layout this dataset conforms to
+            (datasets written before the field existed load as version 1).
         record: Main record schema.
         entity: Entity schema.
         entity_dynamic_state: Entity dynamic state schema.
@@ -104,6 +106,7 @@ class DatasetInfo(BaseModel):
     preview: str = ""
     workspace: WorkspaceType = WorkspaceType.UNDEFINED
     storage_mode: Literal["filesystem", "embedded", "mixed"] = "filesystem"
+    spec_version: int = 2
     record: type[Record] | None = None
     entity: type[Entity] | None = None
     entity_dynamic_state: type[EntityDynamicState] | None = None
@@ -271,6 +274,8 @@ class DatasetInfo(BaseModel):
         info_json["workspace"] = (
             WorkspaceType(info_json["workspace"]) if "workspace" in info_json else WorkspaceType.UNDEFINED
         )
+        # Datasets written before spec_version existed are layout version 1.
+        info_json.setdefault("spec_version", 1)
 
         for slot_name in supported_dataset_info_slots():
             schema_payload = info_json.get(slot_name)

--- a/src/pixano/schemas/views/video.py
+++ b/src/pixano/schemas/views/video.py
@@ -16,13 +16,22 @@ from .view import View
 class Video(View):
     """Video view.
 
+    A `Video` row addresses a time window inside the media it references:
+    `[from_timestamp, to_timestamp)` in seconds. Whole files are the
+    degenerate window (`from_timestamp=0.0`, `to_timestamp=-1.0` meaning end
+    of media). `num_frames` and `duration` describe the window, not the
+    underlying file. Frame addressing inside the window is
+    `media_ts = from_timestamp + frame_index / fps`.
+
     Attributes:
-        num_frames: The number of frames in the video.
+        num_frames: The number of frames in the video window.
         fps: The frames per second of the video.
         width: The video width.
         height: The video height.
         format: The video format.
-        duration: The video duration.
+        duration: The video window duration.
+        from_timestamp: Window start inside the media, in seconds.
+        to_timestamp: Window end inside the media, in seconds (-1 means end of media).
     """
 
     num_frames: int
@@ -31,6 +40,8 @@ class Video(View):
     height: int
     format: str
     duration: float
+    from_timestamp: float = 0.0
+    to_timestamp: float = -1.0
 
 
 def is_video(cls: type, strict: bool = False) -> bool:
@@ -49,6 +60,8 @@ def create_video(
     height: int | None = None,
     format: str | None = None,
     duration: float | None = None,
+    from_timestamp: float = 0.0,
+    to_timestamp: float = -1.0,
     preview: bytes = b"",
     preview_format: str = "",
 ) -> Video:
@@ -67,6 +80,8 @@ def create_video(
         height: The video height. If None, the height is extracted from the video file.
         format: The video format. If None, the format is extracted from the video file.
         duration: The video duration. If None, the duration is extracted from the video file.
+        from_timestamp: Window start inside the media, in seconds.
+        to_timestamp: Window end inside the media, in seconds (-1 means end of media).
         preview: Thumbnail/preview bytes.
         preview_format: Preview format (e.g. "jpeg", "png").
 
@@ -123,6 +138,8 @@ def create_video(
         height=height,
         format=format,
         duration=duration,
+        from_timestamp=from_timestamp,
+        to_timestamp=to_timestamp,
         preview=preview,
         preview_format=preview_format,
     )

--- a/tests/datasets/test_dataset_info.py
+++ b/tests/datasets/test_dataset_info.py
@@ -40,6 +40,7 @@ class TestDatasetInfo:
             "preview",
             "workspace",
             "storage_mode",
+            "spec_version",
             "record",
             "entity",
             "entity_dynamic_state",
@@ -91,6 +92,7 @@ class TestDatasetInfo:
     "preview": "/preview",
     "workspace": "image",
     "storage_mode": "filesystem",
+    "spec_version": 2,
     "record": {
         "base": "Record",
         "fields": {}
@@ -165,6 +167,7 @@ class TestDatasetInfo:
             size="8GB",
             preview="/preview",
             workspace=WorkspaceType.IMAGE,
+            spec_version=1,  # absent in the JSON above ⇒ pre-spec_version layout
             record=Record,
             entity=Entity,
             bbox=BBox,
@@ -348,3 +351,24 @@ class TestDatasetInfo:
     def test_rejects_tables_mapping(self):
         with pytest.raises(ValueError, match="no longer accepts a 'tables' mapping"):
             DatasetInfo(tables={"records": Record})
+
+
+class TestSpecVersion:
+    def test_defaults_to_2_for_new_infos(self):
+        assert DatasetInfo().spec_version == 2
+
+    def test_absent_in_json_means_version_1(self):
+        temp_file = Path(tempfile.NamedTemporaryFile(suffix=".json").name)
+        temp_file.write_text(
+            """{
+    "id": "id",
+    "name": "old",
+    "workspace": "image",
+    "record": {
+        "base": "Record",
+        "fields": {}
+    },
+    "views": {}
+}"""
+        )
+        assert DatasetInfo.from_json(temp_file).spec_version == 1

--- a/tests/datasets/test_dataset_migration.py
+++ b/tests/datasets/test_dataset_migration.py
@@ -1,0 +1,146 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import json
+import multiprocessing
+from pathlib import Path
+
+from pixano.datasets import Dataset, DatasetInfo
+from pixano.schemas import Record, Video
+
+
+def _make_video_dataset(path: Path) -> Dataset:
+    info = DatasetInfo(name="video_ds", record=Record, views={"video": Video})
+    dataset = Dataset.create(path, info)
+    dataset.add_records(
+        {
+            "records": Record(id="rec1"),
+            "videos": Video(
+                id="vid1",
+                record_id="rec1",
+                logical_name="video",
+                uri="videos/clip.mp4",
+                num_frames=10,
+                fps=25.0,
+                width=64,
+                height=48,
+                format="mp4",
+                duration=0.4,
+            ),
+        },
+        check_integrity="none",
+    )
+    return dataset
+
+
+def _downgrade_to_spec_version_1(path: Path) -> None:
+    """Rewrite a freshly built dataset into the pre-window, pre-spec_version layout."""
+    dataset = Dataset(path)
+    dataset.open_table("videos").drop_columns(["from_timestamp", "to_timestamp"])
+    info_file = path / Dataset._INFO_FILE
+    info_json = json.loads(info_file.read_text(encoding="utf-8"))
+    info_json.pop("spec_version", None)
+    info_file.write_text(json.dumps(info_json, indent=4), encoding="utf-8")
+
+
+def _open_dataset(path_str: str) -> None:
+    import os
+
+    from pixano.datasets import Dataset  # noqa: PLC0415 (spawned process)
+
+    dataset = Dataset(Path(path_str))
+    assert "from_timestamp" in dataset.open_table("videos").schema.names
+    # Skip interpreter finalization: lance's native background threads can crash
+    # CPython teardown (PyGILState_Release) in short-lived spawned workers.
+    os._exit(0)
+
+
+class TestSpecVersion2Migration:
+    def test_backfill_on_open(self, tmp_path: Path):
+        dataset_path = tmp_path / "video_ds"
+        _make_video_dataset(dataset_path)
+        _downgrade_to_spec_version_1(dataset_path)
+
+        dataset = Dataset(dataset_path)
+
+        assert dataset.info.spec_version == 2
+        schema_names = dataset.open_table("videos").schema.names
+        assert "from_timestamp" in schema_names
+        assert "to_timestamp" in schema_names
+
+        info_json = json.loads((dataset_path / Dataset._INFO_FILE).read_text(encoding="utf-8"))
+        assert info_json["spec_version"] == 2
+
+        videos = dataset.get_data("videos")
+        assert len(videos) == 1
+        assert videos[0].from_timestamp == 0.0
+        assert videos[0].to_timestamp == -1.0
+
+    def test_migration_is_idempotent(self, tmp_path: Path):
+        dataset_path = tmp_path / "video_ds"
+        _make_video_dataset(dataset_path)
+        _downgrade_to_spec_version_1(dataset_path)
+
+        Dataset(dataset_path)
+        first_pass = (dataset_path / Dataset._INFO_FILE).read_text(encoding="utf-8")
+        Dataset(dataset_path)
+        second_pass = (dataset_path / Dataset._INFO_FILE).read_text(encoding="utf-8")
+
+        assert first_pass == second_pass
+
+    def test_writes_succeed_after_migration(self, tmp_path: Path):
+        dataset_path = tmp_path / "video_ds"
+        _make_video_dataset(dataset_path)
+        _downgrade_to_spec_version_1(dataset_path)
+
+        dataset = Dataset(dataset_path)
+        dataset.add_data(
+            "videos",
+            [
+                Video(
+                    id="vid2",
+                    record_id="rec1",
+                    logical_name="video",
+                    uri="videos/clip.mp4",
+                    num_frames=5,
+                    fps=25.0,
+                    width=64,
+                    height=48,
+                    format="mp4",
+                    duration=0.2,
+                    from_timestamp=1.0,
+                    to_timestamp=1.2,
+                )
+            ],
+            raise_or_warn="none",
+        )
+        windows = {video.id: (video.from_timestamp, video.to_timestamp) for video in dataset.get_data("videos")}
+        assert windows == {"vid1": (0.0, -1.0), "vid2": (1.0, 1.2)}
+
+    def test_fresh_dataset_needs_no_migration(self, tmp_path: Path):
+        dataset_path = tmp_path / "video_ds"
+        _make_video_dataset(dataset_path)
+
+        dataset = Dataset(dataset_path)
+        assert dataset.info.spec_version == 2
+        assert not (dataset_path / (Dataset._INFO_FILE + ".tmp")).exists()
+
+    def test_concurrent_opens_converge(self, tmp_path: Path):
+        dataset_path = tmp_path / "video_ds"
+        _make_video_dataset(dataset_path)
+        _downgrade_to_spec_version_1(dataset_path)
+
+        ctx = multiprocessing.get_context("spawn")
+        workers = [ctx.Process(target=_open_dataset, args=(str(dataset_path),)) for _ in range(2)]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=120)
+
+        assert all(worker.exitcode == 0 for worker in workers)
+        dataset = Dataset(dataset_path)
+        assert dataset.info.spec_version == 2
+        assert "from_timestamp" in dataset.open_table("videos").schema.names


### PR DESCRIPTION
## Issue

Part of the 0.8.0 import/export redesign stack (spec: #664, `docs/specs/data-import-export.md` §11.1/§11.6).

## Description

- `Video` gains `from_timestamp`/`to_timestamp`: a video row now addresses a **time window** inside its media (whole files are the degenerate window). Required for LeRobot v3, whose mp4 shards contain many episodes.
- `DatasetInfo.spec_version` tracks the on-disk layout version (absent in existing `info.json` ⇒ 1).
- Opening a spec-v1 dataset backfills the window columns once via `add_columns` and stamps `spec_version=2`. The migration is concurrency-safe (losers of the `add_columns` race converge on the table schema; the `info.json` rewrite is atomic and idempotent, and patches the raw JSON so views that failed to deserialize are never silently dropped from disk). Read-only datasets stay readable unmigrated.

Tests include a real two-process concurrent-open race, idempotent re-open, post-migration writes, and `spec_version` defaulting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)