### PR TITLE
feat: add the COCO importer and exporter with round-trip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dependencies = [
   "pyyaml>=6.0,<7.0",
 ]
 
+[project.optional-dependencies]
+coco = ["ijson >= 3.2, < 4.0"]
+
 [dependency-groups]
 docs = [
   "griffe >= 1.0.0",

--- a/src/pixano/datasets/io/__init__.py
+++ b/src/pixano/datasets/io/__init__.py
@@ -93,7 +93,9 @@ __all__ = [
 
 
 # Built-in formats register on package import (entry-point plugins load lazily).
+from .formats.coco.importer import COCO  # noqa: E402
 from .formats.pixano_jsonl.importer import PIXANO_JSONL  # noqa: E402
 
 
 FORMATS.register(PIXANO_JSONL)
+FORMATS.register(COCO)

--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -28,7 +28,7 @@ from .importer import DatasetImporter, SourceRef
 from .plan import AnalyzeLimits, ImportPlan
 from .progress import ProgressSink
 from .registry import FORMATS
-from .spec import ImportSpec, resolve_dataset_info
+from .spec import ImportSpec
 
 
 def _resolve_importer(source: SourceRef, spec: ImportSpec, importer: DatasetImporter | None) -> DatasetImporter:
@@ -94,7 +94,7 @@ def import_dataset(
         )
 
     if info is None:
-        info = resolve_dataset_info(spec)
+        info = resolved.resolve_info(spec)
     if spec.dataset.name:
         info.name = spec.dataset.name
     if spec.dataset.description:

--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -118,12 +118,16 @@ def export_dataset(
     """
     from pixano.datasets.dataset import Dataset
 
-    if format != "pixano_jsonl":
-        raise SpecValidationError(f"Export format '{format}' is not available yet; only 'pixano_jsonl' is.")
     if media not in ("files", "uris"):
         raise SpecValidationError("media must be 'files' or 'uris'.")
 
-    from .formats.pixano_jsonl.exporter import PixanoJsonlExporter
-
     resolved = dataset if isinstance(dataset, Dataset) else Dataset(Path(dataset))
-    return PixanoJsonlExporter(media=media).export(resolved, Path(destination))  # type: ignore[arg-type]
+    if format == "pixano_jsonl":
+        from .formats.pixano_jsonl.exporter import PixanoJsonlExporter
+
+        return PixanoJsonlExporter(media=media).export(resolved, Path(destination))  # type: ignore[arg-type]
+    if format == "coco":
+        from .formats.coco.exporter import CocoExporter
+
+        return CocoExporter(media=media).export(resolved, Path(destination))  # type: ignore[arg-type]
+    raise SpecValidationError(f"Export format '{format}' is not available; use 'pixano_jsonl' or 'coco'.")

--- a/src/pixano/datasets/io/formats/coco/__init__.py
+++ b/src/pixano/datasets/io/formats/coco/__init__.py
@@ -6,7 +6,8 @@
 
 """COCO instances format: two-pass streaming importer (spec §7.2)."""
 
+from .exporter import CocoExporter
 from .importer import COCO, CocoImporter
 
 
-__all__ = ["COCO", "CocoImporter"]
+__all__ = ["COCO", "CocoExporter", "CocoImporter"]

--- a/src/pixano/datasets/io/formats/coco/__init__.py
+++ b/src/pixano/datasets/io/formats/coco/__init__.py
@@ -1,0 +1,12 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""COCO instances format: two-pass streaming importer (spec §7.2)."""
+
+from .importer import COCO, CocoImporter
+
+
+__all__ = ["COCO", "CocoImporter"]

--- a/src/pixano/datasets/io/formats/coco/exporter.py
+++ b/src/pixano/datasets/io/formats/coco/exporter.py
@@ -1,0 +1,145 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""COCO exporter: streams a dataset back to instances_<split>.json (spec §10).
+
+Reader-driven (one pass, per-record bundles); media bytes dump incrementally
+beside the JSON. Categories are collected from entity values and assigned
+deterministic ids (alphabetical), fixing the v1 exporter that emitted an empty
+categories list. Pixano string ids ride along as ``pixano_id`` extensions so
+the export is traceable back to its source rows.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Literal
+
+from pixano.datasets.dataset import Dataset
+
+from ...errors import SpecValidationError
+from ...reader import RecordBundleReader
+
+
+_KEYPOINT_VISIBILITY = {"invisible": 0, "hidden": 1, "visible": 2}
+
+
+class CocoExporter:
+    """Streams a dataset to the COCO instances layout, one JSON per split."""
+
+    def __init__(self, media: Literal["files", "uris"] = "files", reader: RecordBundleReader | None = None):
+        """Configure the export media policy."""
+        self.media = media
+        self.reader = reader or RecordBundleReader()
+
+    def export(self, dataset: Dataset, destination: Path) -> Path:
+        """Export the dataset; returns the destination directory."""
+        destination.mkdir(parents=True, exist_ok=True)
+        splits: dict[str, dict[str, list[dict]]] = defaultdict(lambda: {"images": [], "annotations": []})
+        category_names: dict[str, str] = {}  # name -> supercategory
+        image_ordinals: dict[str, int] = defaultdict(int)
+        annotation_ordinals: dict[str, int] = defaultdict(int)
+
+        for bundle in self.reader.iter_bundles(dataset):
+            split = bundle.record.split
+            image_rows = bundle.components.get("images", [])
+            if not image_rows:
+                continue
+            image_row = image_rows[0]
+            image_ordinals[split] += 1
+            image_id = image_ordinals[split]
+            file_name = self._media_ref(image_row, destination, split)
+            splits[split]["images"].append(
+                {
+                    "id": image_id,
+                    "file_name": file_name,
+                    "width": image_row.width,
+                    "height": image_row.height,
+                    "pixano_id": bundle.record_id,
+                    **({"coco_url": image_row.uri} if image_row.uri else {}),
+                }
+            )
+
+            entities = {row.id: row for row in bundle.components.get("entities", [])}
+            annotations_by_entity: dict[str, dict[str, Any]] = {}
+
+            def entry(entity_id: str) -> dict[str, Any]:
+                if entity_id not in annotations_by_entity:
+                    annotation_ordinals[split] += 1
+                    entity = entities.get(entity_id)
+                    category = str(getattr(entity, "category", "") or "") if entity else ""
+                    if category:
+                        category_names.setdefault(category, str(getattr(entity, "supercategory", "") or category))
+                    annotations_by_entity[entity_id] = {
+                        "id": annotation_ordinals[split],
+                        "image_id": image_id,
+                        "iscrowd": int(bool(getattr(entity, "iscrowd", False))) if entity else 0,
+                        "pixano_id": entity_id,
+                        "_category": category,
+                    }
+                return annotations_by_entity[entity_id]
+
+            width, height = image_row.width or 1, image_row.height or 1
+            for box in bundle.components.get("bboxes", []):
+                x, y, w, h = box.coords
+                if box.is_normalized:
+                    x, y, w, h = x * width, y * height, w * width, h * height
+                entry(box.entity_id)["bbox"] = [round(v, 2) for v in (x, y, w, h)]
+                entry(box.entity_id)["area"] = round(w * h, 2)
+            for mask in bundle.components.get("masks", []):
+                counts = mask.counts.decode("utf-8") if isinstance(mask.counts, bytes) else mask.counts
+                entry(mask.entity_id)["segmentation"] = {"size": list(mask.size), "counts": counts}
+            for keypoints in bundle.components.get("keypoints", []):
+                flat: list[float] = []
+                for index, state in enumerate(keypoints.states):
+                    flat.extend(
+                        [
+                            round(keypoints.coords[2 * index] * width, 2),
+                            round(keypoints.coords[2 * index + 1] * height, 2),
+                            _KEYPOINT_VISIBILITY.get(state, 0),
+                        ]
+                    )
+                entry(keypoints.entity_id)["keypoints"] = flat
+                entry(keypoints.entity_id)["num_keypoints"] = sum(
+                    1 for state in keypoints.states if state != "invisible"
+                )
+            splits[split]["annotations"].extend(annotations_by_entity.values())
+
+        category_ids = {name: index for index, name in enumerate(sorted(category_names), start=1)}
+        categories = [
+            {"id": category_ids[name], "name": name, "supercategory": category_names[name]}
+            for name in sorted(category_names)
+        ]
+        for split, payload in splits.items():
+            for annotation in payload["annotations"]:
+                annotation["category_id"] = category_ids.get(annotation.pop("_category"), 0)
+            document = {
+                "info": {"description": dataset.info.name, "version": "pixano-export"},
+                "images": payload["images"],
+                "annotations": payload["annotations"],
+                "categories": categories,
+            }
+            (destination / f"instances_{split}.json").write_text(
+                json.dumps(document, ensure_ascii=False), encoding="utf-8"
+            )
+        return destination
+
+    def _media_ref(self, image_row: Any, destination: Path, split: str) -> str:
+        raw_bytes = getattr(image_row, "raw_bytes", b"")
+        if raw_bytes:
+            if self.media == "uris":
+                raise SpecValidationError(
+                    "media='uris' cannot export embedded media; use media='files' to dump bytes beside the JSON."
+                )
+            extension = (getattr(image_row, "format", "") or "bin").lower()
+            file_name = f"{image_row.id}.{extension}"
+            target = destination / "image" / split / file_name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(raw_bytes)
+            return file_name
+        return Path(str(image_row.uri)).name or f"{image_row.id}.bin"

--- a/src/pixano/datasets/io/formats/coco/importer.py
+++ b/src/pixano/datasets/io/formats/coco/importer.py
@@ -1,0 +1,452 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""The COCO importer: two-pass streaming over instances JSON files (spec §7.2).
+
+Pass 1 streams ``annotations`` into an index keyed by ``image_id`` (SQLite
+spill above a row threshold, so annotation files larger than RAM import in
+bounded memory); pass 2 streams ``images`` joining that index. `ijson` (the
+``coco`` extra) enables true streaming; without it the file is loaded whole,
+flagged by a Finding at analyze — never silently.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any, Iterator
+
+from lancedb.pydantic import LanceModel
+
+from pixano.datasets.dataset_info import DatasetInfo
+from pixano.schemas import CompressedRLE
+
+from ...errors import MetadataError
+from ...ids import stable_id
+from ...importer import BatchBundle, Cursor, DatasetImporter, DetectResult, SourceRef
+from ...media import MediaResolver, probe_image
+from ...plan import AnalyzeLimits, ImportPlan, Provenance, SamplePreview
+from ...registry import Capabilities, DataFormat
+from ...spec import ImportSpec, resolve_dataset_info
+
+
+_COCO_KEYPOINT_STATES = {0: "invisible", 1: "hidden", 2: "visible"}
+_COCO17_TEMPLATE_ID = "coco-17"
+_SPILL_THRESHOLD = 500_000  # annotations held in memory before spilling to SQLite
+
+_DEFAULT_SCHEMA = {
+    "entity": {
+        "attrs": {
+            "category": "str",
+            "supercategory": "str",
+            "iscrowd": {"type": "bool", "default": False},
+        }
+    },
+    "annotations": ["bbox", "mask", "keypoint"],
+}
+
+
+def _find_annotation_files(source_dir: Path) -> list[tuple[str, Path]]:
+    """Locate instances_*.json files; the suffix after 'instances_' is the split."""
+    found: dict[str, Path] = {}
+    for pattern in ("instances_*.json", "annotations/instances_*.json"):
+        for path in sorted(source_dir.glob(pattern)):
+            split = path.stem.removeprefix("instances_") or "train"
+            found.setdefault(split, path)
+    return sorted(found.items())
+
+
+class _AnnotationIndex:
+    """Annotations grouped by image_id: dict-backed, spilling to SQLite past a threshold."""
+
+    def __init__(self, spill_threshold: int = _SPILL_THRESHOLD):
+        """Configure the annotation-index spill threshold (rows kept in memory)."""
+        self.spill_threshold = spill_threshold
+        self._memory: dict[str, list[dict]] = {}
+        self._count = 0
+        self._db: sqlite3.Connection | None = None
+
+    def add(self, image_id: str, annotation: dict) -> None:
+        self._count += 1
+        if self._db is None and self._count > self.spill_threshold:
+            self._spill()
+        if self._db is None:
+            self._memory.setdefault(image_id, []).append(annotation)
+        else:
+            self._db.execute("INSERT INTO anns (image_id, payload) VALUES (?, ?)", (image_id, json.dumps(annotation)))
+
+    def _spill(self) -> None:
+        spill_file = tempfile.NamedTemporaryFile(prefix="pixano-coco-spill-", suffix=".sqlite", delete=False)
+        self._db = sqlite3.connect(spill_file.name)
+        self._db.execute("CREATE TABLE anns (image_id TEXT, payload TEXT)")
+        self._db.execute("CREATE INDEX idx_image ON anns (image_id)")
+        for image_id, spilled_annotations in self._memory.items():
+            for annotation in spilled_annotations:
+                self._db.execute(
+                    "INSERT INTO anns (image_id, payload) VALUES (?, ?)", (image_id, json.dumps(annotation))
+                )
+        self._memory.clear()
+
+    def get(self, image_id: str) -> list[dict]:
+        if self._db is None:
+            return self._memory.get(image_id, [])
+        rows = self._db.execute("SELECT payload FROM anns WHERE image_id = ?", (image_id,)).fetchall()
+        return [json.loads(row[0]) for row in rows]
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    @property
+    def spilled(self) -> bool:
+        return self._db is not None
+
+    def close(self) -> None:
+        if self._db is not None:
+            self._db.close()
+
+
+def _stream_array(json_path: Path, key: str) -> tuple[Iterator[dict], bool]:
+    """Stream the items of a top-level array; returns (iterator, streamed?)."""
+    try:
+        import ijson
+
+        def _iter() -> Iterator[dict]:
+            with json_path.open("rb") as handle:
+                yield from ijson.items(handle, f"{key}.item")
+
+        return _iter(), True
+    except ImportError:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        return iter(payload.get(key, [])), False
+
+
+class CocoImporter(DatasetImporter):
+    """Importer for COCO instances JSON (detection, segmentation, keypoints)."""
+
+    format_name = "coco"
+    importer_version = "1.0.0"
+    supports_resume = True
+    deterministic_ids = True
+
+    def __init__(self, spill_threshold: int = _SPILL_THRESHOLD):
+        """Configure the annotation-index spill threshold (rows kept in memory)."""
+        self.spill_threshold = spill_threshold
+
+    # ------------------------------------------------------------------
+    # Detection & schema
+    # ------------------------------------------------------------------
+
+    def probe(self, source: SourceRef) -> DetectResult | None:
+        """Sniff for instances_*.json at the source root or under annotations/."""
+        if source.path is None or not source.path.is_dir():
+            return None
+        files = _find_annotation_files(source.path)
+        if files:
+            return DetectResult(confidence=0.9, evidence=f"{files[0][1].name}")
+        return None
+
+    def resolve_info(self, spec: ImportSpec) -> DatasetInfo:
+        """COCO has an intrinsic schema; a user-declared schema block still wins."""
+        if spec.schema_ is not None or spec.schema_manifest is not None:
+            return resolve_dataset_info(spec)
+        payload = spec.model_dump(exclude_none=True, by_alias=True)
+        payload["schema"] = _DEFAULT_SCHEMA
+        return resolve_dataset_info(ImportSpec.model_validate(payload))
+
+    # ------------------------------------------------------------------
+    # Analyze
+    # ------------------------------------------------------------------
+
+    def analyze(self, source: SourceRef, spec: ImportSpec, limits: AnalyzeLimits) -> ImportPlan:
+        """Count images/annotations per split; verify media and category references."""
+        plan = ImportPlan(format=self.format_name, importer_version=self.importer_version)
+        if source.path is None or not source.path.is_dir():
+            plan.report.add("invalid_source", Provenance(file=source.location()), suggestion="Expected a directory.")
+            return plan
+        annotation_files = _find_annotation_files(source.path)
+        if not annotation_files:
+            plan.report.add(
+                "missing_annotations",
+                Provenance(file=str(source.path)),
+                suggestion="No instances_*.json found at the source root or under annotations/.",
+            )
+            return plan
+
+        total = 0
+        media_probes = 0
+        for split, json_path in annotation_files:
+            categories = self._load_categories(json_path)
+            provenance = Provenance(file=str(json_path))
+
+            annotation_stream, streamed = _stream_array(json_path, "annotations")
+            if not streamed:
+                plan.report.add(
+                    "coco_in_memory",
+                    provenance,
+                    severity="warning",
+                    suggestion="ijson is not installed; the JSON is loaded whole. pip install pixano[coco] "
+                    "for bounded-memory streaming.",
+                )
+            unknown_categories: set[int] = set()
+            annotation_count = 0
+            for annotation in annotation_stream:
+                annotation_count += 1
+                category_id = annotation.get("category_id")
+                if category_id is not None and category_id not in categories:
+                    unknown_categories.add(int(category_id))
+            if unknown_categories:
+                plan.report.add(
+                    "unknown_category_id",
+                    provenance,
+                    suggestion=f"Annotations reference undeclared category ids: {sorted(unknown_categories)[:5]}.",
+                )
+
+            images, _ = _stream_array(json_path, "images")
+            split_count = 0
+            for image in images:
+                split_count += 1
+                if spec.media.mode == "embed" and media_probes < limits.max_media_probes:
+                    media_probes += 1
+                    if self._locate_image(source.path, split, image.get("file_name", "")) is None:
+                        plan.report.add(
+                            "missing_media",
+                            provenance,
+                            suggestion=f"Image file '{image.get('file_name')}' not found for split '{split}'.",
+                        )
+                if spec.media.mode == "uri" and not image.get("coco_url"):
+                    plan.report.add(
+                        "missing_coco_url",
+                        provenance,
+                        suggestion="Media mode 'uri' needs a coco_url per image; use embed for local files.",
+                    )
+                if len(plan.previews) < limits.max_previews:
+                    plan.previews.append(SamplePreview(record={"split": split, **image}))
+            plan.splits[split] = split_count
+            total += split_count
+
+        plan.totals.records = total
+        return plan
+
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    def iter_batches(
+        self,
+        source: SourceRef,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        cursor: Cursor | None = None,
+    ) -> Iterator[BatchBundle]:
+        """Two passes per split: index annotations, then stream images joining the index."""
+        assert source.path is not None
+        info = self.resolve_info(spec)
+        namespace = spec.ids.namespace or source.path.name
+        resolver = MediaResolver(spec.media, base_dir=source.path)
+        resume_split = cursor.get("split") if cursor else None
+        resume_ordinal = int(cursor.get("image_ordinal", 0)) if cursor else 0
+
+        for split, json_path in _find_annotation_files(source.path):
+            if resume_split is not None and split < resume_split:
+                continue
+            categories = self._load_categories(json_path)
+            index = _AnnotationIndex(self.spill_threshold)
+            try:
+                annotation_stream, _ = _stream_array(json_path, "annotations")
+                for annotation in annotation_stream:
+                    index.add(str(annotation.get("image_id", "")), annotation)
+
+                images, _ = _stream_array(json_path, "images")
+                for ordinal, image in enumerate(images, start=1):
+                    if resume_split == split and ordinal <= resume_ordinal:
+                        continue
+                    tables = self._build_image(
+                        info, spec, resolver, source.path, namespace, split, image, index, categories
+                    )
+                    yield BatchBundle(
+                        tables=tables,
+                        cursor={"split": split, "image_ordinal": ordinal},
+                        provenance=Provenance(file=str(json_path)),
+                    )
+            finally:
+                index.close()
+
+    # ------------------------------------------------------------------
+    # Row construction
+    # ------------------------------------------------------------------
+
+    def _build_image(
+        self,
+        info: DatasetInfo,
+        spec: ImportSpec,
+        resolver: MediaResolver,
+        source_dir: Path,
+        namespace: str,
+        split: str,
+        image: dict,
+        index: _AnnotationIndex,
+        categories: dict[int, dict],
+    ) -> dict[str, list[LanceModel]]:
+        tables: dict[str, list[LanceModel]] = {}
+        image_id = str(image.get("id", ""))
+        record_id = stable_id(namespace, split, image_id)
+        assert info.record is not None
+        tables["records"] = [info.record(id=record_id, split=split)]
+
+        width = int(image.get("width", 0) or 0)
+        height = int(image.get("height", 0) or 0)
+        file_name = str(image.get("file_name", ""))
+        if spec.media.mode == "uri":
+            resolved_uri, raw_bytes = str(image.get("coco_url", "")), b""
+        else:
+            local = self._locate_image(source_dir, split, file_name)
+            if local is None:
+                raise MetadataError(f"Image file '{file_name}' not found for split '{split}'.")
+            resolved = resolver.resolve(str(local.relative_to(source_dir)))
+            resolved_uri, raw_bytes = resolved.uri, resolved.raw_bytes
+            if not width or not height:
+                width, height, _ = probe_image(local)
+        view_cls = info.views["image"]
+        view_id = stable_id(record_id, "view", "image")
+        tables["images"] = [
+            view_cls(
+                id=view_id,
+                record_id=record_id,
+                logical_name="image",
+                uri=resolved_uri,
+                raw_bytes=raw_bytes,
+                width=width,
+                height=height,
+                format=Path(file_name).suffix.removeprefix(".").upper() or "UNKNOWN",
+            )
+        ]
+
+        for annotation in index.get(image_id):
+            self._build_annotation(info, tables, record_id, view_id, annotation, categories, width, height)
+        return tables
+
+    def _build_annotation(
+        self,
+        info: DatasetInfo,
+        tables: dict[str, list[LanceModel]],
+        record_id: str,
+        view_id: str,
+        annotation: dict,
+        categories: dict[int, dict],
+        width: int,
+        height: int,
+    ) -> None:
+        annotation_id = str(annotation.get("id", ""))
+        category = categories.get(int(annotation.get("category_id", -1)), {})
+        entity_id = stable_id(record_id, "ent", annotation_id)
+        assert info.entity is not None
+        tables.setdefault("entities", []).append(
+            info.entity(
+                id=entity_id,
+                record_id=record_id,
+                category=str(category.get("name", "")),
+                supercategory=str(category.get("supercategory", "")),
+                iscrowd=bool(annotation.get("iscrowd", 0)),
+            )
+        )
+        common = {"record_id": record_id, "entity_id": entity_id, "view_id": view_id}
+
+        bbox = annotation.get("bbox")
+        if bbox and len(bbox) == 4 and width and height and info.bbox is not None:
+            x, y, w, h = bbox
+            tables.setdefault("bboxes", []).append(
+                info.bbox(
+                    id=stable_id(entity_id, "bbox", 0),
+                    coords=[x / width, y / height, w / width, h / height],
+                    format="xywh",
+                    is_normalized=True,
+                    confidence=1.0,
+                    **common,
+                )
+            )
+
+        segmentation = annotation.get("segmentation")
+        if segmentation and info.mask is not None:
+            rle = self._to_rle(segmentation, height, width)
+            if rle is not None:
+                tables.setdefault("masks", []).append(
+                    info.mask(id=stable_id(entity_id, "mask", 0), size=rle.size, counts=rle.counts, **common)
+                )
+
+        keypoints = annotation.get("keypoints")
+        if keypoints and width and height and info.keypoint is not None:
+            coords: list[float] = []
+            states: list[str] = []
+            for i in range(0, len(keypoints) - 2, 3):
+                coords.extend([keypoints[i] / width, keypoints[i + 1] / height])
+                states.append(_COCO_KEYPOINT_STATES.get(int(keypoints[i + 2]), "invisible"))
+            tables.setdefault("keypoints", []).append(
+                info.keypoint(
+                    id=stable_id(entity_id, "keypoints", 0),
+                    template_id=_COCO17_TEMPLATE_ID,
+                    coords=coords,
+                    states=states,
+                    **common,
+                )
+            )
+
+    @staticmethod
+    def _to_rle(segmentation: Any, height: int, width: int) -> CompressedRLE | None:
+        if isinstance(segmentation, dict):
+            counts = segmentation.get("counts")
+            if isinstance(counts, list):
+                return CompressedRLE.from_urle({"counts": counts, "size": segmentation.get("size", [height, width])})
+            if isinstance(counts, (str, bytes)):
+                counts_bytes = counts.encode("utf-8") if isinstance(counts, str) else counts
+                return CompressedRLE(size=segmentation.get("size", [height, width]), counts=counts_bytes)
+        if isinstance(segmentation, list) and segmentation and height and width:
+            return CompressedRLE.from_polygons(segmentation, height=height, width=width)
+        return None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_categories(json_path: Path) -> dict[int, dict]:
+        categories, _ = _stream_array(json_path, "categories")
+        return {category["id"]: category for category in categories}
+
+    @staticmethod
+    def _locate_image(source_dir: Path, split: str, file_name: str) -> Path | None:
+        if not file_name:
+            return None
+        for candidate in (
+            source_dir / split / file_name,
+            source_dir / "image" / split / file_name,
+            source_dir / "images" / split / file_name,
+            source_dir / file_name,
+        ):
+            if candidate.is_file():
+                return candidate
+        return None
+
+
+def _detect(source: SourceRef) -> DetectResult | None:
+    return CocoImporter().probe(source)
+
+
+COCO = DataFormat(
+    name="coco",
+    title="COCO instances",
+    importer_cls=CocoImporter,
+    capabilities=Capabilities(
+        media_kinds=frozenset({"image"}),
+        annotation_kinds=frozenset({"bbox", "mask", "keypoints"}),
+        source_kinds=frozenset({"local_dir"}),
+        supports_resume=True,
+        deterministic_ids=True,
+    ),
+    detect=_detect,
+)

--- a/src/pixano/datasets/io/importer.py
+++ b/src/pixano/datasets/io/importer.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Iterator, Literal
 
+from pixano.datasets.dataset_info import DatasetInfo  # noqa: TC001
+
 from .plan import AnalyzeLimits, ImportPlan, Provenance
 
 
@@ -114,6 +116,17 @@ class DatasetImporter(ABC):
         Returns None when the source does not look like this format.
         """
         return None
+
+    def resolve_info(self, spec: "ImportSpec") -> "DatasetInfo":
+        """Resolve the target schema for this format.
+
+        The default honors the user's spec (schema block, manifest, or
+        workspace preset). Formats with an intrinsic schema (COCO, LeRobot)
+        override this to supply it when the spec declares none.
+        """
+        from .spec import resolve_dataset_info
+
+        return resolve_dataset_info(spec)
 
     @abstractmethod
     def analyze(self, source: SourceRef, spec: "ImportSpec", limits: AnalyzeLimits) -> ImportPlan:

--- a/tests/datasets/io/formats/test_coco_importer.py
+++ b/tests/datasets/io/formats/test_coco_importer.py
@@ -151,3 +151,31 @@ class TestCocoImporter:
         dataset = Dataset(result.dataset_path)
         assert dataset.get_data("images")[0].uri == "https://cdn.example.com/a.jpg"
         assert dataset.info.storage_mode == "filesystem"
+
+
+class TestCocoRoundTrip:
+    def test_import_export_reimport_preserves_counts_and_categories(self, tmp_path: Path):
+        from pixano.datasets import Dataset
+        from pixano.datasets.io import export_dataset
+
+        first, _ = _case().run_import(tmp_path / "data1")
+        exported = export_dataset(first, tmp_path / "exported", format="coco")
+
+        assert (exported / "instances_val.json").is_file()
+        document = json.loads((exported / "instances_val.json").read_text())
+        assert document["categories"], "categories must be populated (v1 exported them empty)"
+        assert len(document["images"]) == 3 and len(document["annotations"]) == 39
+        assert all("pixano_id" in image for image in document["images"])
+
+        result = import_dataset(exported, tmp_path / "data2", _spec("coco_rt"), importer=CocoImporter())
+        second = Dataset(result.dataset_path)
+        for table, expected in EXPECTED_COUNTS.items():
+            assert second.open_table(table).count_rows() == expected, table
+
+        first_categories = {entity.category for entity in first.get_data("entities", limit=100)}
+        second_categories = {entity.category for entity in second.get_data("entities", limit=100)}
+        assert second_categories == first_categories
+
+        box_first = sorted(first.get_data("bboxes", limit=100), key=lambda b: b.coords[0])[0]
+        box_second = sorted(second.get_data("bboxes", limit=100), key=lambda b: b.coords[0])[0]
+        assert box_second.coords == pytest.approx(box_first.coords, abs=1e-3)

--- a/tests/datasets/io/formats/test_coco_importer.py
+++ b/tests/datasets/io/formats/test_coco_importer.py
@@ -1,0 +1,153 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets.io import FORMATS, ImportSpec, SourceRef, import_dataset
+from pixano.datasets.io.formats.coco import CocoImporter
+from pixano.datasets.io.ids import namespace_prefix
+from pixano.datasets.io.testing import DatasetImporterTestCase
+from tests.assets.sample_data.metadata import IMAGE_JPG_ASSET_URL
+
+
+FIXTURE = Path(__file__).parents[3] / "assets" / "coco_dataset"
+
+EXPECTED_COUNTS = {"records": 3, "images": 3, "entities": 39, "bboxes": 39, "masks": 39}
+
+
+def _spec(name: str = "coco_val") -> ImportSpec:
+    return ImportSpec.model_validate(
+        {"dataset": {"name": name, "workspace": "image"}, "format": "coco", "ids": {"namespace": "coco_fix"}}
+    )
+
+
+def _case(spill_threshold: int = 500_000) -> DatasetImporterTestCase:
+    return DatasetImporterTestCase(
+        importer=CocoImporter(spill_threshold=spill_threshold),
+        source=FIXTURE,
+        spec=_spec(),
+        expected_counts=EXPECTED_COUNTS,
+    )
+
+
+class TestCocoImporter:
+    def test_fixture_end_to_end(self, tmp_path: Path):
+        case = _case()
+        case.assert_analyze_clean()
+        dataset, _ = case.run_import(tmp_path / "data")
+        case.assert_counts(dataset)
+        case.assert_storage_mode(dataset, "embedded")
+        case.assert_id_prefix(dataset, namespace_prefix("coco_fix"))
+        case.assert_idempotent_rerun(dataset, tmp_path / "data")
+
+    def test_intrinsic_schema_and_values(self, tmp_path: Path):
+        dataset, _ = _case().run_import(tmp_path / "data")
+        entity = dataset.get_data("entities")[0]
+        assert entity.category and entity.supercategory
+        assert entity.iscrowd is False
+        box = dataset.get_data("bboxes")[0]
+        assert box.format == "xywh" and box.is_normalized is True
+        assert all(0.0 <= coord <= 1.0 for coord in box.coords)
+        mask = dataset.get_data("masks")[0]
+        assert mask.counts and mask.size == [426, 640] or mask.size  # RLE round-tripped
+
+    def test_spill_path_is_id_identical(self, tmp_path: Path):
+        in_memory, _ = _case().run_import(tmp_path / "mem")
+        spilled, _ = _case(spill_threshold=1).run_import(tmp_path / "spill")
+        for table in EXPECTED_COUNTS:
+            ids_mem = sorted(r["id"] for r in in_memory.open_table(table).search().select(["id"]).to_list())
+            ids_spill = sorted(r["id"] for r in spilled.open_table(table).search().select(["id"]).to_list())
+            assert ids_mem == ids_spill, table
+
+    def test_cursor_resume_skips_processed_images(self):
+        importer = CocoImporter()
+        spec = _spec()
+        plan = importer.analyze(
+            SourceRef.from_string(str(FIXTURE)),
+            spec,
+            __import__("pixano.datasets.io.plan", fromlist=["AnalyzeLimits"]).AnalyzeLimits(),
+        )
+        all_bundles = list(importer.iter_batches(SourceRef.from_string(str(FIXTURE)), spec, plan))
+        resumed = list(
+            importer.iter_batches(
+                SourceRef.from_string(str(FIXTURE)), spec, plan, cursor={"split": "val", "image_ordinal": 2}
+            )
+        )
+        assert len(all_bundles) == 3 and len(resumed) == 1
+        assert resumed[0].cursor == {"split": "val", "image_ordinal": 3}
+
+    def test_detection(self):
+        assert FORMATS.detect(SourceRef.from_string(str(FIXTURE))).name == "coco"
+
+    def test_keypoints_and_polygons(self, tmp_path: Path):
+        source = tmp_path / "kp_src"
+        (source / "train").mkdir(parents=True)
+        shutil.copy(IMAGE_JPG_ASSET_URL, source / "train" / "img1.jpg")
+        payload = {
+            "images": [{"id": 1, "file_name": "img1.jpg", "width": 586, "height": 640}],
+            "categories": [{"id": 1, "name": "person", "supercategory": "person"}],
+            "annotations": [
+                {
+                    "id": 10,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "bbox": [10, 10, 100, 200],
+                    "segmentation": [[10.0, 10.0, 110.0, 10.0, 110.0, 210.0, 10.0, 210.0]],
+                    "keypoints": [50, 60, 2, 0, 0, 0, 80, 90, 1],
+                }
+            ],
+        }
+        (source / "instances_train.json").write_text(json.dumps(payload))
+
+        result = import_dataset(source, tmp_path / "data", _spec("coco_kp"), importer=CocoImporter())
+        from pixano.datasets import Dataset
+
+        dataset = Dataset(result.dataset_path)
+        keypoints = dataset.get_data("keypoints")[0]
+        assert keypoints.template_id == "coco-17"
+        assert keypoints.states == ["visible", "invisible", "hidden"]
+        assert dataset.open_table("masks").count_rows() == 1  # polygon converted to RLE
+
+    def test_unknown_category_is_an_analyze_error(self, tmp_path: Path):
+        source = tmp_path / "bad_src"
+        source.mkdir()
+        payload = {
+            "images": [{"id": 1, "file_name": "img1.jpg", "width": 10, "height": 10}],
+            "categories": [{"id": 1, "name": "person"}],
+            "annotations": [{"id": 5, "image_id": 1, "category_id": 99, "bbox": [1, 1, 2, 2]}],
+        }
+        (source / "instances_train.json").write_text(json.dumps(payload))
+        plan = CocoImporter().analyze(
+            SourceRef.from_string(str(source)),
+            _spec(),
+            __import__("pixano.datasets.io.plan", fromlist=["AnalyzeLimits"]).AnalyzeLimits(),
+        )
+        assert "unknown_category_id" in plan.report.findings
+
+    def test_uri_mode_uses_coco_url(self, tmp_path: Path):
+        source = tmp_path / "uri_src"
+        source.mkdir()
+        payload = {
+            "images": [
+                {"id": 1, "file_name": "a.jpg", "width": 4, "height": 4, "coco_url": "https://cdn.example.com/a.jpg"}
+            ],
+            "categories": [],
+            "annotations": [],
+        }
+        (source / "instances_val.json").write_text(json.dumps(payload))
+        spec = ImportSpec.model_validate(
+            {"dataset": {"name": "coco_uri", "workspace": "image"}, "format": "coco", "media": {"mode": "uri"}}
+        )
+        result = import_dataset(source, tmp_path / "data", spec, importer=CocoImporter())
+        from pixano.datasets import Dataset
+
+        dataset = Dataset(result.dataset_path)
+        assert dataset.get_data("images")[0].uri == "https://cdn.example.com/a.jpg"
+        assert dataset.info.storage_mode == "filesystem"

--- a/tests/datasets/utils/test_integrity_arrow.py
+++ b/tests/datasets/utils/test_integrity_arrow.py
@@ -45,9 +45,7 @@ class TestValidateArrowBatch:
 
     def test_known_ids_flag_cross_flush_duplicates(self, dataset: Dataset):
         with pytest.raises(DatasetIntegrityError, match="e1"):
-            validate_arrow_batch(
-                "entities", _entities(["e1"], ["rec1"]), {"entities": {"e1"}}, dataset
-            )
+            validate_arrow_batch("entities", _entities(["e1"], ["rec1"]), {"entities": {"e1"}}, dataset)
 
     def test_empty_fk_sentinel_is_skipped(self, dataset: Dataset):
         validate_arrow_batch("entities", _entities(["e1"], [""]), {}, dataset)
@@ -69,9 +67,7 @@ class TestValidateArrowBatch:
             calls.append((target, values))
             return {value: value == "ledger_rec" for value in values}
 
-        validate_arrow_batch(
-            "entities", _entities(["e1"], ["ledger_rec"]), {}, dataset, fk_lookup=ledger_lookup
-        )
+        validate_arrow_batch("entities", _entities(["e1"], ["ledger_rec"]), {}, dataset, fk_lookup=ledger_lookup)
         assert calls == [("records", {"ledger_rec"})]
 
     def test_warn_mode_does_not_raise(self, dataset: Dataset):

--- a/uv.lock
+++ b/uv.lock
@@ -595,6 +595,68 @@ wheels = [
 ]
 
 [[package]]
+name = "ijson"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/b31f040a8764336a11152e474a7abcb3782fedb0d1cdf78f442b82878c56/ijson-3.5.1.tar.gz", hash = "sha256:af40bd1a85f55db0b8b30715c858761306bd92d5590148636f75c3309e6e76bd", size = 69913, upload-time = "2026-07-06T17:37:42.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/b8/6401c0e2f99aeff22fc740a1b1c2328269a81050c0c178462d0452e27c7e/ijson-3.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8b4ed62287feee41b90b55ae2800ef56d6bdfd2fbfa02b4fd0634cd4524bc995", size = 89054, upload-time = "2026-07-06T17:36:03.274Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ad/8d9e1f076560efcc6727b06f3276f30bb811961332d83567de70c179e0e8/ijson-3.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9708c0a3d1f86056049de631933aef8ec57f2008d4cb55ce241790c7ed557428", size = 60674, upload-time = "2026-07-06T17:36:04.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e7/8f001e823846c270e0e9c3526ea99dc3b1ba51b9501e060d8337830d6c76/ijson-3.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:904e8cf9ca69f5de5b6bb405a4a075ce3da3413ad50c11f6813f1201e14a8e45", size = 60738, upload-time = "2026-07-06T17:36:05.283Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c023067cb5ba4cc455a92110a021863fbe3dc3ffcca34ef95aea9290b8f1/ijson-3.5.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8cb5db5bc122da64efb24ce358752d5e097ab41d224ce2992536a0f9073fe4fd", size = 126651, upload-time = "2026-07-06T17:36:06.211Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/93/7c2207377b40bc1227c8fe1811e080f3b73cd4a9486af9c1166486c3156c/ijson-3.5.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cae04eff4006fc36bf0b030b38e2646a97092d87d933d20cfe7262e26ed32321", size = 133200, upload-time = "2026-07-06T17:36:07.239Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ea/e4d3f64822fb29d54970909e1e2784daa17f75fe3c6c27544fe92e247aad/ijson-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70542d4542f079c394e525559188d69e3ccfbfd9bab899acd0bf1dbc7323ddd5", size = 130361, upload-time = "2026-07-06T17:36:08.332Z" },
+    { url = "https://files.pythonhosted.org/packages/03/77/a61b6b68868a7368a0e4335975c5352e6c354d05eb73dbef19e796b3eaab/ijson-3.5.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1321495807dcdaca002cb45f24033208ce1d9f5ffc0c5a5584c5f466d0dcbbd5", size = 133618, upload-time = "2026-07-06T17:36:09.41Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0c/05bde03ef651ae2e1033f136c56f7f5565e9f53e7ff91ca83bfd581cbafa/ijson-3.5.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9fac9284d62c4317d541274e15a6a6ab6f6d22561579f6570967e3a6eaafaebc", size = 128554, upload-time = "2026-07-06T17:36:10.464Z" },
+    { url = "https://files.pythonhosted.org/packages/41/42/29bb5561c60e1f9d58d4fbef686e35b9440d9b56f9254c1c70b807c8f649/ijson-3.5.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1be3a586c8821ecab9ea8b256f39305c8a0cc33222fe393bcc1fb9221470732b", size = 131233, upload-time = "2026-07-06T17:36:11.783Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f7/b0176baac5129b79aa366161d5f524ead91b901f16a5020e495c3f83bcc5/ijson-3.5.1-cp310-cp310-win32.whl", hash = "sha256:3ab6378d9c19f01f206f27f762837ad3979330cabd7864e1b17934c03de6056c", size = 52221, upload-time = "2026-07-06T17:36:12.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ef/a707b5830722e9f7af347945f9ee0f360d38922366bc1400c6177154eb9c/ijson-3.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:0663f718c6123899c6bfd9c449ec195cd8c67666b7ea2c7b36fa0cc0dcb13e17", size = 54641, upload-time = "2026-07-06T17:36:13.724Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/834e7a4ec7e1019b596daf8d74f697aa1d3e38a17a9c31af6081c070557b/ijson-3.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:0a682954b60fcd0c23d504df6fb1ebde051305e41c9b350f39a3b8bfb168def7", size = 53954, upload-time = "2026-07-06T17:36:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d3/16d1595d3ef4743fc55129211bc52f52d59c582d0b7be045d8c04be0ae0c/ijson-3.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2aa9d0cf21d4de89fb633e5ec27e9ad02c3f9a4ffa3940d120b23b8aed3acffc", size = 89069, upload-time = "2026-07-06T17:36:15.727Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a5/ddba126e2d46cf3b86ad762aeb5e0a02ce0ebc6e4529fe7d06eecb217844/ijson-3.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:05eba5268a38809ba1c3dbfa44ea67336e2c353fc11768acc9c6442fe0ccac50", size = 60697, upload-time = "2026-07-06T17:36:16.66Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/444d8d00a4506a79fc5544614106fa48d5f6f7049511148d8b6cddb8e9d7/ijson-3.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:40ddd236c80a667dd6a1f6b625d18ddac68b8719ff795761b7542f2e1f78e4a4", size = 60747, upload-time = "2026-07-06T17:36:17.927Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b1/bc07831e646aebcc91a7bad9c5a0bf7c3f3395f0b10599e021667a3777f1/ijson-3.5.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e6cf9e49902f28af7a2e2f8b35c201195c0f0d5c170a5786e0c0a1b8492a4e37", size = 132095, upload-time = "2026-07-06T17:36:19.022Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/b4547461d75db40744616e40c0a06cf2f46a14e60742f6d12510f4612985/ijson-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ee1e6d59c800aa819952f6cb5ff08707ecd576b29cc9c3d00e33c2b371a92ce", size = 138790, upload-time = "2026-07-06T17:36:20.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/30/7ecba8377509eaea2666db5b39a1a99e23f5e3e1e7ee371ec366cbfc4f7c/ijson-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:affb85eb75fa03a21d1f790bbf26a0e66e5701672062a30dc5c3c6a29c5c0a63", size = 135233, upload-time = "2026-07-06T17:36:21.252Z" },
+    { url = "https://files.pythonhosted.org/packages/38/36/0679010904b24398336b3099b09ccb1daa41c534e7cb0931e89d5fcdbee4/ijson-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3060b141ef758be3742315d44476109460c265b88247e3a4e479949f8b134eac", size = 138832, upload-time = "2026-07-06T17:36:22.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/90/a40f971e78191e423c7b3a23756f37c3a51c27aadd7769b3fb1816e0044d/ijson-3.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ffba9bce60be21b496afc67a05ab8e3f431f87f0282fd6ce3c62004c951a1428", size = 133313, upload-time = "2026-07-06T17:36:23.405Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d7/b012c347d3ab011c0c4f7988dc6e85b83eaab59df1aec089f5db0e7b29c5/ijson-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:170cc4c209f57decc9b7ee5fd340f2a1602d54020fa222846482ff1c99e88fdc", size = 135706, upload-time = "2026-07-06T17:36:24.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/3eacb96124e78271f4e648c6ce36f9ce15ce2cef2afb6f8dc6e213e43979/ijson-3.5.1-cp311-cp311-win32.whl", hash = "sha256:6d581a071dae8dbee61f8d962e892787707bad6e641e2f6fb30dd89d3e896939", size = 52221, upload-time = "2026-07-06T17:36:25.517Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1a/19eff8576da0b46fa4a5c8751536ea27ab34c44b2609b2bcded9d7808d42/ijson-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:1356bca96d015948b601b013defb2d5631e4330e8f5880e4d7c933d472a90c34", size = 54641, upload-time = "2026-07-06T17:36:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/80/86b28f28ebf190fffd4f46790e065311e2758b55d8e6bbd33d92e9a49448/ijson-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2b83b24be73f0c7a301807a4c3081939524421c7ae1556eb6eac7cff50ddfa7", size = 53954, upload-time = "2026-07-06T17:36:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6e/f3ded1ebb85ccc89a30f7b10a0076f30db70ae1d1e0b6423ff93c57b7539/ijson-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee60c7741012671867678eae71c51872cac938b76f3d4ca40a778e6c361774d2", size = 88643, upload-time = "2026-07-06T17:36:28.529Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f2/18f14a1d79ef4898e746b4f50dcdbe60abab317cc2bd8390f043b9553c4e/ijson-3.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:11c1d7d36a13054b5872ecd5d745dc4009d9abdbcba2312de69e66c2f92a46d2", size = 60611, upload-time = "2026-07-06T17:36:29.597Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/6e3e591324fd4c7a7a9e1bc23548bacbd84c0d91766b71f09f13e945e7e9/ijson-3.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9517efbe6604bce16f3e50d49b0cd1bdc58917f98cf2eab026599c5c0422991", size = 60447, upload-time = "2026-07-06T17:36:30.747Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a5/9af7be670381ddac26dd55107ed0110b50f5161673b053311db67f510dcc/ijson-3.5.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ea4fd7bec203a600b1cc88a492dfe6b75ce4b1b87488a66adcd5406022213f64", size = 139092, upload-time = "2026-07-06T17:36:31.749Z" },
+    { url = "https://files.pythonhosted.org/packages/41/fb/f9c1664d75467453e6bd4e5f9cd2211b730b09e049445ab64cbac68cc6a3/ijson-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350caea815e53151994b597abc80cf669454276b5ac6aadcec69ef6d48f7e90b", size = 149921, upload-time = "2026-07-06T17:36:32.912Z" },
+    { url = "https://files.pythonhosted.org/packages/43/80/d20b1c49c4aa7cc6644131e2e57192b45346ef4816566ed1cd9fd05bae38/ijson-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4fcebfe1685bb7ba06a8255a5d428ea6b4b895d7acf979cb637d8bbc9db2f47", size = 149848, upload-time = "2026-07-06T17:36:34.032Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fc/5baa710869f5ab939e6233583ced1546889b55c35f35b844c518ac10abc3/ijson-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d78f362f51c8691798758a9e6ac3c9d385ee1228cb82987c91562a2fae235cd3", size = 150810, upload-time = "2026-07-06T17:36:35.19Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/a12b3d987a5c1677b04557c6f9b9feb7e04b7d4171e9a344856cb9136e9b/ijson-3.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0b184180d45f85fd4479659582749b109e49f4a29c21ac700ccc9c2280fe015e", size = 142989, upload-time = "2026-07-06T17:36:36.23Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/63/1026c535671fc334fc85aeb78f0945c825e7a338575edc753c0f455459ae/ijson-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e353891d33a2e6aa5caf72c2a5fbadd7a46f5f9b32dcfd0c84113b2444c255b8", size = 151702, upload-time = "2026-07-06T17:36:37.296Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/af/b58aa3a2bf4d31c388ea78b49826605f60932891ce97e404d196766b4ea3/ijson-3.5.1-cp312-cp312-win32.whl", hash = "sha256:936f28671f018f8ac4d3f003ae9fa01d0467ab4ef4cfd0c97f23beda485b61c6", size = 52613, upload-time = "2026-07-06T17:36:38.345Z" },
+    { url = "https://files.pythonhosted.org/packages/04/66/ce70a92949c2a753dad91fdd5761dc14f3a44517e80cfc3c26612982ed61/ijson-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:322c783f3ee0c6b383bbd4db88370b10172168808cc2a0bf811f1253f7435602", size = 54729, upload-time = "2026-07-06T17:36:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/e17784240c9cf1d58de2f2853ebaf9cc54f6bce117a1f12a6150bbb4a5aa/ijson-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:e2ac204b59f09e38e16d277f906240e9fd38780e42076599419265af183dc4b4", size = 53714, upload-time = "2026-07-06T17:36:40.308Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c0/5384ccf4fc497ae3dc79a5a28561b05518b503ade29daf3898168d640406/ijson-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3c0556d628443d3e871f414855313b2ae6cd9faa0104de3316bd8db03aab1589", size = 88652, upload-time = "2026-07-06T17:36:41.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/42/58769b8b6d614adb15c2c938c77bcdbfadfba8b1d21a98b5b09cb8961adc/ijson-3.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:12aa7fcf46f0fdc8e9e7cf37541e1dc20ac3f9243a23f4d346ab5395f72b0fe2", size = 60607, upload-time = "2026-07-06T17:36:42.697Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4a/8322c2824c24184880587bbca45531127a21a4b3bfc897f13427fea02424/ijson-3.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a96066d8c12a18ce2fa90579f2bbf991377cb71725874932e4a5d855226c162a", size = 60447, upload-time = "2026-07-06T17:36:43.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/43/7bdca8f733c45ce97f61a64fadd3e51d255c4c9b467345cbf71ccc7bb368/ijson-3.5.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a19413a092d458a57aaa574fec08e265851d3b5c6e018377f426cd5e70b91280", size = 138889, upload-time = "2026-07-06T17:36:45.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/e8a2e63700ab1d63aaf3fa38c454f8178eaa5b80a6d7c019d1d61b490a6c/ijson-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65974568748678165d7e90e3e7ce2f7c233cfe4de6c37fbb0760941c97e14632", size = 149933, upload-time = "2026-07-06T17:36:46.312Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/56/640a4d980f7f2c11e399a7fd5ccb9e3d3c9e1dec3a1d5a10024570697c25/ijson-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bad5d55c99c89de8cd0a4cded51f86427ba3353c4dccca37ec2e32e06f26b437", size = 149857, upload-time = "2026-07-06T17:36:47.309Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a1/c953e22c83992b69ae538a83b3678d28768f1a48042fc7794733423a5ce7/ijson-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1a38d503ce343952e88edfd9a27296a4ec96af7073a9db58b3df6233367f75fc", size = 151141, upload-time = "2026-07-06T17:36:48.405Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ab/8fe5b7269b140e6e5f8837a33ce980fd9b67c70d0f8114289ed1cea4dace/ijson-3.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2f41982c73896acab4a2a14faa14e152e444bd69f37c3139204429fd3fe65a10", size = 143112, upload-time = "2026-07-06T17:36:50.353Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f3/23d1284edcde50ba337ddfba5b5d59f8273084d98b28af94715e73dd2b64/ijson-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3321fede2b638d400de0036889a3a25c3bb689feb8df45e70a393346aad6194f", size = 152184, upload-time = "2026-07-06T17:36:51.536Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4e/df61be89dd295e4da722ec96ba03b1765bcb2becdaaaede9c96a7d2365b6/ijson-3.5.1-cp313-cp313-win32.whl", hash = "sha256:af6ddbd10ac9bce87a835f2de3ec61455ec435c54e7e0ba7b17c31c66de6f164", size = 52607, upload-time = "2026-07-06T17:36:52.596Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d9/03e5dbd3ef7e0cee06fbef0f87b91d7ce1c07fae9b5a1b0ca8b895de62c4/ijson-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:1de3de278b0ffb40338374ad2a730e1c56f933e0706b1815ebeb07b82239b1a3", size = 54730, upload-time = "2026-07-06T17:36:53.526Z" },
+    { url = "https://files.pythonhosted.org/packages/38/30/4f37076c88a96a1a5e44df38b59fade4f59eaef87ef8b5162d55b2d426d5/ijson-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:c8a36a19b92cb7172c6448ab94f446033cfa3129dc4894aebe205f96b3fabf42", size = 53719, upload-time = "2026-07-06T17:36:54.592Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ea/f42470cc773c8686dd0823da8aefc31a138cd9aea1ad476d43c8293068da/ijson-3.5.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:077b1b0bcb6a622d460c6674fe6647c7af5a3b06503e1996d1efcf9f78c94512", size = 57830, upload-time = "2026-07-06T17:37:37.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2f/64c61edab2c5ecf42a524146a70fa6171c8cf3960b947fb4c5f175660cb3/ijson-3.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e8dbf71b21e65cb7f0d4d387c07fe73be820168070c3be05a0763a80f424f1c7", size = 57325, upload-time = "2026-07-06T17:37:38.017Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/5b/553ea8f14dfc756d6b6c9be2e2231ab44877ce96408eb9da3bb3f11ddd13/ijson-3.5.1-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d7c5025a820f36f3e0e64f4b0232b338c690664c12b497e205cf64dcc64fc12", size = 71344, upload-time = "2026-07-06T17:37:38.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3e/0248fd00746731074ca01365a25d8aa3c4d54642c8a14490d94f7550bda9/ijson-3.5.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa7a2c94e43c02e0482088e6ff997e2bd7b9a76e6f1d0fd70891b4b5ff51318f", size = 71335, upload-time = "2026-07-06T17:37:39.965Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b9/1f1259546cc875adad240c468515f428d3a79b3def3ced17be3cdfe29146/ijson-3.5.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:69b5eef70240e9734c5a2fb5cc3742cae411fc833a66b9a50722b9eedb1e27de", size = 68728, upload-time = "2026-07-06T17:37:40.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/02/aafbf0c3e1468c7c0f607065363b49c381de7e4bb43ae6674684a3fafe92/ijson-3.5.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b75b6bf4b0dbb0df24947db6722cd5723ce8d6e6b13fddbfc98db312ba82237", size = 54922, upload-time = "2026-07-06T17:37:41.879Z" },
+]
+
+[[package]]
 name = "importlib-resources"
 version = "5.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1471,6 +1533,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+coco = [
+    { name = "ijson" },
+]
+
 [package.dev-dependencies]
 docs = [
     { name = "griffe" },
@@ -1490,6 +1557,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.0.0,<2.0.0" },
     { name = "fastapi", specifier = ">=0.103.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
+    { name = "ijson", marker = "extra == 'coco'", specifier = ">=3.2,<4.0" },
     { name = "importlib-resources", specifier = ">=5.12.0,<6.0.0" },
     { name = "ipywidgets", specifier = ">=8.0.0,<9.0.0" },
     { name = "jinja2", specifier = ">=3.1.2,<4.0.0" },
@@ -1512,6 +1580,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9.0,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.20.0,<1.0.0" },
 ]
+provides-extras = ["coco"]
 
 [package.metadata.requires-dev]
 docs = [{ name = "griffe", specifier = ">=1.0.0" }]


### PR DESCRIPTION
## Issue

P3.1 of the 0.8.0 redesign (spec §7.2). Based directly on `arch/data-import` — no stack.

## Description

The second real format lands on the io core:

- **`CocoImporter`** — two-pass streaming: pass 1 streams `annotations` into an index keyed by `image_id` (**SQLite spill** above a row threshold, so annotation files larger than RAM import in bounded memory); pass 2 streams `images` joining the index. `ijson` (the new `coco` extra) enables true streaming; without it the file loads whole with a warning Finding at analyze — never silently.
- **Intrinsic schema** via a new `DatasetImporter.resolve_info` hook: COCO knows its own schema (entity `category`/`supercategory`/`iscrowd` + bbox/mask/keypoint tables), while a user-declared schema block still wins. LeRobot will use the same hook.
- **Mappings**: absolute `xywh` boxes normalize against image dims; polygon segmentation → `CompressedRLE.from_polygons`, uncompressed RLE dicts → `from_urle`, compressed counts pass through; keypoints → the `coco-17` template with `v={0,1,2}` → invisible/hidden/visible; `file_name` resolves under `<split>/`, `image/<split>/`, `images/<split>/`; **uri mode** stores `coco_url` verbatim (missing url is an analyze error, per the §6 media contract).
- Deterministic ids, resume cursor `{split, image_ordinal}`, detection on `instances_*.json`, analyze validates media existence and category references. Grid previews come free from the engine (#680).

8 tests: fixture end-to-end (exact counts, idempotent rerun, namespaced ids), **spill path id-identical to the in-memory path**, cursor resume, detection, synthetic keypoints+polygons, unknown-category analyze error, uri mode. Full suite green (585).

Next: the COCO exporter + round-trip (P3.2), then LeRobot with the frames-to-SequenceFrame default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)