### PR TITLE
docs: rewrite import docs onto the zero-Python JSONL v2 flow

### DIFF
--- a/docs-astro/src/config/navigation.ts
+++ b/docs-astro/src/config/navigation.ts
@@ -35,6 +35,7 @@ export const sidebarNav: Record<string, NavSection[]> = {
         },
         { title: "Quickstart", href: "/getting_started/quickstart/" },
         { title: "Key Concepts", href: "/getting_started/key_concepts/" },
+        { title: "Importing Data", href: "/getting_started/importing_data/" },
       ],
     },
   ],
@@ -109,9 +110,6 @@ export const sidebarNav: Record<string, NavSection[]> = {
           title: "builders",
           children: [
             { title: "dataset_builder", href: "/api_reference/module/datasets/builders/dataset_builder/" },
-            { title: "image", href: "/api_reference/module/datasets/builders/folders/image/" },
-            { title: "video", href: "/api_reference/module/datasets/builders/folders/video/" },
-            { title: "vqa", href: "/api_reference/module/datasets/builders/folders/vqa/" },
           ],
         },
         {

--- a/docs-astro/src/pages/cookbook/entity_linking.mdx
+++ b/docs-astro/src/pages/cookbook/entity_linking.mdx
@@ -37,67 +37,63 @@ Each line in `metadata.jsonl` describes one item with both an image view and a t
 
 ```json
 {
-  "status": "validated",
   "views": {
-    "image": "image_001.jpg",
-    "text": "The Eiffel Tower is a wrought-iron lattice tower in Paris."
+    "image": "images/image_001.jpg",
+    "text": { "content": "The Eiffel Tower is a wrought-iron lattice tower in Paris." }
   },
+  "attrs": { "status": "validated" },
   "entities": [
     {
-      "name": "Eiffel Tower",
-      "annotations": {
-        "image": { "bbox": [0.3, 0.1, 0.4, 0.8] },
-        "text": { "text_span": [4, 16] }
-      }
+      "attrs": { "name": "Eiffel Tower" },
+      "annotations": [
+        { "kind": "bbox", "view": "image", "coords": [0.3, 0.1, 0.4, 0.8], "format": "xywh", "is_normalized": true },
+        { "kind": "text_span", "view": "text", "mention": "Eiffel Tower", "spans_start": [4], "spans_end": [16] }
+      ]
     }
   ]
 }
 ```
 
-- `views.text` is a string (the full text content).
-- `text_span` is a `[start, end]` character offset pair.
-- Each entity can have annotations on both the image and text views.
+- A text view takes `{"content": …}` for inline text **or** `{"uri": "doc.txt"}` for a file — exactly one, always explicit.
+- A `text_span` carries the `mention` string plus parallel `spans_start`/`spans_end` character offsets (a mention can span several ranges).
+- With two views declared, every annotation names its view: the bbox lives on `image`, the span on `text`.
 
-### Review the dataset info
+### Review the schema
 
-The dataset info at `examples/mel/info.py`:
+The schema lives in `pixano.yaml` at the source root:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import BBox, CompressedRLE, Entity, Image, Record, Text, TextSpan
-
-
-class MELEntity(Entity):
-    name: str = ""
-
-
-dataset_info = DatasetInfo(
-    name="MEL Sample",
-    description="Sample import for image-text entity linking datasets.",
-    workspace=WorkspaceType.IMAGE_TEXT_ENTITY_LINKING,
-    record=Record,
-    entity=MELEntity,
-    bbox=BBox,
-    mask=CompressedRLE,
-    text_span=TextSpan,
-    views={"image": Image, "text": Text},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: mel_sample
+  workspace: image_text_entity_linking
+schema:
+  views:
+    image: { kind: image }
+    text: { kind: text }
+  entity:
+    attrs:
+      name: str
+  annotations: [bbox, mask, text_span]
 ```
 
 Key elements:
 
-- `WorkspaceType.IMAGE_TEXT_ENTITY_LINKING` enables the image + text panel UI.
-- `views` has two entries: `"image"` (type `Image`) and `"text"` (type `Text`).
-- `TextSpan` is the annotation type that marks character ranges in the text.
-- Entities can be linked to both `BBox` (on the image) and `TextSpan` (on the text).
+- `workspace: image_text_entity_linking` enables the image + text panel UI.
+- `views` has two entries: `"image"` (an image) and `"text"` (a text document).
+- `text_span` is the annotation kind that marks character ranges in the text.
+- Entities can be linked to both a `bbox` (on the image) and a `text_span` (on the text).
+
+See [Importing Data](/getting_started/importing_data/) for the full reference.
 
 ### Run the import
 
 ```bash
-pixano data import ./my_data ./mel_source \
-    --info examples/mel/info.py:dataset_info
+pixano data import ./my_data ./mel_source
 ```
+
+Pixano validates every line first and prints a plan; use `--dry-run` to only validate.
 
 ### Launch the server
 

--- a/docs-astro/src/pages/cookbook/multi_view_detection.mdx
+++ b/docs-astro/src/pages/cookbook/multi_view_detection.mdx
@@ -68,52 +68,48 @@ Each line in `metadata.jsonl` pairs an RGB image with its thermal counterpart an
 
 ```json
 {
-  "status": "validated",
   "views": {
     "rgb": "rgb/000000.jpg",
     "thermal": "thermal/000000.jpg"
   },
+  "attrs": { "status": "validated" },
   "entities": [
     {
-      "category": "person",
-      "annotations": {
-        "thermal": { "bbox": [0.12, 0.25, 0.15, 0.30] }
-      }
+      "attrs": { "category": "person" },
+      "annotations": [
+        { "kind": "bbox", "view": "thermal", "coords": [0.12, 0.25, 0.15, 0.30], "format": "xywh", "is_normalized": true }
+      ]
     }
   ]
 }
 ```
 
-The dataset info for image mode (`examples/flir/info.py:dataset_info`):
+With more than one view declared, **every annotation names its view** — here the bounding box was detected in the `thermal` view.
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import BBox, Entity, Image, Record
+The schema for image mode lives in `pixano.yaml` at the source root:
 
-
-class FLIREntity(Entity):
-    category: str = ""
-
-
-dataset_info = DatasetInfo(
-    name="FLIR Static Sample",
-    description="Sample import for FLIR static image pairs.",
-    workspace=WorkspaceType.IMAGE,
-    record=Record,
-    entity=FLIREntity,
-    bbox=BBox,
-    views={"rgb": Image, "thermal": Image},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: flir_static_sample
+  workspace: image
+schema:
+  views:
+    rgb: { kind: image }
+    thermal: { kind: image }
+  entity:
+    attrs:
+      category: str
+  annotations: [bbox]
 ```
 
-Note `views` has two entries: `"rgb"` and `"thermal"`, both of type `Image`. This tells Pixano to display them side by side.
+Note `views` has two entries: `"rgb"` and `"thermal"`, both images. This tells Pixano to display them side by side. See [Importing Data](/getting_started/importing_data/) for the full reference.
 
 Import:
 
 ```bash
-pixano data import ./my_data ./flir_sample \
-    --info examples/flir/info.py:dataset_info
+pixano data import ./my_data ./flir_sample
 ```
 
 ### Video mode — synchronized sequences
@@ -146,54 +142,39 @@ Each metadata entry uses glob patterns for frame sequences and per-frame annotat
 
 ```json
 {
-  "status": "validated",
+  "attrs": { "status": "validated" },
   "views": {
-    "rgb": { "path": "rgb/video_000/*.jpg", "fps": 30 },
-    "thermal": { "path": "thermal/video_000/*.jpg", "fps": 30 }
+    "rgb": { "frame_pattern": "rgb/video_000/*.jpg", "fps": 30 },
+    "thermal": { "frame_pattern": "thermal/video_000/*.jpg", "fps": 30 }
   },
-  "annotation_files": {
-    "bbox": "bboxes/video_000/*.json"
-  }
+  "annotation_files": [
+    { "kind": "bbox", "view": "rgb", "pattern": "bboxes/video_000/*.json", "encoding": "track_json" }
+  ]
 }
 ```
 
-The dataset info for video mode (`examples/flir/info.py:video_dataset_info`):
+Frames matching each `frame_pattern` are imported in lexicographic order at the declared `fps`; the per-frame `track_json` files are stem-matched to their frames. The video-mode schema:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import (
-    BBox, Entity, EntityDynamicState,
-    Record, SequenceFrame, Tracklet,
-)
-
-
-class FLIREntity(Entity):
-    category: str = ""
-
-
-class FLIREntityDynamicState(EntityDynamicState):
-    pass
-
-
-video_dataset_info = DatasetInfo(
-    name="FLIR Dynamic Sample",
-    description="Sample import for FLIR dynamic synchronized frame sequences.",
-    workspace=WorkspaceType.VIDEO,
-    record=Record,
-    entity=FLIREntity,
-    entity_dynamic_state=FLIREntityDynamicState,
-    tracklet=Tracklet,
-    bbox=BBox,
-    views={"rgb": SequenceFrame, "thermal": SequenceFrame},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: flir_dynamic_sample
+  workspace: video
+schema:
+  views:
+    rgb: { kind: sequence_frames }
+    thermal: { kind: sequence_frames }
+  entity:
+    attrs:
+      category: str
+  annotations: [bbox, tracklet]
 ```
 
 Import:
 
 ```bash
-pixano data import ./my_data ./flir_video_sample \
-    --info examples/flir/info.py:video_dataset_info
+pixano data import ./my_data ./flir_video_sample
 ```
 
 ### Launch the server

--- a/docs-astro/src/pages/cookbook/object_detection.mdx
+++ b/docs-astro/src/pages/cookbook/object_detection.mdx
@@ -53,43 +53,33 @@ This separation is intentional. By keeping records, views, entities, and annotat
 
 ## Dataset schema
 
-Here is the `DatasetInfo` used to import a VOC dataset into Pixano:
+The schema lives in a `pixano.yaml` file at the root of the source folder — no Python required:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import BBox, CompressedRLE, Entity, Image, Record
-
-
-class VOCEntity(Entity):
-    """An object detected in a VOC image."""
-    category: str = ""
-    is_difficult: bool = False
-
-
-dataset_info = DatasetInfo(
-    name="VOC 2007 Sample",
-    description="Pascal VOC 2007 object detection dataset.",
-    workspace=WorkspaceType.IMAGE,
-    record=Record,
-    entity=VOCEntity,
-    bbox=BBox,
-    mask=CompressedRLE,
-    views={"image": Image},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: voc_2007
+  workspace: image
+schema:
+  entity:
+    attrs:
+      category: str
+      is_difficult: { type: bool, default: false }
+  annotations: [bbox, keypoint, mask]
 ```
 
 Let's look at each piece:
 
-- **`VOCEntity`** — A custom subclass of `Entity` with two domain-specific fields. `category` stores the object class (e.g. `"car"`, `"person"`). `is_difficult` mirrors VOC's flag for objects that are hard to recognize.
+- **`entity.attrs`** — Two domain-specific fields on entities. `category` stores the object class (e.g. `"car"`, `"person"`). `is_difficult` mirrors VOC's flag for objects that are hard to recognize.
 
-- **`bbox=BBox`** — Creates a bounding box table. This is where the rectangular coordinates for each entity will be stored. VOC annotations use normalized coordinates in `[x, y, w, h]` format, which Pixano handles natively.
+- **`annotations: [bbox, …]`** — Creates a bounding box table. This is where the rectangular coordinates for each entity will be stored. VOC annotations use normalized coordinates in `[x, y, w, h]` format, which Pixano handles natively.
 
-- **`mask=CompressedRLE`** — Creates a segmentation mask table using compressed run-length encoding. The original VOC dataset only has bounding boxes — we add masks here to show that **Pixano supports multiple annotation types per entity**. This also enables AI-assisted segmentation tools like SAM in the annotation workspace.
+- **`… mask]`** — Creates a segmentation mask table using compressed run-length encoding. The original VOC dataset only has bounding boxes — we add masks here to show that **Pixano supports multiple annotation types per entity**. This also enables AI-assisted segmentation tools like SAM in the annotation workspace.
 
-- **`views={"image": Image}`** — Each record has one view named `"image"`.
+- **`workspace: image`** — Provides the single-image view named `"image"` and tells the UI to use the single-image viewer with annotation tools.
 
-- **`workspace=WorkspaceType.IMAGE`** — Tells the UI to use the single-image viewer with annotation tools.
+See [Importing Data](/getting_started/importing_data/) for the full `pixano.yaml` and JSONL reference.
 
 ## Import the dataset
 
@@ -126,17 +116,14 @@ Each line in `metadata.jsonl` describes one image and its annotations:
 
 ```json
 {
-  "status": "validated",
   "views": { "image": "000032.jpg" },
+  "attrs": { "status": "validated" },
   "entities": [
     {
-      "category": "aeroplane",
-      "is_difficult": false,
-      "annotations": {
-        "image": {
-          "bbox": [0.078, 0.09, 0.756, 0.792]
-        }
-      }
+      "attrs": { "category": "aeroplane", "is_difficult": false },
+      "annotations": [
+        { "kind": "bbox", "coords": [0.078, 0.09, 0.756, 0.792], "format": "xywh", "is_normalized": true }
+      ]
     }
   ]
 }
@@ -144,19 +131,20 @@ Each line in `metadata.jsonl` describes one image and its annotations:
 
 Notice the structure:
 - `"views"` maps view names to filenames — Pixano uses this to find the image
-- `"entities"` is a list of objects, each with the custom fields from `VOCEntity`
-- `"annotations"` is nested per view — the `"image"` key matches the view name defined in `DatasetInfo`, and `"bbox"` matches the annotation slot. Coordinates are normalized `[x, y, w, h]` values in `[0, 1]`.
+- `"entities"` is a list of objects, each carrying the custom `attrs` declared in `pixano.yaml`
+- `"annotations"` is a flat list discriminated by `"kind"` — `{"kind": "bbox"}` maps to the `BBox` table. Coordinates are explicit: `"format"` and `"is_normalized"` are required (or declared once as file-scoped defaults in a header line) — Pixano never guesses them from value ranges.
 
 ### Run the import
 
 ```bash
 pixano init ./my_library
-pixano data import ./my_library ./voc_sample \
-    --info data_importation/voc/info.py:dataset_info
+pixano data import ./my_library ./voc_sample
 ```
 
+Pixano validates every line first and prints a plan (record counts per split, findings with `file:line` locations). Only a clean, confirmed plan is imported.
+
 <Callout type="tip" title="Import options">
-Use `--dry-run` to validate your metadata without creating the dataset. Use `--mode overwrite` to re-import over an existing dataset.
+Use `--dry-run` to validate your metadata without creating the dataset. Use `--mode overwrite` to re-import over an existing dataset — re-imports are idempotent thanks to deterministic ids.
 </Callout>
 
 ## Launch and explore
@@ -199,7 +187,7 @@ Let's connect the dots:
 
 - **Pascal VOC** is an object detection benchmark where each image contains objects localized with bounding boxes and classified into 20 categories.
 - In Pixano, this maps to **records** (images), **entities** (objects with `category` and `is_difficult`), and **annotations** (bounding boxes and optionally masks).
-- The `DatasetInfo` schema defines which tables Pixano creates — adding `CompressedRLE` alongside `BBox` enables multi-type annotation and AI segmentation tools.
+- The `pixano.yaml` schema defines which tables Pixano creates — adding `mask` alongside `bbox` enables multi-type annotation and AI segmentation tools.
 - **Provenance fields** on annotations let you combine human labels, model predictions, and AI-assisted masks in a single dataset.
 
 ## Next steps

--- a/docs-astro/src/pages/cookbook/video_tracking.mdx
+++ b/docs-astro/src/pages/cookbook/video_tracking.mdx
@@ -72,51 +72,34 @@ The key insight: in image datasets, an entity has annotations directly. In video
 
 ## Dataset schema
 
-Here is the `DatasetInfo` used to import a DAVIS dataset:
+The schema lives in a `pixano.yaml` file at the root of the source folder:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import (
-    CompressedRLE, Entity, EntityDynamicState,
-    Record, SequenceFrame, Tracklet,
-)
-
-
-class DAVISEntity(Entity):
-    """A segmented object in a DAVIS video."""
-    category: str = "object"
-
-
-class DAVISEntityDynamicState(EntityDynamicState):
-    """Per-frame dynamic state for a DAVIS entity."""
-    pass
-
-
-dataset_info = DatasetInfo(
-    name="DAVIS 2017 Sample",
-    description="DAVIS 2017 video object segmentation dataset.",
-    workspace=WorkspaceType.VIDEO,
-    record=Record,
-    entity=DAVISEntity,
-    entity_dynamic_state=DAVISEntityDynamicState,
-    tracklet=Tracklet,
-    mask=CompressedRLE,
-    views={"image": SequenceFrame},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: davis_2017
+  workspace: video
+schema:
+  views:
+    image: { kind: sequence_frames }
+  entity:
+    attrs:
+      category: { type: str, default: object }
+  annotations: [mask, tracklet]
 ```
 
 Compared to the image dataset schema, several things are new:
 
-- **`WorkspaceType.VIDEO`** — Switches the UI to video mode with a timeline, frame navigation, and track inspector.
+- **`workspace: video`** — Switches the UI to video mode with a timeline, frame navigation, and track inspector.
 
-- **`SequenceFrame` instead of `Image`** — A `SequenceFrame` extends `Image` with `frame_index` (integer position in the sequence) and `timestamp` (time in seconds). This is how Pixano knows the temporal ordering of frames within a video.
+- **`kind: sequence_frames` instead of `image`** — A sequence-frame view stores one row per frame with `frame_index` (integer position in the sequence) and `timestamp` (time in seconds). This is how Pixano knows the temporal ordering of frames within a video.
 
-- **`tracklet=Tracklet`** — Creates a tracklet table. Each tracklet has `start_timestep`, `end_timestep`, `start_timestamp`, and `end_timestamp` fields that define when the tracked entity is visible. Per-frame masks link back to the tracklet.
+- **`tracklet`** — Creates a tracklet table. Each tracklet has `start_timestep`, `end_timestep`, `start_timestamp`, and `end_timestamp` fields that define when the tracked entity is visible. Per-frame masks link back to the tracklet.
 
-- **`entity_dynamic_state=DAVISEntityDynamicState`** — Creates a table for per-frame entity state. Here we use an empty subclass (DAVIS doesn't have per-frame attributes beyond the mask), but you could add fields like `is_occluded: bool = False` or `visibility: float = 1.0`.
+- **`mask`** — Segmentation masks in compressed run-length encoding. Each mask is a per-frame annotation linked to a tracklet and entity.
 
-- **`mask=CompressedRLE`** — Segmentation masks in compressed run-length encoding. Each mask is a per-frame annotation linked to a tracklet and entity.
+You could also add per-frame entity state (e.g. `entity_dynamic_state: { attrs: { occluded: { type: bool, default: false } } }`) — DAVIS doesn't need it beyond the mask itself. See [Importing Data](/getting_started/importing_data/) for the full reference.
 
 ## Import the dataset
 
@@ -166,27 +149,29 @@ Each line describes one video using **glob patterns** for frames and masks:
 
 ```json
 {
-  "status": "validated",
+  "attrs": { "status": "validated" },
   "views": {
-    "image": { "path": "frames/bear/*.jpg", "fps": 24 }
+    "image": { "frame_pattern": "frames/bear/*.jpg", "fps": 24 }
   },
-  "annotation_files": {
-    "mask": "masks/bear/*.png"
-  }
+  "annotation_files": [
+    { "kind": "mask", "view": "image", "pattern": "masks/bear/*.png", "encoding": "index_png", "entity_map": "auto" }
+  ]
 }
 ```
 
 Notice the differences from image datasets:
-- `"views"` uses an object with `"path"` (a glob pattern) and `"fps"` (frame rate) instead of a simple filename. Pixano expands the glob to discover all frames and creates one `SequenceFrame` per file, ordered alphabetically.
-- `"annotation_files"` is a separate key (not inside `"entities"`) that maps annotation types to glob patterns for mask files. Pixano matches masks to frames by filename (e.g. `00000.png` matches `00000.jpg`).
+- `"views"` uses an object with `"frame_pattern"` (a glob) and `"fps"` (frame rate, required — nothing is inferred) instead of a simple filename. Pixano expands the glob to discover all frames, ordered alphabetically, one sequence frame per file.
+- `"annotation_files"` is a list of typed sidecars. `"encoding": "index_png"` means indexed PNGs where each pixel value is one object (0 = background); Pixano matches masks to frames by filename stem (e.g. `00000.png` matches `00000.jpg`). `"entity_map": "auto"` names the objects `object_1`, `object_2`, … — or map pixel values to names explicitly: `{"1": "bear"}`.
+- Tracklets are derived automatically from the frames each object appears in — no manual bookkeeping.
 
 ### Run the import
 
 ```bash
 pixano init ./my_library
-pixano data import ./my_library ./davis_sample \
-    --info data_importation/davis/info.py:dataset_info
+pixano data import ./my_library ./davis_sample
 ```
+
+Pixano validates every line first and prints a plan; use `--dry-run` to only validate.
 
 ## Launch and explore
 
@@ -238,7 +223,7 @@ Let's connect the dots:
 - **DAVIS** is a video object segmentation benchmark where objects are tracked and segmented with pixel-accurate masks across every frame.
 - Moving from images to video introduces temporal challenges: identity persistence, occlusion handling, and per-frame variation.
 - Pixano handles this with **SequenceFrame** views (ordered frames with timestamps), **Tracklets** (temporal segments linking per-frame annotations to entities), and **EntityDynamicState** (per-frame attributes separate from geometry).
-- The `DatasetInfo` schema for video includes `WorkspaceType.VIDEO`, `SequenceFrame`, `Tracklet`, and optionally `EntityDynamicState` — which together unlock the timeline UI, track management, and temporal annotation tools.
+- The video schema combines `workspace: video`, `sequence_frames` views, and `tracklet` annotations (optionally per-frame `entity_dynamic_state` attrs) — which together unlock the timeline UI, track management, and temporal annotation tools.
 - **SAM in video** combines tracklets for temporal identity with per-frame segmentation, enabling efficient annotation workflows that mirror the DAVIS semi-supervised task.
 
 ## Next steps

--- a/docs-astro/src/pages/cookbook/vqa.mdx
+++ b/docs-astro/src/pages/cookbook/vqa.mdx
@@ -55,38 +55,27 @@ This combination of **language annotation** (Q&A messages) and **spatial annotat
 
 ## Dataset schema
 
-Here is the `DatasetInfo` used to import a VQAv2 dataset:
+The schema lives in a `pixano.yaml` file at the root of the source folder — no Python required:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import BBox, CompressedRLE, Entity, Image, Message, Record
-
-
-class VQAv2Entity(Entity):
-    """An entity referenced by VQA questions."""
-    category: str = ""
-    subcategory: str = ""
-
-
-dataset_info = DatasetInfo(
-    name="VQAv2 Sample",
-    description="VQAv2 visual question answering dataset.",
-    workspace=WorkspaceType.IMAGE_VQA,
-    record=Record,
-    entity=VQAv2Entity,
-    message=Message,
-    bbox=BBox,
-    mask=CompressedRLE,
-    views={"image": Image},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: vqav2_sample
+  workspace: image_vqa
+schema:
+  entity:
+    attrs:
+      category: str
+      subcategory: str
+  annotations: [message, bbox, mask]
 ```
 
 Let's break this down:
 
-- **`VQAv2Entity`** — A custom entity with `category` (e.g. `"animal"`, `"furniture"`) and `subcategory` (e.g. `"cat"`, `"couch"`). These entities represent the objects that questions refer to.
+- **`entity.attrs`** — Custom entity fields: `category` (e.g. `"animal"`, `"furniture"`) and `subcategory` (e.g. `"cat"`, `"couch"`). These entities represent the objects that questions refer to.
 
-- **`message=Message`** — Creates a message table for Q&A pairs. Each `Message` has:
+- **`message`** — Creates a message table for Q&A pairs. Each message has:
   - `type` — `"QUESTION"` or `"ANSWER"` (or `"SYSTEM"` for instructions)
   - `content` — the text of the question or answer
   - `question_type` — `"OPEN"` for free-form, `"SINGLE_CHOICE"` or `"MULTI_CHOICE"` for multiple-choice
@@ -95,9 +84,11 @@ Let's break this down:
   - `number` — the message's position within the conversation
   - `entity_ids` — links the message to specific entities in the image
 
-- **`bbox=BBox` and `mask=CompressedRLE`** — The original VQAv2 dataset contains only questions and answers. We include bounding boxes and masks because **Pixano lets you enrich a VQA dataset with entity annotations**. You can draw boxes and masks on the objects that questions refer to, creating a bridge between language understanding and spatial grounding.
+- **`bbox` and `mask`** — The original VQAv2 dataset contains only questions and answers. We include bounding boxes and masks because **Pixano lets you enrich a VQA dataset with entity annotations**. You can draw boxes and masks on the objects that questions refer to, creating a bridge between language understanding and spatial grounding.
 
-- **`workspace=WorkspaceType.IMAGE_VQA`** — Switches the UI to VQA mode: the image is displayed alongside a conversation panel for managing questions and answers.
+- **`workspace: image_vqa`** — Provides the single-image view and switches the UI to VQA mode: the image is displayed alongside a conversation panel for managing questions and answers.
+
+See [Importing Data](/getting_started/importing_data/) for the full `pixano.yaml` and JSONL reference.
 
 ## Import the dataset
 
@@ -130,16 +121,13 @@ Each line describes one image with its questions and answers:
 
 ```json
 {
-  "status": "validated",
   "views": { "image": "000000.jpg" },
-  "messages": [
+  "attrs": { "status": "validated" },
+  "conversations": [
     {
-      "question": {
-        "content": "Where are the kids riding?",
-        "question_type": "OPEN"
-      },
-      "responses": [
-        { "content": "carnival ride" }
+      "messages": [
+        { "type": "QUESTION", "question_type": "OPEN", "content": "Where are the kids riding?" },
+        { "type": "ANSWER", "content": "carnival ride" }
       ]
     }
   ]
@@ -147,9 +135,10 @@ Each line describes one image with its questions and answers:
 ```
 
 Notice the structure:
-- `"messages"` is a list of Q&A exchanges for this image
-- Each exchange has a `"question"` object with `"content"` and `"question_type"`
-- `"responses"` is a list of answers — VQAv2 supports multiple answers per question from different annotators
+- `"conversations"` is a list of exchanges for this image; each holds an ordered `"messages"` list
+- Every message declares its `"type"` — `QUESTION`, `ANSWER`, or `SYSTEM`
+- `"question_type"` is **required** on questions: `OPEN` for free-form, `SINGLE_CHOICE`/`MULTI_CHOICE` for multiple-choice, `YES_NO` for boolean — Pixano never infers it
+- Multiple answers per question (as in VQAv2) are simply consecutive `ANSWER` messages
 
 <Callout type="note" title="Multiple-choice questions" collapsible>
 
@@ -157,12 +146,15 @@ For multiple-choice questions, set `question_type` to `"SINGLE_CHOICE"` or `"MUL
 
 ```json
 {
-  "question": {
-    "content": "What is in the image?",
-    "question_type": "SINGLE_CHOICE",
-    "choices": ["a cat", "a dog", "a bird", "a fish"]
-  },
-  "responses": [{ "content": "a cat" }]
+  "messages": [
+    {
+      "type": "QUESTION",
+      "question_type": "SINGLE_CHOICE",
+      "content": "What is in the image?",
+      "choices": ["a cat", "a dog", "a bird", "a fish"]
+    },
+    { "type": "ANSWER", "content": "a cat" }
+  ]
 }
 ```
 
@@ -172,9 +164,10 @@ For multiple-choice questions, set `question_type` to `"SINGLE_CHOICE"` or `"MUL
 
 ```bash
 pixano init ./my_library
-pixano data import ./my_library ./vqav2_sample \
-    --info data_importation/vqav2/info.py:dataset_info
+pixano data import ./my_library ./vqav2_sample
 ```
+
+Pixano validates every line first and prints a plan; use `--dry-run` to only validate.
 
 ## Launch and explore
 

--- a/docs-astro/src/pages/getting_started/importing_data.mdx
+++ b/docs-astro/src/pages/getting_started/importing_data.mdx
@@ -1,0 +1,221 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: "Importing Data"
+section: getting_started
+---
+import Callout from '../../components/Callout.astro'
+import PrevNext from '../../components/PrevNext.astro'
+
+# Importing Data
+
+Pixano 0.8 imports datasets from plain files — no Python required. You describe your data in a JSONL file, describe your schema in a YAML file, and run one command. This page is the reference for that format.
+
+<Callout type="info" title="What you'll learn">
+
+- The folder layout Pixano imports from
+- The `metadata.jsonl` line format (JSONL v2): views, entities, annotations, conversations
+- The `pixano.yaml` schema spec
+- How media storage works: embedded by default, URIs for datalake data
+- The CLI: `import`, `export`, `formats`, and `migrate-jsonl`
+
+</Callout>
+
+## The folder layout
+
+A Pixano source is a folder with one subfolder per split. Each split holds a `metadata.jsonl` file (one JSON object per line, one line per sample) and the media it references:
+
+```
+my_dataset/
+├── pixano.yaml            # the dataset + schema spec
+├── train/
+│   ├── metadata.jsonl
+│   └── images/…
+└── val/
+    ├── metadata.jsonl
+    └── images/…
+```
+
+Import it with:
+
+```sh
+pixano data import /path/to/data_dir ./my_dataset
+```
+
+The command **analyzes first**: it validates every line, counts records, checks that media files exist, and prints a plan with precise error locations (`file:line`). Nothing is written until the plan is clean and confirmed. Use `--dry-run` to only validate, `--yes` to skip the confirmation.
+
+<Callout type="note" title="No metadata at all?">
+
+A split folder containing only images (no `metadata.jsonl`) imports as an unlabeled image dataset — one record per file. This is what the app's **Import** dialog uses.
+
+</Callout>
+
+## The line format (JSONL v2)
+
+Every line is one sample: its views (media), its entities (annotated objects), and optionally conversations (VQA). The format is **strict**: unknown keys are errors with did-you-mean suggestions, and nothing is guessed from value shapes. What you write is what you get.
+
+A minimal detection sample:
+
+```json
+{"views": {"image": "images/000042.jpg"},
+ "entities": [
+   {"attrs": {"category": "dog"},
+    "annotations": [
+      {"kind": "bbox", "coords": [0.132, 0.28, 0.41, 0.55], "format": "xywh", "is_normalized": true}
+    ]}
+ ]}
+```
+
+### The header line (optional)
+
+The first line may declare the format version and file-scoped defaults, so per-annotation boilerplate disappears:
+
+```json
+{"$pixano": "jsonl/2", "defaults": {"bbox": {"format": "xywh", "is_normalized": true}, "source": {"type": "model", "name": "yolo-x"}}}
+```
+
+With bbox defaults declared, annotations can omit `format`/`is_normalized`. Without them, both are **required** on every bbox — Pixano never infers normalization from value ranges.
+
+### Views
+
+Views are declared in `pixano.yaml` (name + kind) and referenced by name on each line. The payload shape depends on the declared kind:
+
+| Kind | Payload |
+|------|---------|
+| `image` | `"path.jpg"` shorthand, or `{"uri": …, "width": …, "height": …}` |
+| `video` | `{"uri": …, "fps": …, "from_timestamp": …, "to_timestamp": …}` — a **time window** into a media file |
+| `sequence_frames` | `{"frames": [{"uri": …, "frame_index": …}, …]}` or `{"frame_pattern": "frames/x/*.jpg", "fps": 24}` |
+| `text` | `{"content": "inline text"}` or `{"uri": "doc.txt"}` — exactly one |
+| `point_cloud` | `{"uri": "scan.ply"}` |
+
+### Annotation kinds
+
+Annotations live in a flat list under each entity, discriminated by `"kind"`. Payload keys are exactly the Pixano schema field names, so the format is self-documenting:
+
+| Kind | Payload keys |
+|------|--------------|
+| `bbox` | `coords` (4), `format` (`xywh`/`xyxy`), `is_normalized`, `confidence` |
+| `mask` | `rle: {size, counts}` **or** `polygons` (hand-authorable; converted at import) |
+| `keypoints` | `template_id`, `coords` (2 per point), `states` |
+| `multi_path` | `coords`, `num_points`, `is_closed` |
+| `text_span` | `mention`, `spans_start`, `spans_end` |
+| `classification` | `labels`, `confidences` |
+
+On multi-view datasets every annotation carries `"view": "<name>"`; single-view datasets can omit it. Per-frame annotations on video/sequence views add `"frame_index"`. The kinds `bbox3d`, `keypoints3d`, and `relation` are reserved for a future release — using them today produces a clear "reserved kind" error, not a typo message.
+
+### Tracking: tracklets and per-frame state
+
+For video, entities can carry explicit tracklets and per-frame states:
+
+```json
+{"views": {"camera": {"uri": "videos/bear.mp4", "fps": 30}},
+ "entities": [
+   {"attrs": {"category": "bear"},
+    "tracklets": [{"view": "camera", "start_timestep": 0, "end_timestep": 120}],
+    "states": [{"frame_index": 12, "attrs": {"occluded": true}}],
+    "annotations": [
+      {"kind": "bbox", "frame_index": 12, "coords": [0.1, 0.1, 0.2, 0.3]}
+    ]}
+ ]}
+```
+
+If you omit `tracklets` but provide per-frame annotations, Pixano derives one tracklet per view from the min/max `frame_index` — the only derivation in the format, and it is deterministic.
+
+### Conversations (VQA)
+
+```json
+{"views": {"image": "000001.jpg"},
+ "conversations": [
+   {"messages": [
+     {"type": "QUESTION", "question_type": "SINGLE_CHOICE", "content": "Where are the kids riding?", "choices": ["carnival ride", "bus"]},
+     {"type": "ANSWER", "content": "carnival ride"}
+   ]}
+ ]}
+```
+
+`question_type` is required on questions — `OPEN`, `SINGLE_CHOICE`, `MULTI_CHOICE`, or `YES_NO`.
+
+### Sidecar annotation files
+
+Dense per-frame annotations can live in separate files, stem-matched to frames:
+
+```json
+{"views": {"camera": {"frame_pattern": "frames/bear/*.jpg", "fps": 24}},
+ "annotation_files": [
+   {"kind": "mask", "view": "camera", "pattern": "masks/bear/*.png", "encoding": "index_png", "entity_map": {"1": "bear", "2": "cub"}}
+ ]}
+```
+
+`index_png` files are indexed PNGs where each pixel value is one object (0 = background). `entity_map` names them; `"auto"` derives `object_1`, `object_2`, …
+
+## The schema spec: pixano.yaml
+
+The YAML file names the dataset, picks a workspace, and declares views and custom attributes:
+
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: voc_2007
+  workspace: image
+schema:
+  record:
+    attrs:
+      license: str
+  entity:
+    attrs:
+      category: str
+      is_difficult: { type: bool, default: false }
+  annotations: [bbox, mask, keypoint]
+```
+
+Workspaces (`image`, `video`, `image_vqa`, `image_text_entity_linking`) provide sensible defaults; `views:` overrides them for multi-view or custom setups:
+
+```yaml
+schema:
+  views:
+    rgb: { kind: image }
+    thermal: { kind: image }
+```
+
+Everything in the yaml can also be given as CLI flags (`--name`, `--workspace`, `--media`, …) — flags win over the file.
+
+## Media storage: embed or URI
+
+Pixano stores media one of two ways (spec §6):
+
+- **Embed (default)** — media bytes are stored inside the dataset's LanceDB tables, which are built for exactly this. The dataset folder is fully self-contained: copy it, move it, serve it — no dangling paths, no media server to configure.
+- **URI (`media: {mode: uri}`)** — for data that already lives in a datalake (S3, HTTP), Pixano stores your URIs verbatim and your infrastructure serves them. Bare local paths are an **error** in this mode: a browser cannot fetch a server-side path, so the analyze step tells you to embed instead.
+
+Mixed datasets are legal: local images embed while, say, LeRobot episode videos stay as `https://` URIs. The dataset records itself as `mixed`.
+
+## Deterministic ids and round-trips
+
+You may provide explicit `id`s on any object; everything else gets a **deterministic** id derived from the source (namespace, split, file, line). Re-importing the same source produces the same ids — which makes `--mode add` re-runs idempotent, and makes export/import a true round-trip:
+
+```sh
+pixano data export /path/to/data_dir voc_2007 ./exported
+pixano data import /path/to/data_dir ./exported   # id-identical dataset
+```
+
+The export emits exactly this format, with explicit ids and its own `pixano.yaml`. Export output *is* import input.
+
+## Migrating from Pixano 0.7
+
+The 0.7 `metadata.jsonl` dialect (bare `image:` keys, `objects` lists, `{path, fps}` globs, nested VQA messages) is converted by:
+
+```sh
+pixano data migrate-jsonl ./old_dataset ./migrated_dataset
+```
+
+Everything 0.7 silently guessed — bbox normalization from value ranges, mention-less text spans — is converted with an explicit **needs attention** note so you can verify it. Media files are not copied; point the import at the original media or copy them over.
+
+<Callout type="warning" title="Custom Python builders">
+
+`DatasetBuilder` subclasses are deprecated and will be removed in 0.9. The replacement is the `DatasetImporter` contract in `pixano.datasets.io` — the same interface Pixano's own formats use, with a ready-made test harness in `pixano.datasets.io.testing`.
+
+</Callout>
+
+<PrevNext
+  prev={{ href: "/getting_started/key_concepts/", label: "Key Concepts" }}
+  next={{ href: "/cookbook/", label: "Cookbook" }}
+/>

--- a/docs-astro/src/pages/getting_started/key_concepts.mdx
+++ b/docs-astro/src/pages/getting_started/key_concepts.mdx
@@ -46,46 +46,39 @@ Consider an image dataset for detecting vehicles:
 5. You can later add model predictions (YOLO, GroundingDINO, etc.) as additional annotations — provenance fields on the annotation let you distinguish human labels from model outputs.
 6. You compute embeddings (e.g. OpenCLIP) so the dataset becomes searchable — those go in the **embedding** table.
 
-## DatasetInfo
+## The dataset schema
 
-Every dataset is defined by a `DatasetInfo` that declares its name, workspace type, and schema:
+Every dataset is defined by a schema that declares its name, workspace type, views, and custom attributes. When importing, it lives in a `pixano.yaml` file:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import BBox, Entity, Image, Record
-
-
-class Vehicle(Entity):
-    category: str = ""
-
-
-dataset_info = DatasetInfo(
-    name="Vehicle Detection",
-    workspace=WorkspaceType.IMAGE,
-    record=Record,
-    entity=Vehicle,
-    bbox=BBox,
-    views={"image": Image},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: vehicle_detection
+  workspace: image
+schema:
+  entity:
+    attrs:
+      category: str
+  annotations: [bbox]
 ```
 
-The `workspace` selects the UI layout. The schema types you pass (`record`, `entity`, `bbox`, `views`, etc.) determine which tables are created in the database.
+The `workspace` selects the UI layout and provides default views. The `annotations` list determines which annotation tables are created in the database. See [Importing Data](/getting_started/importing_data/) for the full reference.
 
 ### Custom fields
 
-Each schema group maps to a base class you can subclass to add domain-specific fields:
+Records, entities, and per-frame states accept domain-specific attributes with a type and an optional default:
 
-```python
-from pixano.schemas import Entity
-
-class DetectedObject(Entity):
-    category: str = ""
-    is_difficult: bool = False
-    confidence: float = 0.0
+```yaml
+schema:
+  entity:
+    attrs:
+      category: str
+      is_difficult: { type: bool, default: false }
+      confidence: { type: float, default: 0.0 }
 ```
 
-Fields must have default values (Pixano uses Pydantic under the hood).
+(Programmatic users can build the same schema in Python via `DatasetInfo` and Pydantic subclasses — the yaml compiles to exactly that.)
 
 ## Record fields
 

--- a/docs-astro/src/pages/getting_started/quickstart.mdx
+++ b/docs-astro/src/pages/getting_started/quickstart.mdx
@@ -12,7 +12,7 @@ By the end of this page, you will have imported your own images into Pixano and 
 
 <Callout type="info" title="What you'll learn">
 
-- What a **DatasetInfo** is and why you need one
+- How a **pixano.yaml** schema defines your dataset
 - The role of **records**, **views**, **entities**, and **annotations** in a dataset
 - How to **import** images and **launch** the Pixano app
 
@@ -35,45 +35,34 @@ This sets up your dataset library and runs all internal setup. From now on, `./m
 
 ## Step 2 — Define your dataset schema
 
-Before importing anything, you need to tell Pixano **what your dataset looks like**. You do this by creating a `DatasetInfo` — a Python object that declares which tables Pixano should create in the database.
+Before importing anything, you need to tell Pixano **what your dataset looks like**. You do this in a small YAML file — no Python required.
 
-Create a file called `my_info.py` anywhere on your machine (e.g. in your current working directory):
+Create a folder for your source data with a `pixano.yaml` at its root:
 
-```python
-from pixano.datasets import DatasetInfo
-from pixano.datasets.workspaces import WorkspaceType
-from pixano.schemas import BBox, CompressedRLE, Entity, Image, Record
-
-
-class MyObject(Entity):
-    """A custom entity for the objects we want to annotate."""
-    category: str = ""
-
-
-dataset_info = DatasetInfo(
-    name="My First Dataset",
-    workspace=WorkspaceType.IMAGE,
-    record=Record,
-    entity=MyObject,
-    bbox=BBox,
-    mask=CompressedRLE,
-    views={"image": Image},
-)
+```yaml
+pixano: 2
+format: pixano_jsonl
+dataset:
+  name: my_first_dataset
+  workspace: image
+schema:
+  entity:
+    attrs:
+      category: str
+  annotations: [bbox, mask]
 ```
 
 Let's break this down — each piece maps to a concept in Pixano's data model:
 
-- **`Record`** — Represents one sample in your dataset. Each image you import becomes one record. Records carry metadata like which split they belong to (`train`, `val`) and their annotation status (`new`, `inProgress`, `validated`).
+- **Records** — Represent one sample each. Every image you import becomes one record. Records carry metadata like which split they belong to (`train`, `val`) and their annotation status (`new`, `inProgress`, `validated`).
 
-- **`views={"image": Image}`** — Defines the media attached to each record. Here, each record has a single view named `"image"`. For multi-view setups (e.g. stereo cameras), you would add more entries to this dictionary.
+- **`workspace: image`** — Provides a single view named `"image"` per record and selects the UI layout: a single-image viewer with annotation tools. Other options include `video`, `image_vqa`, and `image_text_entity_linking`. Multi-view setups (e.g. stereo cameras) declare their own `views:` block instead.
 
-- **`entity=MyObject`** — Entities are the **objects you want to label** in your images — a car, a person, a tree. We subclass `Entity` to add a `category` field so we can tag what kind of object each one is. You can add any fields you need (e.g. `is_occluded: bool = False`).
+- **`entity.attrs`** — Entities are the **objects you want to label** in your images — a car, a person, a tree. We add a `category` field so we can tag what kind of object each one is. You can add any fields you need (e.g. `is_occluded: { type: bool, default: false }`).
 
-- **`bbox=BBox`** — Tells Pixano to create a bounding box annotation table. This is where the rectangular coordinates for each labeled object will be stored.
+- **`annotations: [bbox, …]`** — Tells Pixano to create a bounding box annotation table. This is where the rectangular coordinates for each labeled object will be stored.
 
-- **`mask=CompressedRLE`** — Tells Pixano to also create a mask annotation table, using compressed run-length encoding. This enables pixel-level segmentation annotations alongside bounding boxes.
-
-- **`workspace=WorkspaceType.IMAGE`** — Selects the UI layout. `IMAGE` gives you a single-image viewer with annotation tools. Other options include `VIDEO`, `IMAGE_VQA`, and `IMAGE_TEXT_ENTITY_LINKING`.
+- **`… mask]`** — Tells Pixano to also create a mask annotation table, using compressed run-length encoding. This enables pixel-level segmentation annotations alongside bounding boxes.
 
 <Callout type="tip" title="Why define the schema upfront?">
 Pixano uses your schema to create the right database tables before any data is imported. This means annotations are structured and queryable from day one — not just flat files. It also means Pixano knows which annotation tools to show you in the UI.
@@ -83,17 +72,19 @@ Pixano uses your schema to create the right database tables before any data is i
 
 Pixano imports data from a **source folder** organized by **splits**. Each split is a subfolder containing your images.
 
-Create a folder and put a few images in it:
+Create a split folder next to your `pixano.yaml` and put a few images in it:
 
 ```bash
 mkdir -p my_images/train
 # Copy 3-5 JPEG or PNG images into my_images/train/
+# Move pixano.yaml into my_images/
 ```
 
 Your folder should look like this:
 
 ```
 my_images/
+  pixano.yaml
   train/
     photo1.jpg
     photo2.jpg
@@ -109,25 +100,26 @@ Without a `metadata.jsonl` file, Pixano auto-discovers all supported images in e
 Now bring everything together:
 
 ```bash
-pixano data import ./my_library ./my_images --info my_info.py:dataset_info
+pixano data import ./my_library ./my_images
 ```
 
 Here is what this command does:
 
-1. Reads your `DatasetInfo` from `my_info.py`
-2. Scans `my_images/` for split folders and images
-3. Creates a new dataset in `./my_library` with the tables you defined
-4. Stores each image as a record with its associated view
-
-The `--info` flag uses the format `path/to/file.py:attribute_name` to locate your `DatasetInfo` object. The path can be absolute or relative to your current working directory — it doesn't need to be inside the library or the source folder.
+1. Reads your schema from `my_images/pixano.yaml`
+2. Scans `my_images/` for split folders and images, validates everything, and prints a plan
+3. After you confirm, creates a new dataset in `./my_library` with the tables you defined
+4. Stores each image as a record with its associated view — media bytes embedded, fully self-contained
 
 Common import options:
 
 | Option | Description |
 |--------|-------------|
-| `--info` | Dataset info as `path/to/file.py:attribute`. Required. |
+| `--spec` | Path to a `pixano.yaml` outside the source folder. |
+| `--name`, `--workspace` | Override the yaml (or replace it entirely for simple datasets). |
 | `--mode` | `create` (default), `overwrite`, or `add`. |
-| `--dry-run` | Validate without creating the dataset. |
+| `--dry-run` | Validate and print the plan without creating the dataset. |
+
+To attach annotations at import time, add a `metadata.jsonl` per split — see [Importing Data](/getting_started/importing_data/).
 
 ## Step 5 — Launch and explore
 
@@ -152,7 +144,7 @@ Server options:
 
 Let's connect the dots between what you did and how Pixano sees your data:
 
-- The **DatasetInfo** you wrote became a set of **database tables** — one for records, one for image views, one for entities, one for bounding boxes, and one for masks.
+- The **pixano.yaml** you wrote became a set of **database tables** — one for records, one for image views, one for entities, one for bounding boxes, and one for masks.
 - Each image you placed in `my_images/train/` became a **record** in the `train` split, with an associated **image view**.
 - The **entity** and **annotation** tables are empty for now — they will be populated as you (or a model) annotate objects in the UI.
 - Because you declared `BBox` and `CompressedRLE` in your schema, the annotation workspace knows to offer both bounding box and mask tools when you start labeling.


### PR DESCRIPTION
## Issue

Final slice of the P2 lane (spec: `docs/specs/data-import-export.md` §5/§9/§12).

**⚠️ Stacked on #677** — merge order: #675 → #676 → #677 → this.

## Description

- **New [Importing Data] reference page** (`getting_started/importing_data`): the folder layout, the complete JSONL v2 line grammar (views by kind, the six annotation kinds with schema-field payload keys, tracklets/states, conversations, sidecar files), `pixano.yaml`, the media contract (embed by default XOR datalake URIs — with the *why*), deterministic ids + the export/import round-trip, and `migrate-jsonl`.
- **Quickstart + Key Concepts**: the schema is now authored in `pixano.yaml`; the `--info` Python flow is gone. `DatasetInfo` stays mentioned once as the programmatic equivalent the yaml compiles to.
- **All five cookbook recipes** (VOC, DAVIS, FLIR multi-view, VQAv2, MEL): metadata examples rewritten in the v2 grammar — kind-discriminated annotation lists, explicit bbox `format`/`is_normalized`, `conversations` with typed messages, `frame_pattern` + typed `annotation_files` sidecars, text views with explicit `content`/`uri`. Every recipe imports with plain `pixano data import`, no Python. The pedagogy (background sections, concept-mapping tables, annotation-UX guides) is untouched.
- **Navigation**: Importing Data added to Getting Started; nav entries for the deleted builder modules removed.

Verified: `astro build` green — 126 pages, regenerated API index, no stale module pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)