### PR TITLE
feat: compile the declarative schema shorthand into DatasetInfo

### DIFF
--- a/src/pixano/datasets/dataset_schema.py
+++ b/src/pixano/datasets/dataset_schema.py
@@ -288,6 +288,11 @@ def _deserialize_table_schema(payload: dict[str, Any]) -> type[LanceModel]:
 
     model_name = payload.get("name")
     if model_name is None:
+        if payload.get("fields"):
+            raise ValueError(
+                f"Schema manifest for base '{base_name}' declares custom fields but no subclass 'name'; "
+                "refusing to silently drop them."
+            )
         return base_type
 
     fields = {

--- a/src/pixano/datasets/io/__init__.py
+++ b/src/pixano/datasets/io/__init__.py
@@ -31,7 +31,7 @@ from .media import MediaResolver, ResolvedMedia, VideoProbe, ffprobe_available, 
 from .plan import AnalyzeLimits, Finding, ImportPlan, PreflightReport, Provenance, SamplePreview
 from .progress import ProgressEvent, ProgressSink, ThrottledSink, TqdmSink
 from .registry import FORMATS, Capabilities, DataFormat, FormatRegistry
-from .spec import ExportSpec, IdPolicy, ImportSpec, MediaPolicy, SchemaSpec, workspace_preset
+from .spec import ExportSpec, IdPolicy, ImportSpec, MediaPolicy, SchemaSpec, resolve_dataset_info, workspace_preset
 
 
 __all__ = [
@@ -82,6 +82,7 @@ __all__ = [
     "probe_image",
     "probe_video",
     "replay_journals",
+    "resolve_dataset_info",
     "stable_id",
     "workspace_preset",
 ]

--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -24,7 +24,7 @@ from .importer import DatasetImporter, SourceRef
 from .plan import AnalyzeLimits, ImportPlan
 from .progress import ProgressSink
 from .registry import FORMATS
-from .spec import ImportSpec, workspace_preset
+from .spec import ImportSpec, resolve_dataset_info
 
 
 def _resolve_importer(source: SourceRef, spec: ImportSpec, importer: DatasetImporter | None) -> DatasetImporter:
@@ -90,7 +90,7 @@ def import_dataset(
         )
 
     if info is None:
-        info = workspace_preset(spec.dataset.workspace)
+        info = resolve_dataset_info(spec)
     if spec.dataset.name:
         info.name = spec.dataset.name
     if spec.dataset.description:

--- a/src/pixano/datasets/io/spec.py
+++ b/src/pixano/datasets/io/spec.py
@@ -30,11 +30,14 @@ from pixano.schemas import (
     Image,
     KeyPoints,
     Message,
+    PointCloud,
     Record,
     SequenceFrame,
     Text,
     TextSpan,
     Tracklet,
+    Video,
+    View,
 )
 
 from .errors import SpecValidationError
@@ -69,23 +72,210 @@ class DatasetSpec(BaseModel):
     workspace: WorkspaceType = WorkspaceType.UNDEFINED
 
 
-class SchemaSpec(BaseModel):
-    """Hand-authorable schema shorthand (spec §4).
+_VIEW_KINDS: dict[str, type[View]] = {
+    "image": Image,
+    "sequence_frames": SequenceFrame,
+    "video": Video,
+    "text": Text,
+    "point_cloud": PointCloud,
+}
+_KIND_BY_VIEW: dict[type[View], str] = {cls: kind for kind, cls in _VIEW_KINDS.items()}
 
-    Held as raw data in this slice; ``compile()`` into a ``DatasetInfo`` lands
-    with the pixano_jsonl format (plan P2.1).
-    """
+# Zero-values used when an attr declares neither a default nor required=true.
+_ZERO_DEFAULTS: dict[str, Any] = {"str": "", "int": 0, "float": 0.0, "bool": False}
+
+
+def _attr_field(attr_name: str, value: Any) -> tuple[Any, Any]:
+    """Turn one shorthand attr into a pydantic (annotation, default) pair."""
+    from pixano.datasets.dataset_schema import _MANIFEST_TYPES
+
+    payload = {"type": value} if isinstance(value, str) else dict(value or {})
+    type_name = payload.get("type")
+    if not isinstance(type_name, str) or type_name not in _MANIFEST_TYPES:
+        known = ", ".join(sorted(_MANIFEST_TYPES))
+        raise SpecValidationError(
+            f"Attr '{attr_name}': type {type_name!r} is not declarable in a spec (known: {known}). "
+            "Nested dict/object attrs need a custom Python importer (spec §4)."
+        )
+    annotation: Any = _MANIFEST_TYPES[type_name]
+    if payload.get("collection"):
+        annotation = list[annotation]
+
+    if payload.get("required"):
+        return annotation, ...
+    if "default" in payload:
+        return annotation, payload["default"]
+    if payload.get("collection"):
+        return annotation, Field(default_factory=list)
+    if type_name in _ZERO_DEFAULTS:
+        return annotation, _ZERO_DEFAULTS[type_name]
+    return annotation, ...  # no sensible zero-value: the attr is required
+
+
+def _synthesize(base: type, attrs: dict[str, Any]) -> type:
+    """Create a named subclass carrying the shorthand attrs (manifest-serializable)."""
+    from pydantic import create_model
+
+    fields = {name: _attr_field(name, value) for name, value in attrs.items()}
+    return create_model(f"Custom{base.__name__}", __base__=base, **fields)
+
+
+def _attrs_from_schema(schema_cls: type) -> dict[str, Any]:
+    """Inverse of `_synthesize`: recover the shorthand attrs of a subclass."""
+    from pixano.datasets.dataset_schema import _MANIFEST_TYPES, _serialize_table_schema
+
+    manifest = _serialize_table_schema(schema_cls)
+    attrs: dict[str, Any] = {}
+    for field_name, payload in manifest.get("fields", {}).items():
+        type_name = payload.get("type")
+        if type_name == "FixedSizeList" or type_name not in _MANIFEST_TYPES:
+            raise SpecValidationError(
+                f"Field '{field_name}' of {schema_cls.__name__} ({type_name!r}) is outside the declarative "
+                "schema dialect; export it via ImportSpec.schema_manifest instead."
+            )
+        attr: dict[str, Any] = {"type": type_name}
+        if payload.get("collection"):
+            attr["collection"] = True
+        if payload.get("required"):
+            attr["required"] = True
+        elif "default" in payload:
+            attr["default"] = payload["default"]
+        attrs[field_name] = attr
+    return attrs
+
+
+class SchemaSpec(BaseModel):
+    """Hand-authorable schema shorthand (spec §4), compiled onto the manifest dialect."""
 
     model_config = ConfigDict(extra="forbid")
 
     views: dict[str, Any] = Field(default_factory=dict)
     record: dict[str, Any] = Field(default_factory=dict)
     entity: dict[str, Any] = Field(default_factory=dict)
-    annotations: list[Any] | dict[str, Any] = Field(default_factory=list)
+    entity_dynamic_state: dict[str, Any] | None = None
+    annotations: list[str] | dict[str, Any] = Field(default_factory=list)
 
     def compile(self, workspace: WorkspaceType = WorkspaceType.UNDEFINED) -> DatasetInfo:
-        """Compile the shorthand into a DatasetInfo. Implemented in plan P2.1."""
-        raise NotImplementedError("SchemaSpec.compile lands with the pixano_jsonl format (plan P2.1).")
+        """Compile the shorthand into a `DatasetInfo` (preset-seeded, spec-overridden)."""
+        from pixano.schemas import supported_dataset_info_slots
+        from pixano.schemas.table_names import supported_slot_schema
+
+        try:
+            info = workspace_preset(workspace)
+        except SpecValidationError:
+            info = DatasetInfo(workspace=workspace, record=Record, entity=Entity, views={"image": Image})
+
+        payload: dict[str, Any] = {
+            "name": info.name,
+            "workspace": workspace,
+            "record": info.record,
+            "entity": info.entity,
+            "entity_dynamic_state": info.entity_dynamic_state,
+            "views": dict(info.views),
+        }
+        for slot in supported_dataset_info_slots():
+            if slot in ("record", "entity", "entity_dynamic_state"):
+                continue
+            payload[slot] = getattr(info, slot)
+
+        if self.record.get("attrs"):
+            payload["record"] = _synthesize(Record, self.record["attrs"])
+        if self.entity.get("attrs"):
+            payload["entity"] = _synthesize(Entity, self.entity["attrs"])
+        if self.entity_dynamic_state is not None:
+            payload["entity_dynamic_state"] = (
+                _synthesize(EntityDynamicState, self.entity_dynamic_state["attrs"])
+                if self.entity_dynamic_state.get("attrs")
+                else EntityDynamicState
+            )
+
+        if self.annotations:
+            slot_specs = (
+                {slot: {} for slot in self.annotations} if isinstance(self.annotations, list) else self.annotations
+            )
+            annotation_slots = set(supported_dataset_info_slots()) - {"record", "entity", "entity_dynamic_state"}
+            for slot in annotation_slots:
+                payload[slot] = None  # the spec's annotation list replaces the preset's
+            for slot, slot_spec in slot_specs.items():
+                if slot not in annotation_slots:
+                    known = ", ".join(sorted(annotation_slots))
+                    raise SpecValidationError(f"Unknown annotation slot '{slot}' (known: {known}).")
+                base = supported_slot_schema(slot)
+                attrs = (slot_spec or {}).get("attrs") if isinstance(slot_spec, dict) else None
+                payload[slot] = _synthesize(base, attrs) if attrs else base
+
+        if self.views:
+            views: dict[str, type[View]] = {}
+            kind_classes: dict[str, type[View]] = {}
+            for logical_name, view_spec in self.views.items():
+                view_payload = {"kind": view_spec} if isinstance(view_spec, str) else dict(view_spec or {})
+                kind = view_payload.get("kind")
+                if kind not in _VIEW_KINDS:
+                    known = ", ".join(sorted(_VIEW_KINDS))
+                    raise SpecValidationError(f"View '{logical_name}': unknown kind {kind!r} (known: {known}).")
+                raw_attrs = view_payload.get("attrs") or {}
+                if not isinstance(raw_attrs, dict):
+                    raise SpecValidationError(f"View '{logical_name}': attrs must be a mapping.")
+                view_attrs: dict[str, Any] = dict(raw_attrs)
+                if kind not in kind_classes:
+                    kind_classes[kind] = (
+                        _synthesize(_VIEW_KINDS[kind], view_attrs) if view_attrs else _VIEW_KINDS[kind]
+                    )
+                elif view_attrs and _attrs_from_schema(kind_classes[kind]) != _attrs_from_schema(
+                    _synthesize(_VIEW_KINDS[kind], view_attrs)
+                ):
+                    raise SpecValidationError(
+                        f"Views of kind '{kind}' share one table and must declare identical attrs."
+                    )
+                views[logical_name] = kind_classes[kind]
+            payload["views"] = views
+
+        return DatasetInfo.model_validate(payload)
+
+    @classmethod
+    def from_dataset_info(cls, info: DatasetInfo) -> "SchemaSpec":
+        """Inverse of :meth:`compile`: recover the shorthand from a `DatasetInfo`."""
+        from pixano.schemas import supported_dataset_info_slots
+
+        views: dict[str, Any] = {}
+        for logical_name, view_cls in info.views.items():
+            base = next((b for b in view_cls.__mro__ if b in _KIND_BY_VIEW), None)
+            if base is None:
+                raise SpecValidationError(
+                    f"View '{logical_name}' ({view_cls.__name__}) is outside the declarative dialect."
+                )
+            view_payload: dict[str, Any] = {"kind": _KIND_BY_VIEW[base]}
+            if view_cls is not base:
+                view_payload["attrs"] = _attrs_from_schema(view_cls)
+            views[logical_name] = view_payload
+
+        annotations: dict[str, Any] = {}
+        for slot in supported_dataset_info_slots():
+            if slot in ("record", "entity", "entity_dynamic_state"):
+                continue
+            schema_cls = getattr(info, slot)
+            if schema_cls is None:
+                continue
+            from pixano.schemas.table_names import supported_slot_schema
+
+            base = supported_slot_schema(slot)
+            annotations[slot] = {"attrs": _attrs_from_schema(schema_cls)} if schema_cls is not base else {}
+
+        return cls(
+            views=views,
+            record={"attrs": _attrs_from_schema(info.record)} if info.record and info.record is not Record else {},
+            entity={"attrs": _attrs_from_schema(info.entity)} if info.entity and info.entity is not Entity else {},
+            entity_dynamic_state=(
+                None
+                if info.entity_dynamic_state is None
+                else (
+                    {"attrs": _attrs_from_schema(info.entity_dynamic_state)}
+                    if info.entity_dynamic_state is not EntityDynamicState
+                    else {}
+                )
+            ),
+            annotations=(sorted(annotations) if all(not payload for payload in annotations.values()) else annotations),
+        )
 
 
 class ImportSpec(BaseModel):
@@ -98,6 +288,7 @@ class ImportSpec(BaseModel):
     format: str = "auto"
     media: MediaPolicy = Field(default_factory=MediaPolicy)
     schema_: SchemaSpec | None = Field(default=None, alias="schema")
+    schema_manifest: dict[str, Any] | None = None
     defaults: dict[str, Any] = Field(default_factory=dict)
     ids: IdPolicy = Field(default_factory=IdPolicy)
     mode: Literal["create", "overwrite", "add"] = "create"
@@ -193,3 +384,31 @@ def workspace_preset(workspace: WorkspaceType) -> DatasetInfo:
             views={"image": Image, "text": Text},
         )
     raise SpecValidationError(f"No workspace preset for workspace '{workspace.value}'.")
+
+
+def resolve_dataset_info(spec: ImportSpec) -> DatasetInfo:
+    """Resolve the target `DatasetInfo` for a spec (spec §4).
+
+    Priority: verbatim ``schema_manifest`` payloads (the round-trip escape for
+    schemas outside the authoring dialect) > the ``schema`` shorthand compiled
+    onto the workspace preset > the bare workspace preset.
+    """
+    if spec.schema_manifest is not None:
+        from pixano.datasets.dataset_schema import _deserialize_table_schema
+
+        payload: dict[str, Any] = {"workspace": spec.dataset.workspace}
+        for slot_name, manifest in spec.schema_manifest.items():
+            if slot_name == "views":
+                payload["views"] = {
+                    logical_name: _deserialize_table_schema(view_manifest)
+                    for logical_name, view_manifest in manifest.items()
+                }
+            else:
+                payload[slot_name] = _deserialize_table_schema(manifest)
+        try:
+            return DatasetInfo.model_validate(payload)
+        except Exception as exc:
+            raise SpecValidationError(f"Invalid schema_manifest: {exc}") from None
+    if spec.schema_ is not None:
+        return spec.schema_.compile(spec.dataset.workspace)
+    return workspace_preset(spec.dataset.workspace)

--- a/tests/datasets/io/test_schema_spec.py
+++ b/tests/datasets/io/test_schema_spec.py
@@ -1,0 +1,181 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets import DatasetInfo
+from pixano.datasets.dataset_schema import _deserialize_table_schema, _serialize_table_schema
+from pixano.datasets.io import ImportSpec, SchemaSpec, SpecValidationError, resolve_dataset_info, workspace_preset
+from pixano.datasets.workspaces import WorkspaceType
+from pixano.schemas import BBox, Entity, Image, Record
+
+
+def _schemas_field_identical(left: type | None, right: type | None) -> bool:
+    """Field-level identity: same manifest (base + custom fields), class name aside."""
+    if left is None or right is None:
+        return left is right
+    left_manifest = _serialize_table_schema(left)
+    right_manifest = _serialize_table_schema(right)
+    return (left_manifest["base"], left_manifest["fields"]) == (right_manifest["base"], right_manifest["fields"])
+
+
+def _infos_field_identical(left: DatasetInfo, right: DatasetInfo) -> bool:
+    if set(left.tables) != set(right.tables):
+        return False
+    return all(_schemas_field_identical(left.tables[name], right.tables[name]) for name in left.tables)
+
+
+class TestSchemaSpecCompile:
+    def test_spec_example_block_compiles(self):
+        schema = SchemaSpec.model_validate(
+            {
+                "views": {"rgb": {"kind": "image"}, "thermal": {"kind": "image"}},
+                "record": {"attrs": {"license": "str"}},
+                "entity": {"attrs": {"category": "str", "is_difficult": {"type": "bool", "default": False}}},
+                "annotations": ["bbox", "multi_path"],
+            }
+        )
+        info = schema.compile(WorkspaceType.IMAGE)
+
+        assert set(info.views) == {"rgb", "thermal"}
+        assert info.views["rgb"] is info.views["thermal"]  # one class per kind (shared table)
+        assert "license" in info.record.model_fields
+        assert info.record.model_fields["license"].default == ""
+        assert info.entity.model_fields["is_difficult"].default is False
+        assert set(info.tables) == {"records", "images", "entities", "bboxes", "multi_paths"}
+        assert info.keypoint is None  # the annotations list replaced the preset's slots
+
+    def test_compiled_info_round_trips_through_info_json(self, tmp_path: Path):
+        schema = SchemaSpec.model_validate({"entity": {"attrs": {"category": "str"}}, "annotations": ["bbox"]})
+        info = schema.compile(WorkspaceType.IMAGE)
+        info.name = "compiled"
+
+        json_file = tmp_path / "info.json"
+        info.to_json(json_file)
+        loaded = DatasetInfo.from_json(json_file)
+
+        assert "category" in loaded.entity.model_fields
+        assert _infos_field_identical(info, loaded)
+
+    def test_unknown_view_kind_and_slot(self):
+        with pytest.raises(SpecValidationError, match="unknown kind 'hologram'"):
+            SchemaSpec.model_validate({"views": {"x": {"kind": "hologram"}}}).compile(WorkspaceType.IMAGE)
+        with pytest.raises(SpecValidationError, match="Unknown annotation slot 'bbox3d'"):
+            SchemaSpec.model_validate({"annotations": ["bbox3d"]}).compile(WorkspaceType.IMAGE)
+
+    def test_dict_typed_attr_is_out_of_dialect(self):
+        with pytest.raises(SpecValidationError, match="custom Python importer"):
+            SchemaSpec.model_validate({"entity": {"attrs": {"meta": {"type": "dict"}}}}).compile(WorkspaceType.IMAGE)
+
+    def test_conflicting_attrs_on_shared_kind(self):
+        schema = SchemaSpec.model_validate(
+            {
+                "views": {
+                    "a": {"kind": "image", "attrs": {"exposure": "float"}},
+                    "b": {"kind": "image", "attrs": {"gain": "float"}},
+                }
+            }
+        )
+        with pytest.raises(SpecValidationError, match="identical attrs"):
+            schema.compile(WorkspaceType.IMAGE)
+
+
+class TestFromDatasetInfoInverse:
+    @pytest.mark.parametrize(
+        "workspace",
+        [
+            WorkspaceType.IMAGE,
+            WorkspaceType.VIDEO,
+            WorkspaceType.IMAGE_VQA,
+            WorkspaceType.IMAGE_TEXT_ENTITY_LINKING,
+        ],
+    )
+    def test_identity_on_workspace_presets(self, workspace):
+        info = workspace_preset(workspace)
+        recompiled = SchemaSpec.from_dataset_info(info).compile(workspace)
+        assert _infos_field_identical(info, recompiled)
+
+    def test_identity_with_custom_attrs(self):
+        original = SchemaSpec.model_validate(
+            {
+                "views": {"image": {"kind": "image"}},
+                "record": {"attrs": {"license": "str"}},
+                "entity": {"attrs": {"category": "str", "score": {"type": "float", "required": True}}},
+                "annotations": {"bbox": {"attrs": {"quality": "float"}}},
+            }
+        ).compile(WorkspaceType.IMAGE)
+
+        recompiled = SchemaSpec.from_dataset_info(original).compile(WorkspaceType.IMAGE)
+        assert _infos_field_identical(original, recompiled)
+
+
+class TestSchemaManifestPassthrough:
+    def test_exotic_info_round_trips_verbatim(self):
+        # A schema outside the authoring dialect (subclass with a custom name) passes
+        # through schema_manifest untouched.
+        original = DatasetInfo(
+            workspace=WorkspaceType.IMAGE,
+            record=Record,
+            entity=type("ExoticEntity", (Entity,), {"__annotations__": {"wingspan": float}, "wingspan": 0.0}),
+            bbox=BBox,
+            views={"image": Image},
+        )
+        manifest = {
+            "record": _serialize_table_schema(original.record),
+            "entity": _serialize_table_schema(original.entity),
+            "bbox": _serialize_table_schema(original.bbox),
+            "views": {"image": _serialize_table_schema(Image)},
+        }
+        spec = ImportSpec.model_validate({"dataset": {"workspace": "image"}, "schema_manifest": manifest})
+        resolved = resolve_dataset_info(spec)
+
+        assert _infos_field_identical(original, resolved)
+        assert resolved.entity.__name__ == "ExoticEntity"  # verbatim, name preserved
+
+    def test_shorthand_beats_preset_and_manifest_beats_shorthand(self):
+        spec = ImportSpec.model_validate({"dataset": {"workspace": "image"}, "schema": {"annotations": ["mask"]}})
+        assert set(resolve_dataset_info(spec).tables) == {"records", "images", "entities", "masks"}
+
+        preset_only = ImportSpec.model_validate({"dataset": {"workspace": "image"}})
+        assert "keypoints" in resolve_dataset_info(preset_only).tables
+
+
+class TestSerializerHardError:
+    def test_nameless_fields_manifest_raises(self):
+        with pytest.raises(ValueError, match="refusing to silently drop"):
+            _deserialize_table_schema(
+                {"base": "Entity", "fields": {"category": {"type": "str", "collection": False, "required": False}}}
+            )
+
+    def test_nameless_empty_fields_still_returns_base(self):
+        assert _deserialize_table_schema({"base": "Entity", "fields": {}}) is Entity
+
+
+class TestSpecExampleYamlStillValid:
+    def test_full_yaml_with_schema_compiles(self, tmp_path: Path):
+        spec_file = tmp_path / "pixano.yaml"
+        spec_file.write_text(
+            """
+pixano: 2
+dataset:
+  name: "FLIR ADAS"
+  workspace: image
+format: pixano_jsonl
+schema:
+  views:
+    rgb: {kind: image}
+    thermal: {kind: image}
+  entity:
+    attrs: {category: str}
+  annotations: [bbox]
+"""
+        )
+        spec = ImportSpec.from_yaml(spec_file)
+        info = resolve_dataset_info(spec)
+        assert set(info.views) == {"rgb", "thermal"}
+        assert "category" in info.entity.model_fields


### PR DESCRIPTION
## Issue

Part of the 0.8.0 import/export redesign stack (spec: #664, `docs/specs/data-import-export.md` §4).

## Description

Opens the JSONL v2 lane: the `pixano.yaml` `schema:` block becomes executable.

- **`SchemaSpec.compile(workspace)`** — compiles the hand-authorable shorthand (views/record/entity/annotations with typed attrs) onto the workspace preset by synthesizing manifest-serializable subclasses. Views of one kind share one class (they share one table; conflicting attrs are an error); attrs outside the manifest dialect (e.g. nested dicts) fail with an error pointing at custom Python importers — the documented declarative/Python frontier.
- **`SchemaSpec.from_dataset_info`** — the exporter-facing inverse: `compile(from_dataset_info(info))` is field-identical for all four workspace presets and for custom-attr schemas (CI-tested identity).
- **`ImportSpec.schema_manifest`** — verbatim manifest passthrough for schemas outside the authoring dialect, so every dataset the engine can build remains round-trippable (the JSONL v2 exporter will emit it as the fallback).
- **`resolve_dataset_info(spec)`** — resolution order manifest > shorthand > preset, wired into `io.import_dataset`.
- The nameless-fields **silent drop** in `_deserialize_table_schema` (custom fields vanishing when a manifest lacked a subclass name) is now a hard error.

15 new tests; full suite green (522).

🤖 Generated with [Claude Code](https://claude.com/claude-code)