### PR TITLE
feat: add Dataset.merge_records, scalar indexes, and cache invalidation

### DIFF
--- a/src/pixano/api/routers/_deps.py
+++ b/src/pixano/api/routers/_deps.py
@@ -18,6 +18,21 @@ from pixano.datasets import Dataset
 _dataset_cache: dict[str, Dataset] = {}
 
 
+def invalidate_dataset(dataset_id: str) -> None:
+    """Drop cached `Dataset` instances for the given dataset id.
+
+    Registered as a `Dataset` cache-invalidation hook so that rebuilding or
+    overwriting a dataset on disk (e.g. an import job) is picked up by the API
+    without a server restart.
+    """
+    prefix = f"{dataset_id}:"
+    for cache_key in [key for key in _dataset_cache if key.startswith(prefix)]:
+        _dataset_cache.pop(cache_key, None)
+
+
+Dataset.register_cache_invalidation_hook(invalidate_dataset)
+
+
 def get_dataset_dep(
     dataset_id: str,
     settings: Settings = Depends(get_settings),

--- a/src/pixano/datasets/dataset.py
+++ b/src/pixano/datasets/dataset.py
@@ -12,7 +12,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Literal, Union, cast, overload
+from typing import TYPE_CHECKING, Callable, ClassVar, List, Literal, Sequence, Union, cast, overload
 
 import lancedb
 import PIL.Image
@@ -99,8 +99,8 @@ class Dataset:
     It is a collection of tables that can be queried and manipulated with LanceDB.
 
     Tables are defined by the :class:`DatasetInfo` ``tables`` mapping, which maps
-    table names to :class:`LanceModel` schema classes.  The main table is always
-    named ``"record"`` and its schema must inherit from :class:`Record`.  All
+    table names to :class:`LanceModel` schema classes. The main table is always
+    named ``"records"`` and its schema must inherit from :class:`Record`.  All
     auxiliary tables must have schemas that inherit from :class:`RecordComponent`.
 
     Attributes:
@@ -441,7 +441,7 @@ class Dataset:
             schema = self.info.tables.get(table_name)
         if schema is None:
             return set()
-        return {"blob"} if "blob" in schema.model_fields else set()
+        return {column for column in ("blob", "raw_bytes") if column in schema.model_fields}
 
     def open_tables(self, names: list[str] | None = None, exclude_embeddings: bool = True) -> dict[str, LanceTable]:
         """Open the dataset tables with LanceDB.
@@ -1021,12 +1021,203 @@ class Dataset:
         # Insert into LanceDB in dependency order
         for table_name in ordered_tables:
             rows = normalized[table_name]
+            for row in rows:
+                if hasattr(row, "created_at"):
+                    row.created_at = datetime.now()
+                if hasattr(row, "updated_at"):
+                    row.updated_at = row.created_at if hasattr(row, "created_at") else datetime.now()
             table = self.open_table(table_name)
             table.add(rows)
 
         # Invalidate row-count cache if records were touched
         if SchemaGroup.RECORD.value in normalized:
             self._num_rows_cache = None
+
+    def merge_records(
+        self,
+        data: dict[str, LanceModel | list[LanceModel] | pa.RecordBatch | pa.Table],
+        check_integrity: Literal["raise", "warn", "none"] = "raise",
+        known_ids: dict[str, set[str]] | None = None,
+    ) -> dict[str, int]:
+        """Upsert rows into multiple tables in a single call.
+
+        The multi-table counterpart of :meth:`update_data` and the idempotent
+        counterpart of :meth:`add_records`: rows whose ``id`` already exists
+        are updated, new ids are inserted, so re-running the same payload
+        converges instead of duplicating. Tables are processed in FK
+        dependency order (record → view → entity → … → annotation).
+
+        Args:
+            data: Mapping of table name to one or more rows, or to an Arrow
+                ``RecordBatch``/``Table``. Arrow payloads currently require
+                ``check_integrity="none"`` — vectorized Arrow integrity checks
+                land with the import engine (spec §8); missing
+                ``created_at``/``updated_at`` columns are appended to Arrow
+                payloads so the LanceDB schema cast cannot fail on them.
+            check_integrity: Integrity-check mode for row payloads. Uniqueness
+                against already-stored ids is intentionally not enforced
+                (existing ids are updates by design); in-batch duplicates,
+                missing ids, and foreign keys are checked.
+            known_ids: Optional ``table → ids`` mapping (e.g. an import
+                engine's id ledger) used to resolve foreign keys without DB
+                lookups.
+
+        Returns:
+            Mapping of table name to number of rows upserted.
+        """
+        row_payloads: dict[str, list[LanceModel]] = {}
+        arrow_payloads: dict[str, pa.Table] = {}
+        for table_name, value in data.items():
+            if value is None:
+                continue
+            if isinstance(value, pa.RecordBatch):
+                value = pa.Table.from_batches([value])
+            if isinstance(value, pa.Table):
+                if value.num_rows:
+                    arrow_payloads[table_name] = value
+                continue
+            rows = value if isinstance(value, list) else [value]
+            if rows:
+                row_payloads[table_name] = rows
+
+        if arrow_payloads and check_integrity != "none":
+            raise NotImplementedError(
+                "merge_records only supports Arrow payloads with check_integrity='none' for now. "
+                "Vectorized Arrow integrity checks land with the import engine (spec §8)."
+            )
+        if not row_payloads and not arrow_payloads:
+            return {}
+
+        ordered_tables = self._table_insert_order([*row_payloads.keys(), *arrow_payloads.keys()])
+
+        # Sort temporal row batches by timestamp for storage co-locality.
+        for table_name, rows in row_payloads.items():
+            schema_type = self.info.tables.get(table_name)
+            if schema_type is not None and "timestamp" in schema_type.model_fields:
+                row_payloads[table_name] = sorted(rows, key=lambda s: (getattr(s, "timestamp", 0),))
+
+        if check_integrity != "none":
+            pending_ids: dict[str, set[str]] = {
+                tname: {row.id for row in rows if row.id} for tname, rows in row_payloads.items()
+            }
+            accumulated: dict[str, set[str]] = {tname: set(ids) for tname, ids in (known_ids or {}).items()}
+            for table_name in ordered_tables:
+                rows_to_check = row_payloads.get(table_name)
+                if rows_to_check is None:
+                    continue
+                # Upsert semantics: ids already known for the target table are
+                # legal (they are updates), so uniqueness applies only inside
+                # the batch; other tables' known ids still resolve FKs.
+                upsert_known = {tname: ids for tname, ids in accumulated.items() if tname != table_name}
+                validate_batch(
+                    table_name,
+                    rows_to_check,
+                    upsert_known,
+                    self,
+                    raise_or_warn=check_integrity,
+                    pending_ids=pending_ids,
+                )
+                accumulated.setdefault(table_name, set()).update(row.id for row in rows_to_check if row.id)
+
+        counts: dict[str, int] = {}
+        for table_name in ordered_tables:
+            table = self.open_table(table_name)
+            if table_name in row_payloads:
+                rows = row_payloads[table_name]
+                self._stamp_upsert_timestamps(table, rows)
+                table.merge_insert("id").when_matched_update_all().when_not_matched_insert_all().execute(rows)
+                counts[table_name] = len(rows)
+            else:
+                arrow_table = self._with_timestamp_columns(table, arrow_payloads[table_name])
+                table.merge_insert("id").when_matched_update_all().when_not_matched_insert_all().execute(arrow_table)
+                counts[table_name] = arrow_table.num_rows
+
+        if SchemaGroup.RECORD.value in counts:
+            self._num_rows_cache = None
+        return counts
+
+    def _stamp_upsert_timestamps(self, table: LanceTable, rows: list[LanceModel]) -> None:
+        """Stamp ``updated_at`` and preserve stored ``created_at`` for existing rows."""
+        if not rows or not (hasattr(rows[0], "created_at") or hasattr(rows[0], "updated_at")):
+            return
+
+        stored_created_at: dict[str, datetime | None] = {}
+        if hasattr(rows[0], "created_at"):
+            row_ids = {row.id for row in rows if row.id}
+            if row_ids:
+                stored_created_at = {
+                    stored["id"]: stored["created_at"]
+                    for stored in TableQueryBuilder(table, self._db_connection)
+                    .select(["id", "created_at"])
+                    .where(f"id in {to_sql_list(row_ids)}")
+                    .to_list()
+                }
+
+        for row in rows:
+            now = datetime.now()
+            if hasattr(row, "updated_at"):
+                row.updated_at = now
+            if hasattr(row, "created_at"):
+                existing = stored_created_at.get(row.id)
+                row.created_at = existing if existing is not None else now
+
+    def _with_timestamp_columns(self, table: LanceTable, arrow_table: pa.Table) -> pa.Table:
+        """Append missing ``created_at``/``updated_at`` columns to an Arrow payload."""
+        table_schema = table.schema
+        present = set(arrow_table.schema.names)
+        now = datetime.now()
+        for column in ("created_at", "updated_at"):
+            if column in table_schema.names and column not in present:
+                field = table_schema.field(column)
+                arrow_table = arrow_table.append_column(field, pa.array([now] * arrow_table.num_rows, type=field.type))
+        return arrow_table
+
+    def create_scalar_indexes(
+        self,
+        columns: Sequence[str] = ("id", "record_id"),
+        tables: Sequence[str] | None = None,
+    ) -> None:
+        """Create BTree scalar indexes on the given columns of the given tables.
+
+        Idempotent: columns that are already indexed or absent from a table's
+        schema are skipped. Indexes make ``merge_insert``, foreign-key lookups,
+        export paging, and ``record_id`` filters scale past full-table scans.
+
+        Args:
+            columns: Column names to index where present.
+            tables: Table names to index. Defaults to every dataset table.
+        """
+        table_names = list(tables) if tables is not None else list(self.info.tables.keys())
+        for table_name in table_names:
+            table = self.open_table(table_name)
+            indexed_columns: set[str] = set()
+            for index in table.list_indices():
+                indexed_columns.update(getattr(index, "columns", None) or [])
+            schema_names = set(table.schema.names)
+            for column in columns:
+                if column in schema_names and column not in indexed_columns:
+                    table.create_scalar_index(column, index_type="BTREE")
+
+    # ------------------------------------------------------------------
+    # Cross-process cache invalidation
+    # ------------------------------------------------------------------
+
+    _cache_invalidation_hooks: ClassVar[list[Callable[[str], None]]] = []
+
+    @classmethod
+    def register_cache_invalidation_hook(cls, hook: Callable[[str], None]) -> None:
+        """Register a callable invoked with a dataset id when its caches must be dropped."""
+        if hook not in cls._cache_invalidation_hooks:
+            cls._cache_invalidation_hooks.append(hook)
+
+    @classmethod
+    def invalidate_caches(cls, dataset_id: str) -> None:
+        """Notify registered caches that a dataset changed on disk (e.g. after an import)."""
+        for hook in cls._cache_invalidation_hooks:
+            try:
+                hook(dataset_id)
+            except Exception as exc:
+                logger.warning("Cache invalidation hook %r failed for dataset %s: %s", hook, dataset_id, exc)
 
     def delete_data(self, table_name: str, ids: list[str]) -> list[str]:
         """Delete data from a table.

--- a/src/pixano/datasets/dataset_features_values.py
+++ b/src/pixano/datasets/dataset_features_values.py
@@ -41,16 +41,23 @@ class DatasetFeaturesValues(BaseModel):
     """Constraints for the dataset features values.
 
     Attributes:
-        item: Constraints for the dataset item table.
+        item: Constraints for the dataset item table (legacy name, kept for
+            on-disk compatibility with existing ``features_values.json`` files).
+        records: Constraints for the dataset record table.
         views: Constraints for the dataset view tables.
         entities: Constraints for the dataset entity tables.
+        entity_dynamic_states: Constraints for the entity dynamic state table.
         annotations: Constraints for the dataset annotation tables.
+        embeddings: Constraints for the dataset embedding tables.
     """
 
     item: ConstraintDict = {}
+    records: ConstraintDict = {}
     views: ConstraintDict = {}
     entities: ConstraintDict = {}
+    entity_dynamic_states: ConstraintDict = {}
     annotations: ConstraintDict = {}
+    embeddings: ConstraintDict = {}
 
     def to_json(self, json_fp: Path) -> None:
         """Save DatasetFeaturesValues to json file."""

--- a/src/pixano/datasets/utils/integrity.py
+++ b/src/pixano/datasets/utils/integrity.py
@@ -6,7 +6,7 @@
 
 import warnings
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from pixano.datasets.utils.errors import DatasetIntegrityError
 from pixano.schemas import SchemaGroup, canonical_table_name_for_slot
@@ -188,6 +188,7 @@ def validate_batch(
     dataset: "Dataset",
     raise_or_warn: Literal["raise", "warn", "none"] = "raise",
     pending_ids: dict[str, set[str]] | None = None,
+    fk_lookup: Callable[[str, set[str]], dict[str, bool]] | None = None,
 ) -> None:
     """Validate a batch of schemas before insertion using in-memory ID tracking.
 
@@ -203,6 +204,9 @@ def validate_batch(
         pending_ids: Mapping of table_name -> set of IDs that are buffered for insertion
             in this flush cycle. Used only for FK checks so sibling tables that haven't
             been flushed yet can be resolved.
+        fk_lookup: Optional replacement for the bulk DB lookup, called as
+            ``fk_lookup(target_table, values) -> {value: found}``. An import engine
+            can answer from its id ledger to skip DB scans on fresh builds.
     """
     errors: list[tuple[IntegrityCheck, str, str, str, Any]] = []
 
@@ -239,11 +243,12 @@ def validate_batch(
                 for t in target_tables:
                     fk_values_by_target.setdefault(t, set()).add(field_value)
 
-    # Bulk DB queries: one per target table
+    # Bulk lookups: one per target table (DB by default, or the caller's ledger)
+    lookup = fk_lookup if fk_lookup is not None else dataset.find_ids_in_table
     db_found: dict[str, set[str]] = {}
     for target_table, values in fk_values_by_target.items():
         try:
-            result = dataset.find_ids_in_table(target_table, values)
+            result = lookup(target_table, values)
             db_found[target_table] = {v for v, found in result.items() if found}
         except Exception:
             db_found[target_table] = set()

--- a/tests/datasets/test_dataset_features_values.py
+++ b/tests/datasets/test_dataset_features_values.py
@@ -27,7 +27,15 @@ class TestDatasetFeaturesValues:
             },
             annotations={"annotation1": []},
         )
-        assert set(type(fv).model_fields.keys()) == {"item", "views", "entities", "annotations"}
+        assert set(type(fv).model_fields.keys()) == {
+            "item",
+            "records",
+            "views",
+            "entities",
+            "entity_dynamic_states",
+            "annotations",
+            "embeddings",
+        }
 
     def test_to_json(self):
         fv = DatasetFeaturesValues(
@@ -58,6 +66,7 @@ class TestDatasetFeaturesValues:
             }
         ]
     },
