### PR TITLE
feat: add io core foundation (errors, plan, ids, progress, manifest)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -108,7 +108,7 @@ jobs:
           uv sync --group test
 
       - name: Test with pytest
-        run: uv run pytest --cov=src/pixano/ tests/
+        run: uv run pytest --cov=src/pixano/ -m "not slow and not hub" tests/
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v5
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ path = "src/pixano/__version__.py"
 [tool.pytest.ini_options]
 markers = [
     "e2e: End-to-end tests requiring a live inference server (set PIXANO_INFERENCE_URL)",
+    "slow: Long-running scale/soak tests, excluded from the default CI run",
+    "hub: Tests downloading from the Hugging Face hub, excluded from the default CI run",
 ]
 
 [tool.ruff]

--- a/src/pixano/datasets/io/__init__.py
+++ b/src/pixano/datasets/io/__init__.py
@@ -1,0 +1,55 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Shared data import/export core (see docs/specs/data-import-export.md).
+
+This package hosts the one import/export mechanism used by the CLI, the REST
+API, and the Python API: declarative specs, format registry, importer
+contract, and the import engine.
+"""
+
+from .errors import (
+    FormatDetectionError,
+    JobStateError,
+    MediaResolutionError,
+    MetadataError,
+    PixanoDataError,
+    PlanMismatchError,
+    ResumeError,
+    SpecValidationError,
+    UnsupportedStorageError,
+)
+from .ids import IdLedger, namespace_prefix, stable_id
+from .manifest import ImportManifest
+from .plan import AnalyzeLimits, Finding, ImportPlan, PreflightReport, Provenance, SamplePreview
+from .progress import ProgressEvent, ProgressSink, ThrottledSink, TqdmSink
+
+
+__all__ = [
+    "AnalyzeLimits",
+    "Finding",
+    "FormatDetectionError",
+    "IdLedger",
+    "ImportManifest",
+    "ImportPlan",
+    "JobStateError",
+    "MediaResolutionError",
+    "MetadataError",
+    "PixanoDataError",
+    "PlanMismatchError",
+    "PreflightReport",
+    "ProgressEvent",
+    "ProgressSink",
+    "Provenance",
+    "ResumeError",
+    "SamplePreview",
+    "SpecValidationError",
+    "ThrottledSink",
+    "TqdmSink",
+    "UnsupportedStorageError",
+    "namespace_prefix",
+    "stable_id",
+]

--- a/src/pixano/datasets/io/errors.py
+++ b/src/pixano/datasets/io/errors.py
@@ -1,0 +1,63 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Typed error hierarchy for the data import/export core.
+
+Every error carries an optional :class:`~pixano.datasets.io.plan.Provenance`
+naming the file/line/JSON-pointer that produced it, so failures always point
+at the offending source data.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from .plan import Provenance
+
+
+class PixanoDataError(Exception):
+    """Base class for all data import/export errors."""
+
+    def __init__(self, message: str, provenance: "Provenance | None" = None):
+        """Initialize the error with a message and optional source provenance."""
+        self.provenance = provenance
+        if provenance is not None:
+            message = f"{message} [{provenance.location()}]"
+        super().__init__(message)
+
+
+class FormatDetectionError(PixanoDataError):
+    """The source's data format could not be detected unambiguously."""
+
+
+class SpecValidationError(PixanoDataError):
+    """The declarative import/export spec is invalid."""
+
+
+class MetadataError(PixanoDataError):
+    """A metadata file or line does not conform to the declared format."""
+
+
+class MediaResolutionError(PixanoDataError):
+    """A media reference cannot be resolved under the active media policy."""
+
+
+class PlanMismatchError(PixanoDataError):
+    """The source changed between analysis and ingestion."""
+
+
+class UnsupportedStorageError(PixanoDataError):
+    """The operation is not supported on this storage backend (e.g. S3 data dirs)."""
+
+
+class JobStateError(PixanoDataError):
+    """The job is not in a state that allows the requested transition."""
+
+
+class ResumeError(PixanoDataError):
+    """The job cannot be resumed (e.g. its importer has no deterministic ids)."""

