### PR TITLE
feat: add the import engine with atomic staged builds and add-mode upserts

### DIFF
--- a/src/pixano/cli/init.py
+++ b/src/pixano/cli/init.py
@@ -13,6 +13,6 @@ def init(
     data_dir: Path = typer.Argument(..., help="Path to initialize."),
 ) -> None:
     """Initialize a Pixano data directory."""
-    for subdir in ["library", "media", "models"]:
+    for subdir in ["library", "media", "models", ".pixano"]:
         (data_dir / subdir).mkdir(parents=True, exist_ok=True)
     typer.echo(f"Initialized Pixano data directory at {data_dir}")

--- a/src/pixano/datasets/dataset_info.py
+++ b/src/pixano/datasets/dataset_info.py
@@ -328,8 +328,10 @@ class DatasetInfo(BaseModel):
         """
         library: list[DatasetInfo] | list[tuple[DatasetInfo, Path]] = []
 
-        # Browse directory
+        # Browse directory (dot-directories such as engine staging/trash are not datasets)
         for json_fp in sorted(directory.glob("*/info.json")):
+            if json_fp.parent.name.startswith("."):
+                continue
             try:
                 info: DatasetInfo = DatasetInfo.from_json(json_fp)
             except Exception as e:
@@ -391,6 +393,8 @@ class DatasetInfo(BaseModel):
             The DatasetInfo.
         """
         for json_fp in directory.glob("*/info.json"):
+            if json_fp.parent.name.startswith("."):
+                continue
             info = DatasetInfo.from_json(json_fp)
             if info.id == id:
                 try:

--- a/src/pixano/datasets/io/__init__.py
+++ b/src/pixano/datasets/io/__init__.py
@@ -11,6 +11,8 @@ API, and the Python API: declarative specs, format registry, importer
 contract, and the import engine.
 """
 
+from .api import analyze, import_dataset
+from .engine import ImportEngine, ImportResult, replay_journals
 from .errors import (
     FormatDetectionError,
     JobStateError,
@@ -34,6 +36,8 @@ from .spec import ExportSpec, IdPolicy, ImportSpec, MediaPolicy, SchemaSpec, wor
 
 __all__ = [
     "AnalyzeLimits",
+    "ImportEngine",
+    "ImportResult",
     "BatchBundle",
     "Capabilities",
     "Cursor",
@@ -72,9 +76,12 @@ __all__ = [
     "UnsupportedStorageError",
     "VideoProbe",
     "ffprobe_available",
+    "analyze",
+    "import_dataset",
     "namespace_prefix",
     "probe_image",
     "probe_video",
+    "replay_journals",
     "stable_id",
     "workspace_preset",
 ]

--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -1,0 +1,100 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""The shared Python entry points behind the CLI and the REST API (spec §3.1).
+
+``analyze`` and ``import_dataset`` are the whole public surface: the CLI
+renders the returned :class:`ImportPlan` and calls ``import_dataset`` with a
+tqdm sink; the REST layer does the same with a job-store sink.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+from pixano.datasets.dataset_info import DatasetInfo
+
+from .engine import ImportEngine, ImportResult
+from .errors import SpecValidationError
+from .importer import DatasetImporter, SourceRef
+from .plan import AnalyzeLimits, ImportPlan
+from .progress import ProgressSink
+from .registry import FORMATS
+from .spec import ImportSpec, workspace_preset
+
+
+def _resolve_importer(source: SourceRef, spec: ImportSpec, importer: DatasetImporter | None) -> DatasetImporter:
+    if importer is not None:
+        return importer
+    if spec.format == "auto":
+        data_format = FORMATS.detect(source)
+    else:
+        data_format = FORMATS.get(spec.format)
+    if data_format.importer_cls is None:
+        raise SpecValidationError(f"Data format '{data_format.name}' is export-only.")
+    return data_format.importer_cls()
+
+
+def analyze(
+    source: str | Path,
+    spec: ImportSpec | None = None,
+    limits: AnalyzeLimits | None = None,
+    importer: DatasetImporter | None = None,
+) -> ImportPlan:
+    """Analyze a source without side effects and return its import plan."""
+    spec = spec or ImportSpec()
+    source_ref = SourceRef.from_string(str(source))
+    resolved = _resolve_importer(source_ref, spec, importer)
+    return resolved.analyze(source_ref, spec, limits or AnalyzeLimits())
+
+
+def import_dataset(
+    source: str | Path,
+    data_dir: str | Path,
+    spec: ImportSpec | None = None,
+    *,
+    plan: ImportPlan | None = None,
+    info: DatasetInfo | None = None,
+    importer: DatasetImporter | None = None,
+    sinks: Sequence[ProgressSink] = (),
+    engine: ImportEngine | None = None,
+) -> ImportResult:
+    """Import a source into the data directory's library (analyze → validate → ingest).
+
+    Args:
+        source: Source directory/file, or ``hub://org/repo``.
+        data_dir: The Pixano data directory (holds ``library/``).
+        spec: Declarative import spec; defaults apply when omitted.
+        plan: A previously computed plan; re-analyzed when omitted.
+        info: Target dataset schema; derived from the workspace preset when omitted.
+        importer: Explicit importer instance (advanced; bypasses the registry).
+        sinks: Progress sinks (e.g. a tqdm sink).
+        engine: Preconfigured engine (jobs wire checkpoints/cancellation through it).
+
+    Returns:
+        The import result (dataset id/path, per-table row counts).
+    """
+    spec = spec or ImportSpec()
+    source_ref = SourceRef.from_string(str(source))
+    resolved = _resolve_importer(source_ref, spec, importer)
+
+    if plan is None:
+        plan = resolved.analyze(source_ref, spec, AnalyzeLimits())
+    if not plan.report.is_valid:
+        raise SpecValidationError(
+            f"Analysis found {plan.report.error_count} error(s); fix the source or inspect the plan report."
+        )
+
+    if info is None:
+        info = workspace_preset(spec.dataset.workspace)
+    if spec.dataset.name:
+        info.name = spec.dataset.name
+    if spec.dataset.description:
+        info.description = spec.dataset.description
+
+    engine = engine or ImportEngine(Path(data_dir))
+    return engine.run(resolved, source_ref, spec, plan, info, sinks=sinks)

--- a/src/pixano/datasets/io/engine.py
+++ b/src/pixano/datasets/io/engine.py
@@ -1,0 +1,600 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""The import engine: the only component that writes datasets (spec §8).
+
+Responsibilities the format importers never carry:
+
+- byte- and row-bounded buffering of streamed batches;
+- integrity at scale via an :class:`~pixano.datasets.io.ids.IdLedger`
+  (cross-flush duplicate detection; FK resolution without DB scans on fresh
+  builds);
+- atomicity: ``create``/``overwrite`` build in ``<data_dir>/.pixano/staging/``
+  and atomically rename into ``library/`` (overwrite goes through a journaled
+  old→trash→swap sequence replayed on boot); ``add`` writes an
+  :class:`~pixano.datasets.io.manifest.ImportManifest` *before* the first
+  write and routes every flush through the upserting
+  :meth:`~pixano.datasets.dataset.Dataset.merge_records`;
+- the media-storage census stamping ``DatasetInfo.storage_mode``;
+- scalar indexes, provenance stamps, cache invalidation, and progress events
+  at finalize.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterator, Literal, Sequence
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import shortuuid
+from lancedb.pydantic import LanceModel
+
+from pixano.datasets.dataset import Dataset
+from pixano.datasets.dataset_info import DatasetInfo
+from pixano.datasets.utils.integrity import validate_batch
+from pixano.schemas import SchemaGroup, is_view, schema_to_group
+from pixano.utils import to_snake_case
+
+from .errors import JobStateError, SpecValidationError, UnsupportedStorageError
+from .ids import IdLedger
+from .importer import Cursor, DatasetImporter, SourceRef
+from .manifest import ImportManifest
+from .plan import ImportPlan
+from .progress import ProgressEvent, ProgressSink
+from .spec import ImportSpec
+
+
+logger = logging.getLogger(__name__)
+
+PIXANO_STATE_DIR = ".pixano"
+DEFAULT_FLUSH_ROWS = 1024
+DEFAULT_FLUSH_BYTES = 256 * 1024 * 1024
+
+
+@dataclass
+class ImportResult:
+    """Outcome of one import job."""
+
+    dataset_id: str
+    dataset_path: Path
+    table_counts: dict[str, int]
+    job_id: str
+    manifest_path: Path | None
+    duration_s: float
+    storage_mode: str
+
+
+class _LedgerTableView:
+    """Set-like view over one ledger table for `validate_batch` known_ids checks."""
+
+    def __init__(self, ledger: IdLedger, table: str):
+        self._ledger = ledger
+        self._table = table
+
+    def __contains__(self, id: object) -> bool:
+        return isinstance(id, str) and self._ledger.contains(self._table, id)
+
+
+class _LedgerKnownIds(Mapping):
+    """Mapping façade exposing the ledger as `validate_batch`'s known_ids argument."""
+
+    def __init__(self, ledger: IdLedger, tables: Sequence[str]):
+        self._ledger = ledger
+        self._tables = list(tables)
+
+    def __getitem__(self, table: str) -> _LedgerTableView:
+        return _LedgerTableView(self._ledger, table)
+
+    def get(self, table: str, default: object = None) -> _LedgerTableView:
+        return _LedgerTableView(self._ledger, table)
+
+    def __iter__(self):
+        return iter(self._tables)
+
+    def __len__(self) -> int:
+        return len(self._tables)
+
+
+def state_dir(data_dir: Path) -> Path:
+    """The engine's state directory (staging/trash/journal) — outside library/."""
+    return data_dir / PIXANO_STATE_DIR
+
+
+def replay_journals(data_dir: Path) -> None:
+    """Complete interrupted overwrite swaps (idempotent; run at engine and server start)."""
+    journal_dir = state_dir(data_dir) / "journal"
+    if not journal_dir.is_dir():
+        return
+    for journal_file in sorted(journal_dir.glob("*.json")):
+        try:
+            journal = json.loads(journal_file.read_text(encoding="utf-8"))
+            target = Path(journal["target"])
+            staging = Path(journal["staging"])
+            trash = Path(journal["trash"])
+            if staging.exists() and not target.exists():
+                # Crashed between old→trash and staging→target: finish the swap.
+                os.rename(staging, target)
+            if target.exists() and trash.exists():
+                shutil.rmtree(trash, ignore_errors=True)
+            if target.exists() and not staging.exists():
+                journal_file.unlink(missing_ok=True)
+        except Exception as exc:
+            logger.warning("Could not replay overwrite journal %s: %s", journal_file, exc)
+
+
+class ImportEngine:
+    """Runs one import job end to end (spec §8)."""
+
+    def __init__(
+        self,
+        data_dir: Path,
+        flush_rows: int = DEFAULT_FLUSH_ROWS,
+        flush_bytes: int = DEFAULT_FLUSH_BYTES,
+        checkpoint: Callable[[Cursor, dict[str, int]], None] | None = None,
+        cancel_check: Callable[[], bool] | None = None,
+    ):
+        """Initialize the engine for a data directory.
+
+        Args:
+            data_dir: The Pixano data directory (holds ``library/`` and ``.pixano/``).
+            flush_rows: Row threshold triggering a buffer flush.
+            flush_bytes: Approximate byte threshold triggering a buffer flush.
+            checkpoint: Called after each committed flush with (cursor, table_counts).
+            cancel_check: Polled at flush boundaries; True aborts the job.
+        """
+        if not isinstance(data_dir, Path):
+            raise UnsupportedStorageError("Import jobs require a local filesystem data directory.")
+        self.data_dir = data_dir
+        self.library_dir = data_dir / "library"
+        self.flush_rows = flush_rows
+        self.flush_bytes = flush_bytes
+        self.checkpoint = checkpoint
+        self.cancel_check = cancel_check
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        importer: DatasetImporter,
+        source: SourceRef,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        info: DatasetInfo,
+        sinks: Sequence[ProgressSink] = (),
+    ) -> ImportResult:
+        """Execute the plan: stream, validate, write, finalize — atomically per mode."""
+        started_at = time.monotonic()
+        job_id = shortuuid.uuid()
+        dataset_name = to_snake_case(spec.dataset.name or info.name)
+        if not dataset_name:
+            raise SpecValidationError("dataset.name must contain at least one alphanumeric character.")
+        target_dir = self.library_dir / dataset_name
+
+        replay_journals(self.data_dir)
+
+        if spec.mode == "add":
+            return self._run_add(importer, source, spec, plan, job_id, target_dir, sinks, started_at)
+        return self._run_build(importer, source, spec, plan, info, job_id, dataset_name, target_dir, sinks, started_at)
+
+    # ------------------------------------------------------------------
+    # create / overwrite: staged build + atomic promotion
+    # ------------------------------------------------------------------
+
+    def _run_build(
+        self,
+        importer: DatasetImporter,
+        source: SourceRef,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        info: DatasetInfo,
+        job_id: str,
+        dataset_name: str,
+        target_dir: Path,
+        sinks: Sequence[ProgressSink],
+        started_at: float,
+    ) -> ImportResult:
+        if spec.mode == "create" and target_dir.exists():
+            raise SpecValidationError(
+                f"Dataset '{dataset_name}' already exists at '{target_dir}'. Use mode 'overwrite' or 'add'."
+            )
+
+        staging_dir = state_dir(self.data_dir) / "staging" / f"{dataset_name}-{job_id}"
+        staging_dir.parent.mkdir(parents=True, exist_ok=True)
+        self.library_dir.mkdir(parents=True, exist_ok=True)
+        self._assert_same_filesystem(staging_dir.parent, self.library_dir)
+
+        if not info.id:
+            info.id = shortuuid.uuid()
+        dataset = Dataset.create(staging_dir, info)
+        ledger = IdLedger(spill_dir=staging_dir / ".ledger")
+        table_counts: dict[str, int] = {}
+        census = _MediaCensus()
+
+        try:
+            for cursor in self._stream(importer, source, spec, plan, dataset, ledger, table_counts, census, sinks):
+                if self.checkpoint is not None:
+                    self.checkpoint(cursor, dict(table_counts))
+                self._check_cancelled()
+            self._finalize(dataset, spec, plan, importer, job_id, table_counts, census, sinks, add_mode=False)
+        except BaseException:
+            ledger.close()
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            raise
+        ledger.close()
+        shutil.rmtree(staging_dir / ".ledger", ignore_errors=True)
+
+        self._promote(staging_dir, target_dir, job_id)
+        Dataset.invalidate_caches(dataset.info.id)
+
+        return ImportResult(
+            dataset_id=dataset.info.id,
+            dataset_path=target_dir,
+            table_counts=dict(table_counts),
+            job_id=job_id,
+            manifest_path=None,
+            duration_s=time.monotonic() - started_at,
+            storage_mode=dataset.info.storage_mode,
+        )
+
+    def _promote(self, staging_dir: Path, target_dir: Path, job_id: str) -> None:
+        """Atomically move the staged dataset into the library (journaled for overwrite)."""
+        if not target_dir.exists():
+            os.rename(staging_dir, target_dir)
+            return
+
+        journal_dir = state_dir(self.data_dir) / "journal"
+        trash_dir = state_dir(self.data_dir) / "trash" / f"{target_dir.name}-{job_id}"
+        trash_dir.parent.mkdir(parents=True, exist_ok=True)
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        journal_file = journal_dir / f"{job_id}.json"
+        journal_file.write_text(
+            json.dumps({"target": str(target_dir), "staging": str(staging_dir), "trash": str(trash_dir)}),
+            encoding="utf-8",
+        )
+        os.rename(target_dir, trash_dir)
+        os.rename(staging_dir, target_dir)
+        shutil.rmtree(trash_dir, ignore_errors=True)
+        journal_file.unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # add: manifest + upserting flushes
+    # ------------------------------------------------------------------
+
+    def _run_add(
+        self,
+        importer: DatasetImporter,
+        source: SourceRef,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        job_id: str,
+        target_dir: Path,
+        sinks: Sequence[ProgressSink],
+        started_at: float,
+    ) -> ImportResult:
+        if not target_dir.exists():
+            raise SpecValidationError(f"Dataset '{target_dir.name}' does not exist; use mode 'create'.")
+        dataset = Dataset(target_dir)
+
+        manifest = ImportManifest(
+            job_id=job_id,
+            dataset_id=dataset.info.id,
+            spec_fingerprint=spec.fingerprint(),
+            plan_fingerprint=plan.plan_fingerprint,
+            id_namespace=spec.ids.namespace or "",
+            importer_version=importer.importer_version,
+            pre_import_versions={name: dataset.open_table(name).version for name in dataset.info.tables},
+        )
+        manifest_path = target_dir / "imports" / f"{job_id}.manifest.json"
+        manifest.save(manifest_path)
+
+        # Indexes make the upserting merge path scale past full-table scans.
+        dataset.create_scalar_indexes()
+
+        ledger = IdLedger()
+        table_counts: dict[str, int] = {}
+        census = _MediaCensus()
+        try:
+            for cursor in self._stream(
+                importer, source, spec, plan, dataset, ledger, table_counts, census, sinks, add_mode=True
+            ):
+                if self.checkpoint is not None:
+                    self.checkpoint(cursor, dict(table_counts))
+                self._check_cancelled()
+            self._finalize(dataset, spec, plan, importer, job_id, table_counts, census, sinks, add_mode=True)
+        finally:
+            ledger.close()
+
+        manifest.post_import_versions = {name: dataset.open_table(name).version for name in dataset.info.tables}
+        manifest.save(manifest_path)
+        Dataset.invalidate_caches(dataset.info.id)
+
+        return ImportResult(
+            dataset_id=dataset.info.id,
+            dataset_path=target_dir,
+            table_counts=dict(table_counts),
+            job_id=job_id,
+            manifest_path=manifest_path,
+            duration_s=time.monotonic() - started_at,
+            storage_mode=dataset.info.storage_mode,
+        )
+
+    # ------------------------------------------------------------------
+    # Streaming + buffering
+    # ------------------------------------------------------------------
+
+    def _stream(
+        self,
+        importer: DatasetImporter,
+        source: SourceRef,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        dataset: Dataset,
+        ledger: IdLedger,
+        table_counts: dict[str, int],
+        census: "_MediaCensus",
+        sinks: Sequence[ProgressSink],
+        add_mode: bool = False,
+    ) -> Iterator[Cursor]:
+        """Consume importer bundles through bounded buffers; yield committed cursors."""
+        row_buffers: dict[str, list[LanceModel]] = {}
+        buffered_rows = 0
+        buffered_bytes = 0
+        last_cursor: Cursor = {}
+
+        def flush() -> None:
+            nonlocal buffered_rows, buffered_bytes
+            if not row_buffers:
+                return
+            self._flush_rows(dataset, row_buffers, ledger, table_counts, census, add_mode)
+            row_buffers.clear()
+            buffered_rows = 0
+            buffered_bytes = 0
+            self._emit_progress(sinks, plan, table_counts)
+
+        for bundle in importer.iter_batches(source, spec, plan):
+            for table_name, payload in bundle.tables.items():
+                if isinstance(payload, (pa.RecordBatch, pa.Table)):
+                    # Arrow payloads are pre-batched by the importer: write through.
+                    flush()
+                    self._flush_arrow(dataset, table_name, payload, ledger, table_counts, census, add_mode)
+                    self._emit_progress(sinks, plan, table_counts)
+                    continue
+                rows = payload if isinstance(payload, list) else [payload]
+                if not rows:
+                    continue
+                row_buffers.setdefault(table_name, []).extend(rows)
+                buffered_rows += len(rows)
+                buffered_bytes += sum(_approx_row_bytes(row) for row in rows)
+
+            if buffered_rows >= self.flush_rows or buffered_bytes >= self.flush_bytes:
+                flush()
+                last_cursor = dict(bundle.cursor)
+                yield last_cursor
+
+        flush()
+        yield dict(last_cursor)
+
+    def _flush_rows(
+        self,
+        dataset: Dataset,
+        buffers: dict[str, list[LanceModel]],
+        ledger: IdLedger,
+        table_counts: dict[str, int],
+        census: "_MediaCensus",
+        add_mode: bool,
+    ) -> None:
+        batch = {table: rows for table, rows in buffers.items() if rows}
+        if not batch:
+            return
+        for table, rows in batch.items():
+            census.observe_rows(dataset, table, rows)
+
+        if add_mode:
+            # Upsert path: merge_records owns validation with upsert semantics.
+            known = None if ledger_spilled(ledger) else ledger.known_ids(list(dataset.info.tables))
+            dataset.merge_records(batch, check_integrity="raise", known_ids=known)
+        else:
+            # Fresh build: the ledger answers uniqueness and FK checks — no DB scans.
+            pending_ids = {table: {row.id for row in rows if row.id} for table, rows in batch.items()}
+            known_ids = _LedgerKnownIds(ledger, list(dataset.info.tables))
+            for table_name in dataset._table_insert_order(list(batch.keys())):
+                validate_batch(
+                    table_name,
+                    batch[table_name],
+                    known_ids,  # type: ignore[arg-type]
+                    dataset,
+                    raise_or_warn="raise",
+                    pending_ids=pending_ids,
+                    fk_lookup=ledger.fk_lookup,
+                )
+            dataset.add_records(batch, check_integrity="none")
+
+        for table, rows in batch.items():
+            ledger.add(table, [row.id for row in rows if row.id])
+            table_counts[table] = table_counts.get(table, 0) + len(rows)
+
+    def _flush_arrow(
+        self,
+        dataset: Dataset,
+        table_name: str,
+        payload: pa.RecordBatch | pa.Table,
+        ledger: IdLedger,
+        table_counts: dict[str, int],
+        census: "_MediaCensus",
+        add_mode: bool,
+    ) -> None:
+        arrow_table = pa.Table.from_batches([payload]) if isinstance(payload, pa.RecordBatch) else payload
+        if arrow_table.num_rows == 0:
+            return
+        census.observe_arrow(dataset, table_name, arrow_table)
+        ids = [str(id) for id in arrow_table.column("id").to_pylist() if id]
+
+        # Cross-flush duplicate detection stays ledger-based; vectorized FK checks
+        # land with the first Arrow-producing formats (plan P3.0).
+        duplicate_ids = [id for id, found in ledger.fk_lookup(table_name, set(ids)).items() if found]
+        if duplicate_ids and not add_mode:
+            raise JobStateError(
+                f"Duplicate ids across flushes in table '{table_name}': {sorted(duplicate_ids)[:5]} ..."
+            )
+
+        if add_mode:
+            dataset.merge_records({table_name: arrow_table}, check_integrity="none")
+        else:
+            table = dataset.open_table(table_name)
+            table.add(dataset._with_timestamp_columns(table, arrow_table))
+        ledger.add(table_name, ids)
+        table_counts[table_name] = table_counts.get(table_name, 0) + arrow_table.num_rows
+
+    # ------------------------------------------------------------------
+    # Finalize
+    # ------------------------------------------------------------------
+
+    def _finalize(
+        self,
+        dataset: Dataset,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        importer: DatasetImporter,
+        job_id: str,
+        table_counts: dict[str, int],
+        census: "_MediaCensus",
+        sinks: Sequence[ProgressSink],
+        add_mode: bool,
+    ) -> None:
+        dataset.create_scalar_indexes()
+        for table_name in dataset.info.tables:
+            try:
+                dataset.open_table(table_name).optimize()
+            except Exception as exc:
+                logger.warning("optimize() failed on table '%s': %s", table_name, exc)
+
+        storage_mode = census.storage_mode(existing=dataset.info.storage_mode if add_mode else None)
+        if storage_mode is not None:
+            dataset.info.storage_mode = storage_mode
+            dataset.info.to_json(dataset._info_file)
+
+        provenance_file = dataset.path / "imports" / f"{job_id}.json"
+        provenance_file.parent.mkdir(parents=True, exist_ok=True)
+        provenance_file.write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "format": plan.format,
+                    "importer_version": importer.importer_version,
+                    "spec_fingerprint": spec.fingerprint(),
+                    "plan_fingerprint": plan.plan_fingerprint,
+                    "id_namespace": spec.ids.namespace or "",
+                    "table_counts": table_counts,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        total = plan.totals.records
+        done = table_counts.get(SchemaGroup.RECORD.value, 0)
+        for sink in sinks:
+            sink.emit(
+                ProgressEvent(phase="finalize", done=done, total=total, table_counts=dict(table_counts), final=True)
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _emit_progress(self, sinks: Sequence[ProgressSink], plan: ImportPlan, table_counts: dict[str, int]) -> None:
+        done = table_counts.get(SchemaGroup.RECORD.value, 0)
+        for sink in sinks:
+            sink.emit(
+                ProgressEvent(phase="ingest", done=done, total=plan.totals.records, table_counts=dict(table_counts))
+            )
+
+    def _check_cancelled(self) -> None:
+        if self.cancel_check is not None and self.cancel_check():
+            raise JobStateError("Import cancelled.")
+
+    def _assert_same_filesystem(self, staging_parent: Path, library_dir: Path) -> None:
+        if staging_parent.stat().st_dev != library_dir.stat().st_dev:
+            raise UnsupportedStorageError(
+                "The staging area (<data_dir>/.pixano) and library/ must be on the same filesystem "
+                "for atomic dataset promotion."
+            )
+
+
+def ledger_spilled(ledger: IdLedger) -> bool:
+    """Whether the ledger has spilled to SQLite (its in-memory snapshot is gone)."""
+    return ledger._connection is not None
+
+
+def _approx_row_bytes(row: LanceModel) -> int:
+    size = 64  # rough per-row overhead
+    for attribute in ("raw_bytes", "blob", "preview", "content"):
+        value = getattr(row, attribute, None)
+        if isinstance(value, (bytes, str)):
+            size += len(value)
+    return size
+
+
+class _MediaCensus:
+    """Tracks whether view rows carry embedded bytes, URIs, or both (spec §6)."""
+
+    def __init__(self) -> None:
+        self.saw_embedded = False
+        self.saw_uri = False
+
+    def observe_rows(self, dataset: Dataset, table_name: str, rows: list[LanceModel]) -> None:
+        if not self._is_view_table(dataset, table_name):
+            return
+        for row in rows:
+            if getattr(row, "raw_bytes", b""):
+                self.saw_embedded = True
+            if getattr(row, "uri", ""):
+                self.saw_uri = True
+
+    def observe_arrow(self, dataset: Dataset, table_name: str, arrow_table: pa.Table) -> None:
+        if not self._is_view_table(dataset, table_name):
+            return
+        names = set(arrow_table.schema.names)
+        if "raw_bytes" in names:
+            lengths = pc.binary_length(arrow_table.column("raw_bytes").combine_chunks())
+            if pc.any(pc.greater(lengths, 0)).as_py():
+                self.saw_embedded = True
+        if "uri" in names:
+            lengths = pc.utf8_length(arrow_table.column("uri").combine_chunks())
+            if pc.any(pc.greater(lengths, 0)).as_py():
+                self.saw_uri = True
+
+    def storage_mode(
+        self, existing: 'Literal["filesystem", "embedded", "mixed"] | None' = None
+    ) -> 'Literal["filesystem", "embedded", "mixed"] | None':
+        if not self.saw_embedded and not self.saw_uri:
+            return None  # no view media observed: leave the stored mode untouched
+        observed: Literal["filesystem", "embedded", "mixed"] = (
+            "mixed" if (self.saw_embedded and self.saw_uri) else ("embedded" if self.saw_embedded else "filesystem")
+        )
+        if existing is None:
+            return observed
+        return observed if existing == observed else "mixed"
+
+    @staticmethod
+    def _is_view_table(dataset: Dataset, table_name: str) -> bool:
+        schema_cls = dataset.info.tables.get(table_name)
+        if schema_cls is None:
+            return False
+        try:
+            return schema_to_group(schema_cls) == SchemaGroup.VIEW and is_view(schema_cls)
+        except ValueError:
+            return False

--- a/src/pixano/utils/__init__.py
+++ b/src/pixano/utils/__init__.py
@@ -4,7 +4,7 @@
 # License: CECILL-C
 # =====================================
 
-from .python import estimate_folder_size, get_super_type_from_dict, natural_key, unique_list
+from .python import estimate_folder_size, get_super_type_from_dict, natural_key, to_snake_case, unique_list
 from .validation import issubclass_strict, validate_and_init_create_at_and_update_at
 
 
@@ -14,5 +14,6 @@ __all__ = [
     "get_super_type_from_dict",
     "issubclass_strict",
     "natural_key",
+    "to_snake_case",
     "validate_and_init_create_at_and_update_at",
 ]

--- a/src/pixano/utils/python.py
+++ b/src/pixano/utils/python.py
@@ -150,3 +150,11 @@ def unique_list(sequence: Sequence[Any]) -> list[Any]:
         List of unique elements.
     """
     return list(OrderedDict.fromkeys(sequence))
+
+
+def to_snake_case(value: str) -> str:
+    """Transform a string into a snake_case identifier (used for dataset folder names)."""
+    import re
+
+    snake = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower())
+    return re.sub(r"_+", "_", snake).strip("_")

--- a/tests/datasets/io/_import_main.py
+++ b/tests/datasets/io/_import_main.py
@@ -1,0 +1,46 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Kill-9 test helper: runs a toy import, signalling and stalling at the first checkpoint.
+
+Usage: python _import_main.py <data_dir> <marker_file>
+
+The parent test waits for <marker_file>, then SIGKILLs this process while the
+staged build is mid-flight — the library must remain untouched.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+from pixano.datasets.io import ImportEngine, ImportSpec, import_dataset
+from pixano.datasets.io.spec import workspace_preset
+from pixano.datasets.workspaces import WorkspaceType
+from tests.datasets.io._toy_importer import ToyImporter
+
+
+def main() -> None:
+    data_dir = Path(sys.argv[1])
+    marker_file = Path(sys.argv[2])
+
+    def checkpoint(cursor, table_counts) -> None:
+        marker_file.write_text(str(cursor))
+        time.sleep(120)  # stall inside the build so the parent can SIGKILL us
+
+    spec = ImportSpec.model_validate({"dataset": {"name": "killed_ds", "workspace": "image"}, "format": "toy"})
+    info = workspace_preset(WorkspaceType.IMAGE)
+    import_dataset(
+        "unused-source",
+        data_dir,
+        spec,
+        importer=ToyImporter(num_records=64, batch_size=4),
+        info=info,
+        engine=ImportEngine(data_dir, flush_rows=8, checkpoint=checkpoint),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/datasets/io/_toy_importer.py
+++ b/tests/datasets/io/_toy_importer.py
@@ -1,0 +1,72 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""A minimal deterministic importer used by the engine tests and the kill-9 helper."""
+
+from typing import Iterator
+
+from pixano.datasets.io import AnalyzeLimits, BatchBundle, DatasetImporter, ImportPlan, stable_id
+from pixano.schemas import Entity, Image, Record
+
+
+class ToyImporter(DatasetImporter):
+    """Emits `num_records` records with one image view and one entity each, in bundles of `batch_size`."""
+
+    format_name = "toy"
+    importer_version = "1.0.0"
+    supports_resume = True
+    deterministic_ids = True
+
+    def __init__(
+        self,
+        num_records: int = 10,
+        batch_size: int = 4,
+        media: str = "embed",
+        image_bytes: bytes = b"\x89PNG-fake",
+        duplicate_record_ordinal: int | None = None,
+    ):
+        self.num_records = num_records
+        self.batch_size = batch_size
+        self.media = media
+        self.image_bytes = image_bytes
+        self.duplicate_record_ordinal = duplicate_record_ordinal
+
+    def analyze(self, source, spec, limits: AnalyzeLimits) -> ImportPlan:
+        plan = ImportPlan(format=self.format_name, importer_version=self.importer_version)
+        plan.totals.records = self.num_records
+        return plan
+
+    def iter_batches(self, source, spec, plan, cursor=None) -> Iterator[BatchBundle]:
+        namespace = spec.ids.namespace or "toy"
+        start = int(cursor["ordinal"]) if cursor else 0
+        for begin in range(start, self.num_records, self.batch_size):
+            tables: dict = {"records": [], "images": [], "entities": []}
+            for ordinal in range(begin, min(begin + self.batch_size, self.num_records)):
+                effective = (
+                    self.duplicate_record_ordinal
+                    if self.duplicate_record_ordinal is not None and ordinal == self.num_records - 1
+                    else ordinal
+                )
+                record_id = stable_id(namespace, "record", effective)
+                tables["records"].append(Record(id=record_id, split="train"))
+                media_kwargs = (
+                    {"raw_bytes": self.image_bytes}
+                    if self.media == "embed"
+                    else {"uri": f"https://example.com/{ordinal}.png"}
+                )
+                tables["images"].append(
+                    Image(
+                        id=stable_id(namespace, "image", effective),
+                        record_id=record_id,
+                        logical_name="image",
+                        width=4,
+                        height=4,
+                        format="PNG",
+                        **media_kwargs,
+                    )
+                )
+                tables["entities"].append(Entity(id=stable_id(namespace, "entity", effective), record_id=record_id))
+            yield BatchBundle(tables=tables, cursor={"ordinal": min(begin + self.batch_size, self.num_records)})

--- a/tests/datasets/io/test_atomicity.py
+++ b/tests/datasets/io/test_atomicity.py
@@ -1,0 +1,69 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import hashlib
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from pixano.datasets import Dataset
+from pixano.datasets.io import ImportSpec, import_dataset
+from tests.datasets.io._toy_importer import ToyImporter
+
+
+REPO_ROOT = Path(__file__).parents[3]
+HELPER = Path(__file__).parent / "_import_main.py"
+
+
+def _tree_hash(root: Path) -> str:
+    hasher = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        hasher.update(str(path.relative_to(root)).encode())
+        if path.is_file():
+            hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+
+
+class TestKillNineAtomicity:
+    def test_sigkill_mid_create_leaves_library_untouched(self, tmp_path: Path):
+        # Pre-existing library content that must survive byte-identically.
+        spec = ImportSpec.model_validate({"dataset": {"name": "existing_ds", "workspace": "image"}, "format": "toy"})
+        import_dataset("unused", tmp_path, spec, importer=ToyImporter(num_records=2))
+        library = tmp_path / "library"
+        hash_before = _tree_hash(library)
+
+        marker = tmp_path / "first_flush.marker"
+        process = subprocess.Popen(
+            [sys.executable, str(HELPER), str(tmp_path), str(marker)],
+            cwd=REPO_ROOT,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            deadline = time.monotonic() + 120
+            while not marker.exists():
+                assert process.poll() is None, "helper exited before reaching the first flush"
+                assert time.monotonic() < deadline, "helper never reached the first flush"
+                time.sleep(0.2)
+            os.kill(process.pid, signal.SIGKILL)
+            process.wait(timeout=30)
+        finally:
+            if process.poll() is None:
+                process.kill()
+
+        assert _tree_hash(library) == hash_before, "a killed staged build must not touch library/"
+        assert not (library / "killed_ds").exists()
+
+        # A rerun of the same import succeeds cleanly afterwards.
+        rerun_spec = ImportSpec.model_validate(
+            {"dataset": {"name": "killed_ds", "workspace": "image"}, "format": "toy"}
+        )
+        result = import_dataset("unused", tmp_path, rerun_spec, importer=ToyImporter(num_records=64, batch_size=4))
+        assert Dataset(result.dataset_path).open_table("records").count_rows() == 64

--- a/tests/datasets/io/test_engine.py
+++ b/tests/datasets/io/test_engine.py
@@ -1,0 +1,166 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets import Dataset, DatasetInfo
+from pixano.datasets.io import ImportEngine, ImportSpec, JobStateError, SpecValidationError, import_dataset
+from pixano.datasets.io.engine import replay_journals, state_dir
+from pixano.datasets.utils.errors import DatasetIntegrityError
+from pixano.datasets.workspaces import WorkspaceType
+from tests.datasets.io._toy_importer import ToyImporter
+
+
+def _spec(name: str = "toy_ds", mode: str = "create", namespace: str = "toy") -> ImportSpec:
+    return ImportSpec.model_validate(
+        {
+            "dataset": {"name": name, "workspace": "image"},
+            "format": "toy",
+            "mode": mode,
+            "ids": {"namespace": namespace},
+        }
+    )
+
+
+def _import(data_dir: Path, importer: ToyImporter, spec: ImportSpec, **engine_kwargs):
+    engine = ImportEngine(data_dir, **engine_kwargs) if engine_kwargs else None
+    return import_dataset("unused-source", data_dir, spec, importer=importer, engine=engine)
+
+
+class TestFreshBuild:
+    def test_create_end_to_end(self, tmp_path: Path):
+        result = _import(tmp_path, ToyImporter(num_records=10, batch_size=4), _spec())
+
+        assert result.table_counts == {"records": 10, "images": 10, "entities": 10}
+        assert result.storage_mode == "embedded"
+        assert result.manifest_path is None
+
+        dataset = Dataset(result.dataset_path)
+        assert dataset.open_table("records").count_rows() == 10
+        assert dataset.info.storage_mode == "embedded"
+        record_indices = {c for index in dataset.open_table("records").list_indices() for c in index.columns}
+        assert "id" in record_indices
+
+        provenance = json.loads((result.dataset_path / "imports" / f"{result.job_id}.json").read_text())
+        assert provenance["format"] == "toy"
+        assert provenance["table_counts"]["records"] == 10
+
+        # No staging/ledger leftovers.
+        assert not any((state_dir(tmp_path) / "staging").glob("*")), "staging must be empty after promotion"
+
+    def test_create_refuses_existing(self, tmp_path: Path):
+        _import(tmp_path, ToyImporter(num_records=2), _spec())
+        with pytest.raises(SpecValidationError, match="already exists"):
+            _import(tmp_path, ToyImporter(num_records=2), _spec())
+
+    def test_multi_flush_and_checkpoints(self, tmp_path: Path):
+        checkpoints: list[dict] = []
+        result = _import(
+            tmp_path,
+            ToyImporter(num_records=20, batch_size=4),
+            _spec(),
+            flush_rows=9,
+            checkpoint=lambda cursor, counts: checkpoints.append(dict(cursor)),
+        )
+        assert result.table_counts["records"] == 20
+        assert len(checkpoints) >= 2  # several committed flush boundaries
+
+    def test_cross_flush_duplicate_id_detected(self, tmp_path: Path):
+        importer = ToyImporter(num_records=12, batch_size=3, duplicate_record_ordinal=0)
+        with pytest.raises(DatasetIntegrityError, match="Duplicate id"):
+            _import(tmp_path, importer, _spec(), flush_rows=6)
+        assert not (tmp_path / "library" / "toy_ds").exists(), "failed build must not reach the library"
+
+    def test_uri_media_census(self, tmp_path: Path):
+        result = _import(tmp_path, ToyImporter(num_records=4, media="uri"), _spec())
+        assert result.storage_mode == "filesystem"
+
+    def test_cancel_cleans_staging(self, tmp_path: Path):
+        with pytest.raises(JobStateError, match="cancelled"):
+            _import(
+                tmp_path,
+                ToyImporter(num_records=32, batch_size=4),
+                _spec(),
+                flush_rows=4,
+                cancel_check=lambda: True,
+            )
+        assert not (tmp_path / "library" / "toy_ds").exists()
+        assert not any((state_dir(tmp_path) / "staging").glob("*"))
+
+
+class TestOverwrite:
+    def test_overwrite_replaces_dataset(self, tmp_path: Path):
+        _import(tmp_path, ToyImporter(num_records=5), _spec())
+        result = _import(tmp_path, ToyImporter(num_records=3), _spec(mode="overwrite"))
+
+        dataset = Dataset(result.dataset_path)
+        assert dataset.open_table("records").count_rows() == 3
+        assert not any((state_dir(tmp_path) / "trash").glob("*")), "trash must be emptied after the swap"
+        assert not any((state_dir(tmp_path) / "journal").glob("*.json")), "journal must be cleared"
+
+    def test_replay_completes_interrupted_swap(self, tmp_path: Path):
+        # Build a dataset, then simulate a crash between old->trash and staging->target.
+        result = _import(tmp_path, ToyImporter(num_records=4), _spec())
+        target = result.dataset_path
+
+        staging = state_dir(tmp_path) / "staging" / "toy_ds-crashjob"
+        trash = state_dir(tmp_path) / "trash" / "toy_ds-crashjob"
+        journal_dir = state_dir(tmp_path) / "journal"
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        target.rename(trash.parent.mkdir(parents=True, exist_ok=True) or trash)  # old -> trash
+        # The "new" dataset sits fully built in staging.
+        _import(tmp_path, ToyImporter(num_records=2), _spec())  # rebuild directly into library
+        (tmp_path / "library" / "toy_ds").rename(staging.parent.mkdir(parents=True, exist_ok=True) or staging)
+        (journal_dir / "crashjob.json").write_text(
+            json.dumps({"target": str(target), "staging": str(staging), "trash": str(trash)})
+        )
+
+        replay_journals(tmp_path)
+
+        assert target.exists(), "swap must be completed from the journal"
+        assert Dataset(target).open_table("records").count_rows() == 2
+        assert not trash.exists()
+        assert not (journal_dir / "crashjob.json").exists()
+
+
+class TestAddMode:
+    def test_add_is_idempotent_and_journaled(self, tmp_path: Path):
+        _import(tmp_path, ToyImporter(num_records=6), _spec())
+
+        first = _import(tmp_path, ToyImporter(num_records=6), _spec(mode="add"))
+        second = _import(tmp_path, ToyImporter(num_records=6), _spec(mode="add"))
+
+        dataset = Dataset(first.dataset_path)
+        assert dataset.open_table("records").count_rows() == 6  # re-running converges, never duplicates
+        assert first.manifest_path is not None and first.manifest_path.exists()
+
+        manifest = json.loads(second.manifest_path.read_text())
+        assert manifest["pre_import_versions"]["records"] >= 1
+        assert manifest["post_import_versions"] is not None
+
+    def test_add_requires_existing_dataset(self, tmp_path: Path):
+        with pytest.raises(SpecValidationError, match="does not exist"):
+            _import(tmp_path, ToyImporter(num_records=2), _spec(mode="add"))
+
+
+class TestLibraryGlobHardening:
+    def test_dot_dirs_are_not_datasets(self, tmp_path: Path):
+        result = _import(tmp_path, ToyImporter(num_records=2), _spec())
+
+        # Plant a trashed copy inside a dot-dir of the library and engine trash.
+        junk = tmp_path / "library" / ".staging-junk"
+        junk.mkdir()
+        (junk / "info.json").write_text((result.dataset_path / "info.json").read_text())
+
+        infos = DatasetInfo.load_directory(tmp_path / "library")
+        assert len(infos) == 1
+
+    def test_workspace_flows_through(self, tmp_path: Path):
+        result = _import(tmp_path, ToyImporter(num_records=2), _spec())
+        assert Dataset(result.dataset_path).info.workspace == WorkspaceType.IMAGE


### PR DESCRIPTION
## Issue

Part of the 0.8.0 import/export redesign stack (spec: #664, `docs/specs/data-import-export.md` §8).

## Description

Third slice of the shared import/export core — the `ImportEngine`, the only component that writes datasets:

- **Buffering & integrity**: byte- and row-bounded buffering of importer bundles; on fresh builds the `IdLedger` answers uniqueness and FK checks (cross-flush duplicate ids are detected — closing the `add_records` per-call `known_ids` hole — and no DB scans run); Arrow payloads are written through with timestamp columns appended.
- **Atomicity**: `create`/`overwrite` build in `<data_dir>/.pixano/staging/` and atomically rename into `library/`; overwrite runs a journaled old→trash→swap sequence with `replay_journals()` completing interrupted swaps on boot. A SIGKILLed staged build leaves `library/` **byte-identical** (tree-hash-verified subprocess kill‑9 test) and a rerun succeeds cleanly.
- **Add mode**: an `ImportManifest` (per-table pre/post Lance versions) is written *before* the first write; every flush goes through the upserting `Dataset.merge_records`, so re-running an add converges instead of duplicating.
- **Media census**: `DatasetInfo.storage_mode` is stamped from what the import actually wrote (`embedded` / `filesystem` / `mixed`) instead of being force-set.
- **Finalize**: scalar indexes, `table.optimize()`, a provenance stamp under `{dataset}/imports/{job_id}.json`, API-cache invalidation, terminal progress event.
- **Python API**: `io.analyze()` / `io.import_dataset()` — the shared entry points the CLI and REST layers will call; workspace presets supply the schema when none is given.
- `pixano init` creates `<data_dir>/.pixano`; library listing skips dot-directories so staging/trash can never appear as datasets.

13 new engine/atomicity tests (incl. cancel cleanup, journal replay, idempotent add, media census); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)