+    "records": {},
     "views": {},
     "entities": {
         "entity1": [
@@ -79,9 +88,11 @@ class TestDatasetFeaturesValues:
             }
         ]
     },
+    "entity_dynamic_states": {},
     "annotations": {
         "annotation1": []
-    }
+    },
+    "embeddings": {}
 }"""
         )
 

--- a/tests/datasets/test_merge_records.py
+++ b/tests/datasets/test_merge_records.py
@@ -1,0 +1,236 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from pixano.datasets import Dataset, DatasetInfo
+from pixano.datasets.utils.errors import DatasetIntegrityError
+from pixano.schemas import BBox, Entity, Image, Record
+
+
+def _make_dataset(path: Path) -> Dataset:
+    info = DatasetInfo(name="merge_ds", record=Record, entity=Entity, bbox=BBox, views={"image": Image})
+    return Dataset.create(path, info)
+
+
+def _payload() -> dict:
+    return {
+        "records": Record(id="rec1"),
+        "images": Image(
+            id="img1", record_id="rec1", logical_name="image", uri="images/1.jpg", width=64, height=48, format="JPEG"
+        ),
+        "entities": Entity(id="ent1", record_id="rec1"),
+        "bboxes": BBox(
+            id="box1",
+            record_id="rec1",
+            entity_id="ent1",
+            coords=[0.1, 0.1, 0.2, 0.2],
+            format="xywh",
+            is_normalized=True,
+            confidence=1.0,
+        ),
+    }
+
+
+def _table_counts(dataset: Dataset) -> dict[str, int]:
+    return {name: dataset.open_table(name).count_rows() for name in dataset.info.tables}
+
+
+class TestMergeRecords:
+    def test_run_twice_is_idempotent(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+
+        first = dataset.merge_records(_payload(), check_integrity="raise")
+        counts_after_first = _table_counts(dataset)
+        second = dataset.merge_records(_payload(), check_integrity="raise")
+
+        assert first == second == {"records": 1, "images": 1, "entities": 1, "bboxes": 1}
+        assert (
+            _table_counts(dataset)
+            == counts_after_first
+            == {
+                "records": 1,
+                "images": 1,
+                "entities": 1,
+                "bboxes": 1,
+            }
+        )
+
+    def test_upsert_updates_fields_and_preserves_created_at(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        dataset.merge_records(_payload(), check_integrity="raise")
+        record_created_at_before = dataset.get_data("records")[0].created_at
+
+        updated = _payload()
+        updated["bboxes"].confidence = 0.5
+        dataset.merge_records(updated, check_integrity="raise")
+
+        boxes = dataset.get_data("bboxes")
+        assert len(boxes) == 1
+        assert boxes[0].confidence == 0.5
+
+        # Timestamps live on the record table: created_at survives the upsert,
+        # updated_at moves forward.
+        record = dataset.get_data("records")[0]
+        assert record.created_at == record_created_at_before
+        assert record.updated_at >= record_created_at_before
+
+    def test_dangling_fk_raises(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        payload = _payload()
+        payload["bboxes"].entity_id = "ghost"
+
+        with pytest.raises(DatasetIntegrityError, match="ghost"):
+            dataset.merge_records(payload, check_integrity="raise")
+
+    def test_known_ids_ledger_resolves_fks(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        dataset.merge_records(_payload(), check_integrity="raise")
+
+        # A later flush referencing only already-imported parents, resolved via the ledger.
+        late_box = BBox(
+            id="box2",
+            record_id="rec1",
+            entity_id="ent1",
+            coords=[0.3, 0.3, 0.1, 0.1],
+            format="xywh",
+            is_normalized=True,
+            confidence=1.0,
+        )
+        counts = dataset.merge_records(
+            {"bboxes": late_box},
+            check_integrity="raise",
+            known_ids={"records": {"rec1"}, "entities": {"ent1"}},
+        )
+        assert counts == {"bboxes": 1}
+        assert dataset.open_table("bboxes").count_rows() == 2
+
+    def test_arrow_payload_requires_integrity_none(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        batch = pa.record_batch({"id": pa.array(["rec1"])})
+
+        with pytest.raises(NotImplementedError, match="check_integrity='none'"):
+            dataset.merge_records({"records": batch}, check_integrity="raise")
+
+    def test_arrow_payload_appends_timestamp_columns(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        arrow_schema = dataset.open_table("records").schema
+        subset_schema = pa.schema([f for f in arrow_schema if f.name not in ("created_at", "updated_at")])
+        row = Record(id="rec_arrow").model_dump(exclude={"created_at", "updated_at"})
+        arrow_table = pa.Table.from_pylist([row], schema=subset_schema)
+
+        counts = dataset.merge_records({"records": arrow_table}, check_integrity="none")
+
+        assert counts == {"records": 1}
+        stored = dataset.get_data("records", ids="rec_arrow")
+        assert stored is not None
+        assert stored.created_at is not None
+        assert stored.updated_at is not None
+
+        # Re-merging the same Arrow payload stays idempotent.
+        dataset.merge_records({"records": arrow_table}, check_integrity="none")
+        assert dataset.open_table("records").count_rows() == 1
+
+
+class TestCreateScalarIndexes:
+    def test_idempotent_index_creation(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        dataset.merge_records(_payload(), check_integrity="none")
+
+        dataset.create_scalar_indexes()
+        dataset.create_scalar_indexes()  # second call must be a no-op
+
+        bbox_indices = list(dataset.open_table("bboxes").list_indices())
+        indexed_columns = sorted(column for index in bbox_indices for column in index.columns)
+        assert indexed_columns == ["id", "record_id"]
+
+        # Records table has no record_id column: only id is indexed, absent columns skipped.
+        record_indices = list(dataset.open_table("records").list_indices())
+        assert sorted(column for index in record_indices for column in index.columns) == ["id"]
+
+
+class TestCacheInvalidation:
+    def test_hooks_are_called_and_errors_contained(self):
+        calls: list[str] = []
+
+        def hook(dataset_id: str) -> None:
+            calls.append(dataset_id)
+
+        def broken_hook(dataset_id: str) -> None:
+            raise RuntimeError("boom")
+
+        Dataset.register_cache_invalidation_hook(hook)
+        Dataset.register_cache_invalidation_hook(broken_hook)
+        try:
+            Dataset.invalidate_caches("ds42")
+        finally:
+            Dataset._cache_invalidation_hooks.remove(hook)
+            Dataset._cache_invalidation_hooks.remove(broken_hook)
+
+        assert calls == ["ds42"]
+
+    def test_api_dataset_cache_hook(self):
+        from pixano.api.routers import _deps
+
+        _deps._dataset_cache["ds1:/library"] = object()  # type: ignore[assignment]
+        _deps._dataset_cache["ds2:/library"] = object()  # type: ignore[assignment]
+        try:
+            Dataset.invalidate_caches("ds1")
+            assert "ds1:/library" not in _deps._dataset_cache
+            assert "ds2:/library" in _deps._dataset_cache
+        finally:
+            _deps._dataset_cache.clear()
+
+
+class TestValidateBatchFkLookup:
+    def test_fk_lookup_override(self, tmp_path: Path):
+        from pixano.datasets.utils.integrity import validate_batch
+
+        dataset = _make_dataset(tmp_path / "ds")
+        ghost_box = BBox(
+            id="boxg",
+            record_id="recg",
+            entity_id="entg",
+            coords=[0.1, 0.1, 0.2, 0.2],
+            format="xywh",
+            is_normalized=True,
+            confidence=1.0,
+        )
+
+        # Ledger says the parents exist: no error despite an empty DB.
+        validate_batch(
+            "bboxes",
+            [ghost_box],
+            {},
+            dataset,
+            raise_or_warn="raise",
+            fk_lookup=lambda table, values: {value: True for value in values},
+        )
+
+        # Ledger says they don't: same call fails.
+        with pytest.raises(DatasetIntegrityError):
+            validate_batch(
+                "bboxes",
+                [ghost_box],
+                {},
+                dataset,
+                raise_or_warn="raise",
+                fk_lookup=lambda table, values: {value: False for value in values},
+            )
+
+
+class TestFeaturesValuesBridges:
+    def test_add_constraint_on_records_table(self, tmp_path: Path):
+        dataset = _make_dataset(tmp_path / "ds")
+        dataset.add_constraint("records", "status", ["new", "validated"])
+
+        constraints = dataset.features_values.records["records"]
+        assert constraints[0].name == "status"
+        reloaded = type(dataset.features_values).from_json(tmp_path / "ds" / "features_values.json")
+        assert reloaded.records["records"][0].values == ["new", "validated"]


### PR DESCRIPTION
## Issue

Part of the 0.8.0 import/export redesign stack (spec: #664, `docs/specs/data-import-export.md` §11.5/§11.7).

## Description

Storage-core primitives the import engine builds on:

- `Dataset.merge_records`: FK-ordered multi-table **upsert** on `id` built on `merge_insert` — idempotent under re-delivery (run-twice converges), upsert-aware integrity (in-batch duplicates and FKs checked; existing ids are updates by design), stored `created_at` preservation, an external `known_ids` ledger hook, and Arrow payload support (`check_integrity="none"` until vectorized checks land in P3; missing timestamp columns are auto-appended so the LanceDB schema cast cannot fail).
- `Dataset.create_scalar_indexes`: idempotent BTree indexes on `id`/`record_id` — no index existed anywhere, so `merge_insert`, FK lookups, and `record_id` filters were full scans.
- `Dataset.register_cache_invalidation_hook`/`invalidate_caches`, with the API dataset cache registering itself — imports become visible without a server restart.
- `validate_batch(fk_lookup=...)` override so an import engine can answer FK existence from its ledger on fresh builds.
- Riders: `add_records` stamps timestamps like `add_data`; `_get_blob_columns` also promotes `raw_bytes` on the instance `create_table` path; `DatasetFeaturesValues` gains `records`/`entity_dynamic_states`/`embeddings` bridges so `add_constraint` stops raising `AttributeError`; fix `"record"` → `"records"` in the Dataset docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)