--- a/src/pixano/datasets/io/ids.py
+++ b/src/pixano/datasets/io/ids.py
@@ -1,0 +1,170 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Deterministic id derivation and the cross-flush id ledger.
+
+Ids derive from source identity so re-running an import converges instead of
+duplicating (spec §8). Every derived id is prefixed with an 8-character
+namespace slug, which makes add-mode rollback expressible as a single
+``id LIKE '{prefix}-%'`` delete without journaling individual ids.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import tempfile
+from pathlib import Path
+
+
+_BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_NAMESPACE_PREFIX_LENGTH = 8
+
+
+def _base62(data: bytes) -> str:
+    number = int.from_bytes(data, "big")
+    if number == 0:
+        return _BASE62_ALPHABET[0]
+    digits: list[str] = []
+    while number:
+        number, remainder = divmod(number, 62)
+        digits.append(_BASE62_ALPHABET[remainder])
+    return "".join(reversed(digits))
+
+
+def namespace_prefix(namespace: str) -> str:
+    """Derive the 8-character id prefix for a namespace (source identity)."""
+    digest = hashlib.blake2b(namespace.encode("utf-8"), digest_size=6).digest()
+    return _base62(digest).rjust(_NAMESPACE_PREFIX_LENGTH, _BASE62_ALPHABET[0])[:_NAMESPACE_PREFIX_LENGTH]
+
+
+def stable_id(namespace: str, *parts: str | int) -> str:
+    """Derive a deterministic, collision-resistant id from a namespace and parts.
+
+    The hash is length-prefixed over each part, so ``("ab", "c")`` and
+    ``("a", "bc")`` never collide. Same inputs always produce the same id —
+    across processes and runs — which is what makes imports idempotent and
+    resumable.
+    """
+    hasher = hashlib.blake2b(digest_size=16)
+    for part in parts:
+        encoded = str(part).encode("utf-8")
+        hasher.update(len(encoded).to_bytes(4, "big"))
+        hasher.update(encoded)
+    return f"{namespace_prefix(namespace)}-{_base62(hasher.digest())}"
+
+
+class IdLedger:
+    """Tracks ids inserted per table across flushes, spilling to SQLite at scale.
+
+    The import engine feeds every flushed batch into the ledger and answers
+    uniqueness/foreign-key checks from it — on fresh builds this removes all
+    per-flush database scans (spec §8). Past ``spill_threshold`` total ids the
+    ledger moves to an on-disk SQLite database to bound memory.
+    """
+
+    def __init__(self, spill_dir: Path | None = None, spill_threshold: int = 5_000_000):
+        """Initialize an empty ledger.
+
+        Args:
+            spill_dir: Directory for the SQLite spill file (a temp dir by default).
+            spill_threshold: Total id count beyond which the ledger spills to disk.
+        """
+        self._spill_dir = spill_dir
+        self._spill_threshold = spill_threshold
+        self._memory: dict[str, set[str]] = {}
+        self._total = 0
+        self._connection: sqlite3.Connection | None = None
+
+    # ------------------------------------------------------------------
+    # Writing
+    # ------------------------------------------------------------------
+
+    def add(self, table: str, ids: set[str] | list[str]) -> None:
+        """Record ids as present in a table."""
+        if self._connection is not None:
+            self._sql_add(table, ids)
+            return
+
+        bucket = self._memory.setdefault(table, set())
+        before = len(bucket)
+        bucket.update(ids)
+        self._total += len(bucket) - before
+        if self._total > self._spill_threshold:
+            self._spill()
+
+    # ------------------------------------------------------------------
+    # Lookups
+    # ------------------------------------------------------------------
+
+    def contains(self, table: str, id: str) -> bool:
+        """Whether an id is known for a table."""
+        if self._connection is None:
+            return id in self._memory.get(table, set())
+        row = self._connection.execute("SELECT 1 FROM ids WHERE tbl = ? AND id = ? LIMIT 1", (table, id)).fetchone()
+        return row is not None
+
+    def fk_lookup(self, table: str, ids: set[str]) -> dict[str, bool]:
+        """Bulk existence lookup, signature-compatible with `Dataset.find_ids_in_table`."""
+        if self._connection is None:
+            known = self._memory.get(table, set())
+            return {id: id in known for id in ids}
+
+        found: set[str] = set()
+        id_list = list(ids)
+        chunk_size = 500  # SQLite bound-variable limit safety
+        for start in range(0, len(id_list), chunk_size):
+            chunk = id_list[start : start + chunk_size]
+            placeholders = ",".join("?" * len(chunk))
+            rows = self._connection.execute(
+                f"SELECT id FROM ids WHERE tbl = ? AND id IN ({placeholders})",  # noqa: S608
+                (table, *chunk),
+            ).fetchall()
+            found.update(row[0] for row in rows)
+        return {id: id in found for id in ids}
+
+    def missing(self, table: str, ids: set[str]) -> set[str]:
+        """Subset of ids not known for a table."""
+        lookup = self.fk_lookup(table, ids)
+        return {id for id, is_found in lookup.items() if not is_found}
+
+    def known_ids(self, tables: list[str] | None = None) -> dict[str, set[str]]:
+        """Snapshot of in-memory ids per table (pre-spill only; used for small builds)."""
+        if self._connection is not None:
+            raise RuntimeError("known_ids() is unavailable after the ledger spilled to SQLite; use fk_lookup().")
+        table_names = tables if tables is not None else list(self._memory)
+        return {table: set(self._memory.get(table, set())) for table in table_names}
+
+    # ------------------------------------------------------------------
+    # Spill machinery
+    # ------------------------------------------------------------------
+
+    def _spill(self) -> None:
+        spill_dir = self._spill_dir if self._spill_dir is not None else Path(tempfile.mkdtemp(prefix="pixano-ledger-"))
+        spill_dir.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(spill_dir / "id_ledger.sqlite")
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS ids (tbl TEXT NOT NULL, id TEXT NOT NULL, PRIMARY KEY (tbl, id))"
+        )
+        self._connection = connection
+        for table, ids in self._memory.items():
+            self._sql_add(table, ids)
+        self._memory.clear()
+
+    def _sql_add(self, table: str, ids: set[str] | list[str]) -> None:
+        assert self._connection is not None
+        self._connection.executemany(
+            "INSERT OR IGNORE INTO ids (tbl, id) VALUES (?, ?)",
+            ((table, id) for id in ids),
+        )
+        self._connection.commit()
+
+    def close(self) -> None:
+        """Close the SQLite spill connection, if any."""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/src/pixano/datasets/io/manifest.py
+++ b/src/pixano/datasets/io/manifest.py
@@ -1,0 +1,47 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Add-mode import manifest: the journal enabling idempotent re-runs and rollback.
+
+Written **before** the first write of an add-mode import (spec §8). Records
+the spec/plan fingerprints, the id namespace prefix, and each table's Lance
+version before (and, at finalize, after) the import — enough to roll back via
+guarded version-restore or namespace-prefix deletion without enumerating ids.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+class ImportManifest(BaseModel):
+    """Durable description of one add-mode import job's write scope."""
+
+    job_id: str
+    dataset_id: str
+    spec_fingerprint: str = ""
+    plan_fingerprint: str = ""
+    id_namespace: str = ""
+    ns8_prefix: str = ""
+    importer_version: str = ""
+    pre_import_versions: dict[str, int] = Field(default_factory=dict)
+    post_import_versions: dict[str, int] | None = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def save(self, path: Path) -> None:
+        """Atomically write the manifest (tmp file + rename)."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_name(path.name + ".tmp")
+        tmp_path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        tmp_path.replace(path)
+
+    @classmethod
+    def load(cls, path: Path) -> "ImportManifest":
+        """Load a manifest from disk."""
+        return cls.model_validate_json(path.read_text(encoding="utf-8"))

--- a/src/pixano/datasets/io/plan.py
+++ b/src/pixano/datasets/io/plan.py
@@ -1,0 +1,158 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Analysis-phase artifacts: provenance, findings, preflight report, import plan.
+
+An :class:`ImportPlan` is the fully JSON-serializable output of an importer's
+side-effect-free ``analyze()`` phase. The CLI renders it for confirmation, the
+GUI renders it as the wizard's preview step, and ingestion executes it —
+one artifact, three consumers (spec §8).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+Severity = Literal["error", "warning", "info"]
+
+# How many sample locations to keep per finding (mirrors the previous
+# MetadataValidationReport behavior).
+_MAX_SAMPLES_PER_FINDING = 5
+
+
+def fingerprint(payload: Any) -> str:
+    """Compute a stable fingerprint of a JSON-serializable payload."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+class Provenance(BaseModel):
+    """Where a finding or error comes from in the source data."""
+
+    file: str | None = None
+    line: int | None = None
+    json_pointer: str | None = None
+    record_key: str | None = None
+
+    def location(self) -> str:
+        """Render the provenance as a compact `file:line:pointer` string."""
+        parts = [part for part in (self.file, self.line, self.json_pointer, self.record_key) if part is not None]
+        return ":".join(str(part) for part in parts) if parts else "<unknown>"
+
+
+class Finding(BaseModel):
+    """One aggregated validation finding (same code across many rows)."""
+
+    code: str
+    severity: Severity = "error"
+    count: int = 0
+    samples: list[Provenance] = Field(default_factory=list)
+    suggestion: str = ""
+
+    def add(self, provenance: Provenance) -> None:
+        """Record one more occurrence, keeping at most a few sample locations."""
+        self.count += 1
+        if len(self.samples) < _MAX_SAMPLES_PER_FINDING and provenance not in self.samples:
+            self.samples.append(provenance)
+
+
+class PreflightReport(BaseModel):
+    """Aggregated validation findings for one analyze pass.
+
+    Generalizes the folder-import ``MetadataValidationReport``: findings are
+    keyed by code, carry sample provenances, and split into errors/warnings.
+    """
+
+    findings: dict[str, Finding] = Field(default_factory=dict)
+
+    def add(
+        self,
+        code: str,
+        provenance: Provenance,
+        severity: Severity = "error",
+        suggestion: str = "",
+    ) -> None:
+        """Record one occurrence of a finding."""
+        finding = self.findings.get(code)
+        if finding is None:
+            finding = Finding(code=code, severity=severity, suggestion=suggestion)
+            self.findings[code] = finding
+        finding.add(provenance)
+
+    @property
+    def errors(self) -> list[Finding]:
+        """Findings with error severity."""
+        return [finding for finding in self.findings.values() if finding.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        """Findings with warning or info severity."""
+        return [finding for finding in self.findings.values() if finding.severity != "error"]
+
+    @property
+    def error_count(self) -> int:
+        """Total number of error occurrences."""
+        return sum(finding.count for finding in self.errors)
+
+    @property
+    def warning_count(self) -> int:
+        """Total number of warning/info occurrences."""
+        return sum(finding.count for finding in self.warnings)
+
+    @property
+    def is_valid(self) -> bool:
+        """Whether the analyzed source has no errors."""
+        return self.error_count == 0
+
+
+class SamplePreview(BaseModel):
+    """One normalized preview record shown before ingestion."""
+
+    record: dict[str, Any]
+    thumbnails: dict[str, str] = Field(default_factory=dict)  # logical view name -> data URL
+
+
+class AnalyzeLimits(BaseModel):
+    """Bounds for the analyze phase (spec §8: analyze is pure AND bounded)."""
+
+    max_lines: int | None = None
+    max_bytes: int | None = None
+    max_media_probes: int = 32
+    max_previews: int = 5
+
+
+class PlanTotals(BaseModel):
+    """Record/media totals discovered (or estimated) at analyze time."""
+
+    records: int | None = None
+    media_bytes: int | None = None
+    estimated: bool = False
+
+
+class ImportPlan(BaseModel):
+    """The executable output of an importer's analyze phase."""
+
+    plan_id: str = ""
+    format: str
+    importer_version: str = ""
+    spec_fingerprint: str = ""
+    source_fingerprint: str = ""
+    splits: dict[str, int | None] = Field(default_factory=dict)
+    totals: PlanTotals = Field(default_factory=PlanTotals)
+    inferred_schema: dict[str, Any] | None = None
+    report: PreflightReport = Field(default_factory=PreflightReport)
+    previews: list[SamplePreview] = Field(default_factory=list)
+    media_size_estimate_bytes: int | None = None
+
+    @property
+    def plan_fingerprint(self) -> str:
+        """Fingerprint binding this plan to its spec and source states."""
+        return fingerprint({"spec": self.spec_fingerprint, "source": self.source_fingerprint})

--- a/src/pixano/datasets/io/progress.py
+++ b/src/pixano/datasets/io/progress.py
@@ -1,0 +1,101 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""One progress-event stream for both CLI (tqdm) and job-store (GUI polling) consumers."""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+Phase = Literal["analyze", "ingest", "finalize"]
+
+
+class ProgressEvent(BaseModel):
+    """One progress observation emitted by the import engine."""
+
+    phase: Phase
+    done: int = 0
+    total: int | None = None
+    unit: str = "records"
+    table_counts: dict[str, int] = Field(default_factory=dict)
+    message: str = ""
+    final: bool = False
+
+
+class ProgressSink(ABC):
+    """Consumer of progress events."""
+
+    @abstractmethod
+    def emit(self, event: ProgressEvent) -> None:
+        """Handle one progress event."""
+        ...
+
+    def close(self) -> None:
+        """Release any display/storage resources."""
+
+
+class TqdmSink(ProgressSink):
+    """Renders progress as one tqdm bar per phase, with real totals when known."""
+
+    def __init__(self) -> None:
+        """Initialize with no active bar."""
+        self._bars: dict[Phase, "object"] = {}
+
+    def emit(self, event: ProgressEvent) -> None:
+        """Update (or create) the bar for the event's phase."""
+        import tqdm
+
+        bar = self._bars.get(event.phase)
+        if bar is None:
+            bar = tqdm.tqdm(total=event.total, desc=event.phase, unit=f" {event.unit}")
+            self._bars[event.phase] = bar
+        if event.total is not None and bar.total != event.total:  # type: ignore[attr-defined]
+            bar.total = event.total  # type: ignore[attr-defined]
+        bar.n = event.done  # type: ignore[attr-defined]
+        if event.message:
+            bar.set_postfix_str(event.message, refresh=False)  # type: ignore[attr-defined]
+        bar.refresh()  # type: ignore[attr-defined]
+        if event.final:
+            bar.close()  # type: ignore[attr-defined]
+            self._bars.pop(event.phase, None)
+
+    def close(self) -> None:
+        """Close all open bars."""
+        for bar in self._bars.values():
+            bar.close()  # type: ignore[attr-defined]
+        self._bars.clear()
+
+
+class ThrottledSink(ProgressSink):
+    """Forwards events to an inner sink at most once per interval.
+
+    Terminal events (``final=True``) are always forwarded so consumers never
+    miss completion. Used to bound job-store write frequency (spec §8).
+    """
+
+    def __init__(self, inner: ProgressSink, min_interval: float = 0.5):
+        """Wrap `inner`, forwarding at most one event per `min_interval` seconds."""
+        self._inner = inner
+        self._min_interval = min_interval
+        # -inf so the first event always forwards: time.monotonic() has an
+        # arbitrary epoch (e.g. host uptime) and can be smaller than the interval.
+        self._last_emit = float("-inf")
+
+    def emit(self, event: ProgressEvent) -> None:
+        """Forward the event if the interval elapsed or the event is terminal."""
+        now = time.monotonic()
+        if event.final or (now - self._last_emit) >= self._min_interval:
+            self._last_emit = now
+            self._inner.emit(event)
+
+    def close(self) -> None:
+        """Close the wrapped sink."""
+        self._inner.close()

--- a/tests/datasets/io/__init__.py
+++ b/tests/datasets/io/__init__.py
@@ -1,0 +1,5 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================

--- a/tests/datasets/io/test_ids.py
+++ b/tests/datasets/io/test_ids.py
@@ -1,0 +1,78 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets.io import IdLedger, namespace_prefix, stable_id
+
+
+class TestStableId:
+    def test_deterministic_across_processes(self):
+        expected = stable_id("voc2007", "train", "000042", 3)
+        code = "from pixano.datasets.io import stable_id;" "print(stable_id('voc2007', 'train', '000042', 3), end='')"
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+        assert result.stdout == expected
+
+    def test_namespace_prefix_shape(self):
+        prefix = namespace_prefix("voc2007")
+        assert len(prefix) == 8
+        assert stable_id("voc2007", "x").startswith(f"{prefix}-")
+        assert namespace_prefix("other_ds") != prefix
+
+    def test_distinct_part_tuples_are_distinct(self):
+        # Length-prefixed hashing: concatenation ambiguity must not collide.
+        assert stable_id("ns", "ab", "c") != stable_id("ns", "a", "bc")
+        assert stable_id("ns", "a", "") != stable_id("ns", "a")
+        assert stable_id("ns", 12, 3) != stable_id("ns", 1, 23)
+
+    def test_same_parts_different_namespace_differ(self):
+        assert stable_id("ns1", "train", 0) != stable_id("ns2", "train", 0)
+
+
+class TestIdLedger:
+    def test_memory_path(self):
+        ledger = IdLedger()
+        ledger.add("records", {"a", "b"})
+        assert ledger.contains("records", "a")
+        assert not ledger.contains("records", "c")
+        assert ledger.fk_lookup("records", {"a", "c"}) == {"a": True, "c": False}
+        assert ledger.missing("records", {"a", "c"}) == {"c"}
+        assert ledger.known_ids() == {"records": {"a", "b"}}
+
+    def test_spill_boundary_is_exact(self, tmp_path: Path):
+        ledger = IdLedger(spill_dir=tmp_path, spill_threshold=1_000)
+        first_half = {f"id_{n}" for n in range(800)}
+        second_half = {f"id_{n}" for n in range(800, 5_000)}
+        ledger.add("records", first_half)
+        ledger.add("entities", second_half)  # crosses the threshold -> spills
+
+        assert (tmp_path / "id_ledger.sqlite").exists()
+        assert ledger.contains("records", "id_0")
+        assert ledger.contains("entities", "id_4999")
+        assert not ledger.contains("records", "id_4999")  # table separation survives the spill
+
+        lookup = ledger.fk_lookup("entities", {"id_800", "id_4999", "ghost"})
+        assert lookup == {"id_800": True, "id_4999": True, "ghost": False}
+
+        # Post-spill adds land in SQLite too.
+        ledger.add("records", {"late"})
+        assert ledger.contains("records", "late")
+        with pytest.raises(RuntimeError, match="spilled"):
+            ledger.known_ids()
+        ledger.close()
+
+    @pytest.mark.slow
+    def test_soak_many_ids(self, tmp_path: Path):
+        ledger = IdLedger(spill_dir=tmp_path, spill_threshold=1_000_000)
+        for chunk_start in range(0, 6_000_000, 500_000):
+            ledger.add("records", [f"id_{n}" for n in range(chunk_start, chunk_start + 500_000)])
+        assert ledger.contains("records", "id_5999999")
+        assert not ledger.contains("records", "id_6000000")
+        ledger.close()

--- a/tests/datasets/io/test_plan.py
+++ b/tests/datasets/io/test_plan.py
@@ -1,0 +1,66 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from pixano.datasets.io import Finding, ImportPlan, PreflightReport, Provenance
+from pixano.datasets.io.errors import MetadataError
+from pixano.datasets.io.plan import fingerprint
+
+
+class TestProvenanceAndErrors:
+    def test_location_rendering(self):
+        provenance = Provenance(file="train/metadata.jsonl", line=42, json_pointer="/entities/0/annotations/1")
+        assert provenance.location() == "train/metadata.jsonl:42:/entities/0/annotations/1"
+        assert Provenance().location() == "<unknown>"
+
+    def test_errors_carry_provenance(self):
+        provenance = Provenance(file="train/metadata.jsonl", line=7)
+        error = MetadataError("unknown annotation kind 'boxx'", provenance)
+        assert "train/metadata.jsonl:7" in str(error)
+        assert error.provenance is provenance
+
+
+class TestPreflightReport:
+    def test_aggregation_and_sample_cap(self):
+        report = PreflightReport()
+        for line in range(10):
+            report.add("unknown_key", Provenance(file="f.jsonl", line=line), severity="warning")
+        report.add("missing_view_media", Provenance(file="f.jsonl", line=3))
+
+        assert report.warning_count == 10
+        assert report.error_count == 1
+        assert not report.is_valid
+        assert len(report.findings["unknown_key"].samples) == 5  # capped
+        assert report.findings["unknown_key"].count == 10
+
+    def test_valid_when_only_warnings(self):
+        report = PreflightReport()
+        report.add("prefer_snake_case", Provenance(line=1), severity="warning")
+        assert report.is_valid
+
+
+class TestImportPlan:
+    def test_json_round_trip(self):
+        plan = ImportPlan(
+            format="pixano_jsonl",
+            importer_version="1.0.0",
+            spec_fingerprint=fingerprint({"a": 1}),
+            source_fingerprint=fingerprint(["train/metadata.jsonl", 1234]),
+            splits={"train": 100, "val": None},
+        )
+        plan.report.add("unknown_key", Provenance(file="f.jsonl", line=1), severity="warning")
+
+        restored = ImportPlan.model_validate_json(plan.model_dump_json())
+        assert restored == plan
+        assert restored.plan_fingerprint == plan.plan_fingerprint
+
+    def test_fingerprints_are_stable_and_order_insensitive(self):
+        assert fingerprint({"b": 2, "a": 1}) == fingerprint({"a": 1, "b": 2})
+        assert fingerprint({"a": 1}) != fingerprint({"a": 2})
+
+    def test_finding_model_round_trip(self):
+        finding = Finding(code="x", severity="error", suggestion="use v2 grammar")
+        finding.add(Provenance(line=3))
+        assert Finding.model_validate_json(finding.model_dump_json()) == finding

--- a/tests/datasets/io/test_progress_manifest.py
+++ b/tests/datasets/io/test_progress_manifest.py
@@ -1,0 +1,60 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from pathlib import Path
+
+from pixano.datasets.io import ImportManifest, ProgressEvent, ProgressSink, ThrottledSink
+
+
+class _CollectingSink(ProgressSink):
+    def __init__(self) -> None:
+        self.events: list[ProgressEvent] = []
+
+    def emit(self, event: ProgressEvent) -> None:
+        self.events.append(event)
+
+
+class TestThrottledSink:
+    def test_throttles_but_always_forwards_terminal(self):
+        inner = _CollectingSink()
+        sink = ThrottledSink(inner, min_interval=3600.0)  # effectively "once"
+
+        for done in range(10):
+            sink.emit(ProgressEvent(phase="ingest", done=done, total=10))
+        sink.emit(ProgressEvent(phase="ingest", done=10, total=10, final=True))
+
+        assert len(inner.events) == 2  # the first event + the terminal one
+        assert inner.events[0].done == 0
+        assert inner.events[-1].final is True
+
+    def test_zero_interval_forwards_everything(self):
+        inner = _CollectingSink()
+        sink = ThrottledSink(inner, min_interval=0.0)
+        for done in range(3):
+            sink.emit(ProgressEvent(phase="analyze", done=done))
+        assert len(inner.events) == 3
+
+
+class TestImportManifest:
+    def test_atomic_save_and_load(self, tmp_path: Path):
+        manifest = ImportManifest(
+            job_id="job1",
+            dataset_id="ds1",
+            id_namespace="voc2007",
+            ns8_prefix="AbCdEf12",
+            importer_version="1.0.0",
+            pre_import_versions={"records": 4, "bboxes": 7},
+        )
+        path = tmp_path / "imports" / "job1.manifest.json"
+        manifest.save(path)
+
+        loaded = ImportManifest.load(path)
+        assert loaded == manifest
+        assert not path.with_name(path.name + ".tmp").exists()
+
+        manifest.post_import_versions = {"records": 5, "bboxes": 9}
+        manifest.save(path)
+        assert ImportManifest.load(path).post_import_versions == {"records": 5, "bboxes": 9}


### PR DESCRIPTION
## Issue

Part of the 0.8.0 import/export redesign stack (spec: #664, `docs/specs/data-import-export.md` §3.1).

## Description

First slice of the shared import/export core (`src/pixano/datasets/io/`):

- Typed `PixanoDataError` hierarchy — every error carries source provenance (`file:line:json-pointer`).
- `ImportPlan`/`PreflightReport`/`Finding`: the JSON-serializable analyze output consumed identically by the CLI plan renderer and the future GUI preview (generalizes the folder-import `MetadataValidationReport`).
- `stable_id`/`namespace_prefix`: blake2b→base62 deterministic ids with length-prefixed hashing and an 8-char source-identity namespace prefix (idempotent re-runs, manifest-free rollback). `IdLedger` tracks flushed ids per table with exact SQLite spill past a threshold and plugs into `validate_batch(fk_lookup=...)`.
- `ProgressEvent`/`ProgressSink` with `TqdmSink` and `ThrottledSink` — one event stream for CLI bars and the future job store.
- `ImportManifest`: atomic add-mode journal (fingerprints, id namespace, per-table pre/post Lance versions).
- Pytest markers `slow`/`hub`; CI now runs with `-m "not slow and not hub"`.

Pure additions — no existing code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)