### PR TITLE
fix: stamp image previews at import and expose datalake URLs in view_previews

### DIFF
--- a/src/pixano/api/routers/records.py
+++ b/src/pixano/api/routers/records.py
@@ -66,12 +66,19 @@ def _query_preview_rows(
         raise HTTPException(status_code=500, detail=f"Internal server error. {err}") from err
 
 
+def _preview_url(dataset_id: str, resource: str, row_id: str, uri: object) -> str:
+    """Datalake rows (spec §6 uri mode) are browser-loadable directly; embedded rows go through /preview."""
+    if isinstance(uri, str) and uri.startswith(("http://", "https://")):
+        return uri
+    return f"/datasets/{dataset_id}/{resource}/{row_id}/preview"
+
+
 def _resolve_view_previews(
     dataset_id: str, dataset: Dataset, record_ids: list[str]
 ) -> dict[str, dict[str, PreviewDescriptor]]:
     previews_by_record: dict[str, dict[str, PreviewDescriptor]] = {record_id: {} for record_id in record_ids}
 
-    image_rows = _query_preview_rows(dataset, "images", ["id", "record_id", "logical_name"], record_ids)
+    image_rows = _query_preview_rows(dataset, "images", ["id", "record_id", "logical_name", "uri"], record_ids)
     for row in image_rows:
         record_id = str(row.get("record_id", "") or "")
         logical_name = str(row.get("logical_name", "") or "")
@@ -82,13 +89,13 @@ def _resolve_view_previews(
             resource="images",
             id=row_id,
             kind="image",
-            preview_url=f"/datasets/{dataset_id}/images/{row_id}/preview",
+            preview_url=_preview_url(dataset_id, "images", row_id, row.get("uri")),
         )
 
     sframe_rows = _query_preview_rows(
         dataset,
         "sequence_frames",
-        ["id", "record_id", "logical_name", "frame_index"],
+        ["id", "record_id", "logical_name", "frame_index", "uri"],
         record_ids,
         order_by="frame_index",
     )
@@ -105,7 +112,7 @@ def _resolve_view_previews(
             resource="sframes",
             id=row_id,
             kind="image",
-            preview_url=f"/datasets/{dataset_id}/sframes/{row_id}/preview",
+            preview_url=_preview_url(dataset_id, "sframes", row_id, row.get("uri")),
         )
 
     return previews_by_record

--- a/src/pixano/datasets/io/engine.py
+++ b/src/pixano/datasets/io/engine.py
@@ -25,6 +25,7 @@ Responsibilities the format importers never carry:
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import os
@@ -35,6 +36,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterator, Literal, Sequence
 
+import PIL.Image
 import pyarrow as pa
 import pyarrow.compute as pc
 import shortuuid
@@ -43,7 +45,8 @@ from lancedb.pydantic import LanceModel
 from pixano.datasets.dataset import Dataset
 from pixano.datasets.dataset_info import DatasetInfo
 from pixano.datasets.utils.integrity import validate_batch
-from pixano.schemas import SchemaGroup, is_view, schema_to_group
+from pixano.schemas import SchemaGroup, is_image, is_sequence_frame, is_view, schema_to_group
+from pixano.schemas.views.image import _generate_preview
 from pixano.utils import to_snake_case
 
 from .errors import JobStateError, SpecValidationError, UnsupportedStorageError
@@ -400,6 +403,7 @@ class ImportEngine:
         if not batch:
             return
         for table, rows in batch.items():
+            _stamp_image_previews(dataset, table, rows)
             census.observe_rows(dataset, table, rows)
 
         if add_mode:
@@ -546,6 +550,29 @@ def _approx_row_bytes(row: LanceModel) -> int:
         if isinstance(value, (bytes, str)):
             size += len(value)
     return size
+
+
+def _stamp_image_previews(dataset: Dataset, table_name: str, rows: list[LanceModel]) -> None:
+    """Stamp 64x64 PNG grid thumbnails on embedded image rows (spec finalize step).
+
+    Runs at flush time so every importer inherits it. A corrupt image skips its
+    thumbnail — the grid shows no preview, the import never fails. Video posters
+    are the P3.5 ffmpeg work; the Arrow flush path (first used by LeRobot) is
+    covered there too.
+    """
+    schema = dataset.info.tables.get(table_name)
+    if schema is None or not (is_image(schema) or is_sequence_frame(schema)):
+        return
+    for row in rows:
+        raw_bytes = getattr(row, "raw_bytes", b"")
+        if not raw_bytes or row.preview:
+            continue
+        try:
+            with PIL.Image.open(io.BytesIO(raw_bytes)) as pil_image:
+                row.preview = _generate_preview(pil_image)
+            row.preview_format = "png"
+        except Exception:  # noqa: BLE001 - a bad image must never fail the import
+            continue
 
 
 class _MediaCensus:

--- a/tests/datasets/io/test_previews.py
+++ b/tests/datasets/io/test_previews.py
@@ -1,0 +1,87 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import io
+from pathlib import Path
+
+import PIL.Image
+from fastapi.testclient import TestClient
+
+from pixano.api.main import create_app
+from pixano.api.settings import Settings, get_settings
+from tests.datasets.io.formats.test_jsonl_importer import _case
+
+
+def _import_corpus(name: str, tmp_path: Path):
+    case = _case(name, tmp_path / "src")
+    dataset, _ = case.run_import(tmp_path / "data")
+    return dataset
+
+
+class TestPreviewStamping:
+    def test_imported_images_carry_png_thumbnails(self, tmp_path: Path):
+        dataset = _import_corpus("mel", tmp_path)
+        rows = dataset.open_table("images").search().select(["preview", "preview_format"]).limit(None).to_list()
+        assert rows
+        for row in rows:
+            assert row["preview_format"] == "png"
+            thumbnail = PIL.Image.open(io.BytesIO(row["preview"]))
+            assert thumbnail.format == "PNG"
+            assert max(thumbnail.size) <= 64
+
+    def test_sequence_frames_carry_thumbnails(self, tmp_path: Path):
+        dataset = _import_corpus("frames_masks", tmp_path)
+        rows = dataset.open_table("sequence_frames").search().select(["preview_format"]).limit(None).to_list()
+        assert rows and all(row["preview_format"] == "png" for row in rows)
+
+    def test_uri_mode_rows_have_no_thumbnail(self, tmp_path: Path):
+        dataset = _import_corpus("lerobot_window", tmp_path)  # remote videos, nothing embedded
+        rows = dataset.open_table("videos").search().select(["preview_format"]).limit(None).to_list()
+        assert rows and all(row["preview_format"] == "" for row in rows)
+
+    def test_preview_stamping_is_idempotent(self, tmp_path: Path):
+        first = _import_corpus("mel", tmp_path / "one")
+        second = _import_corpus("mel", tmp_path / "two")
+        previews_first = sorted(
+            (row["id"], row["preview"])
+            for row in first.open_table("images").search().select(["id", "preview"]).limit(None).to_list()
+        )
+        previews_second = sorted(
+            (row["id"], row["preview"])
+            for row in second.open_table("images").search().select(["id", "preview"]).limit(None).to_list()
+        )
+        assert previews_first == previews_second
+
+
+class TestPreviewApi:
+    def _client(self, data_dir: Path) -> TestClient:
+        settings = Settings(library_dir=str(data_dir / "library"))
+        app = create_app(settings)
+        app.dependency_overrides[get_settings] = lambda: settings
+        return TestClient(app)
+
+    def test_preview_route_serves_imported_thumbnails(self, tmp_path: Path):
+        dataset = _import_corpus("mel", tmp_path)
+        client = self._client(tmp_path / "data")
+
+        records = client.get(f"/datasets/{dataset.info.id}/records", params={"include": "view_previews"}).json()
+        descriptor = records["items"][0]["view_previews"]["image"]
+        assert descriptor["preview_url"].endswith("/preview")
+
+        response = client.get(descriptor["preview_url"])
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert PIL.Image.open(io.BytesIO(response.content)).format == "PNG"
+
+    def test_datalake_uri_rows_expose_the_remote_url(self, tmp_path: Path):
+        dataset = _import_corpus("mixed_media", tmp_path)  # embedded photo + remote video
+        client = self._client(tmp_path / "data")
+
+        records = client.get(f"/datasets/{dataset.info.id}/records", params={"include": "view_previews"}).json()
+        previews = records["items"][0]["view_previews"]
+        assert previews["image"]["preview_url"].endswith("/preview")  # embedded -> route
+        embedded = client.get(previews["image"]["preview_url"])
+        assert embedded.status_code == 200


### PR DESCRIPTION
## Issue

First checkpoint-B finding: after importing the generated MEL sample, the browse grid requested `GET /datasets/{id}/images/{view_id}/preview` and got 404 for every image (`/blob` was 200).

**⚠️ Stacked on #679** — merge order: #675 → #676 → #677 → #678 → #679 → this.

## Description

**Root cause**: v1 built view rows through `Image.from_bytes`/`SequenceFrame.from_bytes`, which stamp a 64×64 PNG thumbnail into `preview`; the io importer instantiates the schema classes directly, so `preview` stayed empty and `_stream_preview` 404'd. The grid renders the backend-provided `preview_url` verbatim with no fallback, so a backend fix suffices. The spec's Finalize step already prescribes preview population at import — this closes that conformance gap.

- **`ImportEngine._flush_rows`** stamps a 64×64 PNG `preview` on image-family view rows with embedded bytes, using the same `_generate_preview` helper v1 used. Engine-level, so every importer (including the coming COCO/LeRobot) inherits it. A corrupt image skips its thumbnail — never fails the import. Video posters remain the P3.5 ffmpeg work.
- **`records?include=view_previews`** now returns the row's own `http(s)` URI as `preview_url` for datalake rows (spec §6 uri mode: the browser loads user-served media directly, the same policy the item view applies); embedded rows keep the `/preview` route.
- **Regression tests** close the hole that let this slip (existing `/preview` tests hand-seeded the column): the real importer runs end-to-end and `/preview` is asserted `200 image/png` over a TestClient; thumbnails are PIL-decodable at ≤64px; uri-only rows carry no thumbnail; stamping is byte-identical across re-imports (idempotent add-mode preserved).

**Verified on the exact reported scenario**: regenerated the cookbook MEL sample → `pixano data import` → `pixano server run` → the previously-404 URL pattern returns `200 image/png` (1.9 KB thumbnail). Full suite green (566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)