### PR TITLE
feat: expose REST resources for classification and relation

### DIFF
--- a/src/pixano/api/models.py
+++ b/src/pixano/api/models.py
@@ -16,6 +16,7 @@ from pixano.datasets import Dataset, DatasetFeaturesValues, DatasetInfo
 from pixano.datasets.dataset_schema import _serialize_table_schema
 from pixano.schemas import (
     BBox,
+    Classification,
     CompressedRLE,
     Embedding,
     Entity,
@@ -24,6 +25,7 @@ from pixano.schemas import (
     Message,
     MultiPath,
     Record,
+    Relation,
     TextSpan,
     Tracklet,
 )
@@ -279,6 +281,35 @@ KeyPointsUpdate = _create_transport_model(
 )
 KeyPointsResponse = _create_transport_model("KeyPointsResponse", KeyPoints)
 
+ClassificationCreate = _create_transport_model(
+    "ClassificationCreate",
+    Classification,
+    exclude_fields={"created_at", "updated_at"},
+    required_fields={"id"},
+)
+ClassificationUpdate = _create_transport_model(
+    "ClassificationUpdate",
+    Classification,
+    exclude_fields={"id", "created_at", "updated_at"},
+    optional=True,
+)
+ClassificationResponse = _create_transport_model("ClassificationResponse", Classification)
+
+RelationCreate = _create_transport_model(
+    "RelationCreate",
+    Relation,
+    exclude_fields={"created_at", "updated_at"},
+    required_fields={"id"},
+)
+RelationUpdate = _create_transport_model(
+    "RelationUpdate",
+    Relation,
+    exclude_fields={"id", "created_at", "updated_at"},
+    optional=True,
+)
+RelationResponse = _create_transport_model("RelationResponse", Relation)
+
+
 TextSpanCreate = _create_transport_model(
     "TextSpanCreate",
     TextSpan,
@@ -337,6 +368,8 @@ class DatasetInfoResponse(DatasetInfo):
         "mask",
         "multi_path",
         "keypoint",
+        "classification",
+        "relation",
         "tracklet",
         "message",
         "text_span",
@@ -389,6 +422,9 @@ __all__ = [
     "BBoxCreate",
     "BBoxResponse",
     "BBoxUpdate",
+    "ClassificationCreate",
+    "ClassificationResponse",
+    "ClassificationUpdate",
     "DatasetInfoResponse",
     "DatasetResponse",
     "EmbeddingCreate",
@@ -416,6 +452,9 @@ __all__ = [
     "MessageResponse",
     "MessageUpdate",
     "PaginatedResponse",
+    "RelationCreate",
+    "RelationResponse",
+    "RelationUpdate",
     "ImageResponse",
     "SFrameResponse",
     "TextResponse",

--- a/src/pixano/api/resources.py
+++ b/src/pixano/api/resources.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from pixano.schemas import (
     BBox,
+    Classification,
     CompressedRLE,
     Embedding,
     Entity,
@@ -22,6 +23,7 @@ from pixano.schemas import (
     Message,
     MultiPath,
     Record,
+    Relation,
     SchemaGroup,
     TextSpan,
     Tracklet,
@@ -32,6 +34,9 @@ from .models import (
     BBoxCreate,
     BBoxResponse,
     BBoxUpdate,
+    ClassificationCreate,
+    ClassificationResponse,
+    ClassificationUpdate,
     EmbeddingCreate,
     EmbeddingResponse,
     EntityCreate,
@@ -55,6 +60,9 @@ from .models import (
     RecordCreate,
     RecordResponse,
     RecordUpdate,
+    RelationCreate,
+    RelationResponse,
+    RelationUpdate,
     TextSpanCreate,
     TextSpanResponse,
     TextSpanUpdate,
@@ -137,6 +145,14 @@ def _validate_message_create(service: Any, data: dict[str, Any]) -> None:
 
     for referenced_entity_id in data.get("entity_ids", []):
         service.validate_entity_exists(referenced_entity_id)
+
+
+def _validate_entity_annotation_create(service: Any, data: dict[str, Any]) -> None:
+    service.validate_record_exists(data["record_id"])
+
+    entity_id = data.get("entity_id", "")
+    if entity_id:
+        service.validate_entity_exists(entity_id)
 
 
 RECORD_RESOURCE = ResourceSpec(
@@ -332,6 +348,36 @@ EMBEDDING_RESOURCE = ResourceSpec(
     allow_delete=False,
 )
 
+
+CLASSIFICATION_RESOURCE = ResourceSpec(
+    name="classification",
+    path="classifications",
+    tag="Classifications",
+    schema_group=SchemaGroup.ANNOTATION,
+    schema_cls=Classification,
+    canonical_table_name=canonical_table_name_for_schema(Classification),
+    create_model=ClassificationCreate,
+    update_model=ClassificationUpdate,
+    response_model=ClassificationResponse,
+    list_filters=("record_id", "entity_id", "view_name", "source_type", "where"),
+    validate_create=_validate_entity_annotation_create,
+)
+
+RELATION_RESOURCE = ResourceSpec(
+    name="relation",
+    path="relations",
+    tag="Relations",
+    schema_group=SchemaGroup.ANNOTATION,
+    schema_cls=Relation,
+    canonical_table_name=canonical_table_name_for_schema(Relation),
+    create_model=RelationCreate,
+    update_model=RelationUpdate,
+    response_model=RelationResponse,
+    list_filters=("record_id", "entity_id", "view_name", "source_type", "where"),
+    validate_create=_validate_entity_annotation_create,
+)
+
+
 RESOURCE_SPECS: tuple[ResourceSpec, ...] = (
     RECORD_RESOURCE,
     ENTITY_RESOURCE,
@@ -341,6 +387,8 @@ RESOURCE_SPECS: tuple[ResourceSpec, ...] = (
     MASK_RESOURCE,
     MULTI_PATH_RESOURCE,
     KEYPOINTS_RESOURCE,
+    CLASSIFICATION_RESOURCE,
+    RELATION_RESOURCE,
     MESSAGE_RESOURCE,
     TEXT_SPAN_RESOURCE,
     EMBEDDING_RESOURCE,
@@ -349,6 +397,7 @@ RESOURCE_SPECS: tuple[ResourceSpec, ...] = (
 
 __all__ = [
     "BBOX_RESOURCE",
+    "CLASSIFICATION_RESOURCE",
     "EMBEDDING_RESOURCE",
     "ENTITY_DYNAMIC_STATE_RESOURCE",
     "ENTITY_RESOURCE",
@@ -357,6 +406,7 @@ __all__ = [
     "MASK_RESOURCE",
     "MESSAGE_RESOURCE",
     "MULTI_PATH_RESOURCE",
+    "RELATION_RESOURCE",
     "ResourceSpec",
     "TEXT_SPAN_RESOURCE",
     "TRACKLET_RESOURCE",

--- a/src/pixano/api/routers/__init__.py
+++ b/src/pixano/api/routers/__init__.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRouter
 
 from pixano.api.routers.bboxes import router as bboxes_router
+from pixano.api.routers.classification import router as classification_router
 from pixano.api.routers.conversations import router as conversations_router
 from pixano.api.routers.datasets import router as datasets_router
 from pixano.api.routers.embeddings import router as embeddings_router
@@ -21,6 +22,7 @@ from pixano.api.routers.masks import router as masks_router
 from pixano.api.routers.messages import router as messages_router
 from pixano.api.routers.multi_paths import router as multi_paths_router
 from pixano.api.routers.records import router as records_router
+from pixano.api.routers.relation import router as relation_router
 from pixano.api.routers.text_spans import router as text_spans_router
 from pixano.api.routers.tracklets import router as tracklets_router
 from pixano.api.routers.views import router as views_router
@@ -36,6 +38,8 @@ RESOURCE_ROUTERS: tuple[APIRouter, ...] = (
     masks_router,
     multi_paths_router,
     keypoints_router,
+    classification_router,
+    relation_router,
     messages_router,
     conversations_router,
     text_spans_router,

--- a/src/pixano/api/routers/classification.py
+++ b/src/pixano/api/routers/classification.py
@@ -1,0 +1,13 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Classifications router."""
+
+from pixano.api.resources import CLASSIFICATION_RESOURCE
+from pixano.api.routers.resources import create_resource_router
+
+
+router = create_resource_router(CLASSIFICATION_RESOURCE)

--- a/src/pixano/api/routers/relation.py
+++ b/src/pixano/api/routers/relation.py
@@ -1,0 +1,13 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Relations router."""
+
+from pixano.api.resources import RELATION_RESOURCE
+from pixano.api.routers.resources import create_resource_router
+
+
+router = create_resource_router(RELATION_RESOURCE)

--- a/tests/app/test_api_new_resources.py
+++ b/tests/app/test_api_new_resources.py
@@ -1,0 +1,113 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pixano.api.main import create_app
+from pixano.api.settings import Settings, get_settings
+from pixano.datasets import Dataset, DatasetInfo
+from pixano.schemas import Classification, Entity, Image, Record, Relation
+
+
+DATASET_ID = "classified_ds"
+
+
+@pytest.fixture()
+def client_with_classification_dataset() -> TestClient:
+    library_dir = Path(tempfile.mkdtemp())
+    info = DatasetInfo(
+        id=DATASET_ID,
+        name=DATASET_ID,
+        record=Record,
+        entity=Entity,
+        classification=Classification,
+        relation=Relation,
+        views={"image": Image},
+    )
+    dataset = Dataset.create(library_dir / DATASET_ID, info)
+    dataset.merge_records(
+        {"records": Record(id="rec1"), "entities": Entity(id="ent1", record_id="rec1")},
+        check_integrity="none",
+    )
+
+    settings = Settings(library_dir=str(library_dir), models_dir=str(library_dir))
+
+    @lru_cache
+    def get_settings_override():
+        return settings
+
+    app = create_app(settings)
+    app.dependency_overrides[get_settings] = get_settings_override
+    return TestClient(app)
+
+
+def _crud_cycle(client: TestClient, path: str, create_payload: dict, update_payload: dict) -> None:
+    base = f"/datasets/{DATASET_ID}/{path}"
+    row_id = create_payload["id"]
+
+    created = client.post(base, json=create_payload)
+    assert created.status_code == 201, created.text
+
+    fetched = client.get(f"{base}/{row_id}")
+    assert fetched.status_code == 200, fetched.text
+    for key, value in create_payload.items():
+        if not isinstance(value, dict):
+            assert fetched.json()[key] == value
+
+    listed = client.get(base)
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+
+    updated = client.put(f"{base}/{row_id}", json=update_payload)
+    assert updated.status_code == 200, updated.text
+    for key, value in update_payload.items():
+        if not isinstance(value, dict):
+            assert updated.json()[key] == value
+
+    deleted = client.delete(f"{base}/{row_id}")
+    assert deleted.status_code == 204
+    assert client.get(f"{base}/{row_id}").status_code == 404
+
+
+class TestNewResourceRouters:
+    def test_classifications_crud(self, client_with_classification_dataset: TestClient):
+        _crud_cycle(
+            client_with_classification_dataset,
+            "classifications",
+            {
+                "id": "cls1",
+                "record_id": "rec1",
+                "entity_id": "ent1",
+                "labels": ["car"],
+                "confidences": [0.9],
+            },
+            {"labels": ["truck"], "confidences": [0.7]},
+        )
+
+    def test_relations_crud(self, client_with_classification_dataset: TestClient):
+        _crud_cycle(
+            client_with_classification_dataset,
+            "relations",
+            {
+                "id": "rel1",
+                "record_id": "rec1",
+                "entity_id": "ent1",
+                "predicate": "left_of",
+            },
+            {"predicate": "right_of"},
+        )
+
+    def test_dataset_info_includes_new_slots(self, client_with_classification_dataset: TestClient):
+        response = client_with_classification_dataset.get(f"/datasets/{DATASET_ID}/info")
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["classification"] == {"base": "Classification", "fields": {}}
+        assert payload["relation"] == {"base": "Relation", "fields": {}}


### PR DESCRIPTION
## Issue

Part of the 0.8.0 import/export redesign stack (spec: #664, `docs/specs/data-import-export.md` §11.2).

## Description

API surface for the two families added in #665: transport models (Create/Update/Response), `ResourceSpec` blocks, generic CRUD routers registered in `RESOURCE_ROUTERS`, and `DatasetInfoResponse` serialization of the new schema slots.

Full CRUD verified over TestClient (create → get → list → update → delete → 404) for `/datasets/{id}/classifications` and `/datasets/{id}/relations`.

The 3D counterparts (bboxes-3d, keypoints-3d, cam-calibrations) are deferred to 0.9 with the rest of the 3D scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)