### PR TITLE
feat: add the LeRobot importer with frames-to-SequenceFrame default

### DIFF
--- a/src/pixano/datasets/io/__init__.py
+++ b/src/pixano/datasets/io/__init__.py
@@ -27,7 +27,15 @@ from .errors import (
 from .ids import IdLedger, namespace_prefix, stable_id
 from .importer import BatchBundle, Cursor, DatasetImporter, DetectResult, SourceRef
 from .manifest import ImportManifest
-from .media import MediaResolver, ResolvedMedia, VideoProbe, ffprobe_available, probe_image, probe_video
+from .media import (
+    MediaResolver,
+    ResolvedMedia,
+    VideoProbe,
+    ffmpeg_available,
+    ffprobe_available,
+    probe_image,
+    probe_video,
+)
 from .plan import AnalyzeLimits, Finding, ImportPlan, PreflightReport, Provenance, SamplePreview
 from .progress import ProgressEvent, ProgressSink, ThrottledSink, TqdmSink
 from .reader import RecordBundle, RecordBundleReader
@@ -78,6 +86,8 @@ __all__ = [
     "TqdmSink",
     "UnsupportedStorageError",
     "VideoProbe",
+    "ffmpeg_available",
+    "ffmpeg_available",
     "ffprobe_available",
     "analyze",
     "export_dataset",
@@ -94,8 +104,10 @@ __all__ = [
 
 # Built-in formats register on package import (entry-point plugins load lazily).
 from .formats.coco.importer import COCO  # noqa: E402
+from .formats.lerobot.importer import LEROBOT  # noqa: E402
 from .formats.pixano_jsonl.importer import PIXANO_JSONL  # noqa: E402
 
 
 FORMATS.register(PIXANO_JSONL)
 FORMATS.register(COCO)
+FORMATS.register(LEROBOT)

--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -94,7 +94,7 @@ def import_dataset(
         )
 
     if info is None:
-        info = resolved.resolve_info(spec)
+        info = resolved.resolve_info(spec, source_ref)
     if spec.dataset.name:
         info.name = spec.dataset.name
     if spec.dataset.description:

--- a/src/pixano/datasets/io/formats/coco/importer.py
+++ b/src/pixano/datasets/io/formats/coco/importer.py
@@ -151,7 +151,7 @@ class CocoImporter(DatasetImporter):
             return DetectResult(confidence=0.9, evidence=f"{files[0][1].name}")
         return None
 
-    def resolve_info(self, spec: ImportSpec) -> DatasetInfo:
+    def resolve_info(self, spec: ImportSpec, source: SourceRef | None = None) -> DatasetInfo:
         """COCO has an intrinsic schema; a user-declared schema block still wins."""
         if spec.schema_ is not None or spec.schema_manifest is not None:
             return resolve_dataset_info(spec)

--- a/src/pixano/datasets/io/formats/lerobot/__init__.py
+++ b/src/pixano/datasets/io/formats/lerobot/__init__.py
@@ -1,0 +1,12 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""LeRobot format: episodes as annotatable frame sequences (spec §7.3)."""
+
+from .importer import LEROBOT, LeRobotImporter
+
+
+__all__ = ["LEROBOT", "LeRobotImporter"]

--- a/src/pixano/datasets/io/formats/lerobot/importer.py
+++ b/src/pixano/datasets/io/formats/lerobot/importer.py
@@ -1,0 +1,345 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""The LeRobot importer: episodes become annotatable frame sequences (spec §7.3).
+
+Default mode extracts each episode's camera footage to `SequenceFrame` rows
+(the DAVIS pattern) because the 0.8 UI displays and annotates frame
+sequences. Scale guards: `max_frames_per_episode` uniform stride and the
+plan's size estimate. The opt-in `frames: "reference"` mode emits `Video`
+time-window rows instead (browse-scale, no annotation UI in 0.8).
+
+Options (ImportSpec.options): `episodes` (list or "start:end"), `frames`
+("extract" | "reference"), `max_frames_per_episode` (int).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+from lancedb.pydantic import LanceModel
+
+from pixano.datasets.dataset_info import DatasetInfo
+from pixano.schemas import canonical_table_name_for_schema
+
+from ...errors import MetadataError
+from ...ids import stable_id
+from ...importer import BatchBundle, Cursor, DatasetImporter, DetectResult, SourceRef
+from ...media import MediaResolver, ffmpeg_available, ffprobe_available, probe_video
+from ...plan import AnalyzeLimits, ImportPlan, Provenance, SamplePreview
+from ...registry import Capabilities, DataFormat
+from ...spec import ImportSpec, resolve_dataset_info
+from .layout import Episode, LeRobotLayout, camera_view_name, parse_episode_selection, parse_layout
+
+
+_JPEG_BYTES_PER_PIXEL = 0.12  # rough JPEG size estimate for the analyze plan
+
+
+class LeRobotImporter(DatasetImporter):
+    """Importer for LeRobot v2.1 and v3 datasets (local directories)."""
+
+    format_name = "lerobot"
+    importer_version = "1.0.0"
+    supports_resume = True
+    deterministic_ids = True
+
+    # ------------------------------------------------------------------
+    # Detection & schema
+    # ------------------------------------------------------------------
+
+    def probe(self, source: SourceRef) -> DetectResult | None:
+        """Sniff for meta/info.json carrying a LeRobot codebase_version."""
+        if source.path is None or not (source.path / "meta" / "info.json").is_file():
+            return None
+        content = (source.path / "meta" / "info.json").read_text(encoding="utf-8")
+        if "codebase_version" in content and "fps" in content:
+            return DetectResult(confidence=0.95, evidence="meta/info.json with codebase_version")
+        return None
+
+    def resolve_info(self, spec: ImportSpec, source: SourceRef | None = None) -> DatasetInfo:
+        """LeRobot's schema depends on the source's cameras; a user schema still wins."""
+        if spec.schema_ is not None or spec.schema_manifest is not None or source is None or source.path is None:
+            return resolve_dataset_info(spec)
+        layout = parse_layout(source.path)
+        view_kind = "sequence_frames" if self._frames_mode(spec) == "extract" else "video"
+        payload = spec.model_dump(exclude_none=True, by_alias=True)
+        payload["schema"] = {
+            "views": {camera_view_name(key): {"kind": view_kind} for key in layout.video_keys},
+            "record": {
+                "attrs": {
+                    "episode_index": "int",
+                    "tasks": {"type": "str", "collection": True},
+                    "length": "int",
+                }
+            },
+            "annotations": ["bbox", "mask", "tracklet"],
+        }
+        return resolve_dataset_info(ImportSpec.model_validate(payload))
+
+    @staticmethod
+    def _frames_mode(spec: ImportSpec) -> str:
+        mode = str(spec.options.get("frames", "extract"))
+        if mode not in ("extract", "reference"):
+            raise MetadataError(f"Invalid frames mode '{mode}' (extract or reference).")
+        return mode
+
+    # ------------------------------------------------------------------
+    # Analyze
+    # ------------------------------------------------------------------
+
+    def analyze(self, source: SourceRef, spec: ImportSpec, limits: AnalyzeLimits) -> ImportPlan:
+        """Parse the layout, validate tooling and codecs, and estimate the extract size."""
+        plan = ImportPlan(format=self.format_name, importer_version=self.importer_version)
+        if source.path is None or not source.path.is_dir():
+            plan.report.add("invalid_source", Provenance(file=source.location()), suggestion="Expected a directory.")
+            return plan
+        try:
+            layout = parse_layout(source.path)
+        except MetadataError as error:
+            plan.report.add("invalid_layout", Provenance(file=str(source.path)), suggestion=str(error))
+            return plan
+
+        episodes = self._select_episodes(layout, spec)
+        mode = self._frames_mode(spec)
+        provenance = Provenance(file=str(source.path / "meta" / "info.json"))
+
+        if mode == "extract" and not (ffmpeg_available() and ffprobe_available()):
+            plan.report.add(
+                "ffmpeg_required",
+                provenance,
+                suggestion="Frame extraction needs ffmpeg+ffprobe on PATH; install ffmpeg or use "
+                'options {"frames": "reference"}.',
+            )
+
+        # Probe one shard per camera: codec finding + size estimate.
+        total_frames = 0
+        for key in layout.video_keys:
+            first = next((episode.cameras[key] for episode in episodes if key in episode.cameras), None)
+            if first is None:
+                continue
+            shard = source.path / first.video_path
+            if not shard.is_file():
+                plan.report.add(
+                    "missing_media",
+                    Provenance(file=str(shard)),
+                    suggestion=f"Video shard for camera '{key}' not found.",
+                )
+                continue
+            if ffprobe_available():
+                probe = probe_video(shard)
+                if probe.codec == "av1":
+                    plan.report.add(
+                        "av1_codec",
+                        Provenance(file=str(shard)),
+                        severity="warning",
+                        suggestion="AV1 shards decode for frame extraction but do not play in Safari; "
+                        "documented limitation.",
+                    )
+                if mode == "extract":
+                    cap = self._max_frames(spec)
+                    for episode in episodes:
+                        camera = episode.cameras.get(key)
+                        if camera is None:
+                            continue
+                        duration = (
+                            camera.to_timestamp - camera.from_timestamp if camera.to_timestamp > 0 else probe.duration
+                        )
+                        episode_frames = int(duration * layout.fps) if layout.fps else probe.num_frames
+                        total_frames += min(episode_frames, cap) if cap else episode_frames
+                    plan.totals.media_bytes = int(
+                        (plan.totals.media_bytes or 0)
+                        + total_frames * probe.width * probe.height * _JPEG_BYTES_PER_PIXEL
+                    )
+
+        for episode in episodes[: limits.max_previews]:
+            plan.previews.append(
+                SamplePreview(
+                    record={"episode_index": episode.index, "tasks": episode.tasks, "length": episode.length}
+                )
+            )
+        plan.splits["train"] = len(episodes)
+        plan.totals.records = len(episodes)
+        return plan
+
+    @staticmethod
+    def _select_episodes(layout: LeRobotLayout, spec: ImportSpec) -> list[Episode]:
+        available = [episode.index for episode in layout.episodes]
+        selected = set(parse_episode_selection(spec.options.get("episodes"), available))
+        return [episode for episode in layout.episodes if episode.index in selected]
+
+    @staticmethod
+    def _max_frames(spec: ImportSpec) -> int:
+        return int(spec.options.get("max_frames_per_episode", 0) or 0)
+
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    def iter_batches(
+        self,
+        source: SourceRef,
+        spec: ImportSpec,
+        plan: ImportPlan,
+        cursor: Cursor | None = None,
+    ) -> Iterator[BatchBundle]:
+        """One bundle per episode; frames extracted (default) or window rows emitted."""
+        assert source.path is not None
+        info = self.resolve_info(spec, source)
+        layout = parse_layout(source.path)
+        episodes = self._select_episodes(layout, spec)
+        mode = self._frames_mode(spec)
+        namespace = spec.ids.namespace or source.path.name
+        resolver = MediaResolver(spec.media, base_dir=source.path)
+        resume_ordinal = int(cursor.get("episode_ordinal", 0)) if cursor else 0
+
+        for ordinal, episode in enumerate(episodes, start=1):
+            if ordinal <= resume_ordinal:
+                continue
+            record_id = stable_id(namespace, "train", episode.index)
+            assert info.record is not None
+            tables: dict[str, list[LanceModel]] = {
+                "records": [
+                    info.record(
+                        id=record_id,
+                        split="train",
+                        episode_index=episode.index,
+                        tasks=episode.tasks,
+                        length=episode.length,
+                    )
+                ]
+            }
+            for key, camera in sorted(episode.cameras.items()):
+                view_name = camera_view_name(key)
+                shard = source.path / camera.video_path
+                if mode == "extract":
+                    rows = self._extract_frames(
+                        info, layout, spec, record_id, view_name, shard, camera.from_timestamp, camera.to_timestamp
+                    )
+                else:
+                    rows = [self._video_row(info, layout, resolver, record_id, view_name, camera, shard, source.path)]
+                for row in rows:
+                    tables.setdefault(canonical_table_name_for_schema(type(row)), []).append(row)
+            yield BatchBundle(
+                tables=tables,
+                cursor={"episode_ordinal": ordinal},
+                provenance=Provenance(file=str(source.path), record_key=str(episode.index)),
+            )
+
+    def _extract_frames(
+        self,
+        info: DatasetInfo,
+        layout: LeRobotLayout,
+        spec: ImportSpec,
+        record_id: str,
+        view_name: str,
+        shard: Path,
+        from_timestamp: float,
+        to_timestamp: float,
+    ) -> list[LanceModel]:
+        if not shard.is_file():
+            raise MetadataError(f"Video shard not found: {shard}")
+        probe = probe_video(shard)
+        fps = layout.fps or probe.fps
+
+        with tempfile.TemporaryDirectory(prefix="pixano-lerobot-") as tmp:
+            command = ["ffmpeg", "-nostdin", "-v", "error"]
+            if from_timestamp > 0:
+                command += ["-ss", f"{from_timestamp:.6f}"]
+            command += ["-i", str(shard)]
+            if to_timestamp > 0:
+                command += ["-t", f"{to_timestamp - from_timestamp:.6f}"]
+            command += ["-vf", f"fps={fps}", "-q:v", "2", f"{tmp}/%06d.jpg"]
+            result = subprocess.run(command, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise MetadataError(f"ffmpeg frame extraction failed on '{shard.name}': {result.stderr.strip()[:200]}")
+
+            frame_files = sorted(Path(tmp).glob("*.jpg"))
+            cap = self._max_frames(spec)
+            if cap and len(frame_files) > cap:
+                stride = len(frame_files) / cap
+                frame_files = [frame_files[int(position * stride)] for position in range(cap)]
+
+            view_cls = info.views[view_name]
+            rows: list[LanceModel] = []
+            for frame_index, frame_file in enumerate(frame_files):
+                rows.append(
+                    view_cls(
+                        id=stable_id(record_id, "view", view_name, frame_index),
+                        record_id=record_id,
+                        logical_name=view_name,
+                        uri="",
+                        raw_bytes=frame_file.read_bytes(),
+                        width=probe.width,
+                        height=probe.height,
+                        format="JPEG",
+                        frame_index=frame_index,
+                        timestamp=from_timestamp + frame_index / fps if fps else float(frame_index),
+                    )
+                )
+            return rows
+
+    def _video_row(
+        self,
+        info: DatasetInfo,
+        layout: LeRobotLayout,
+        resolver: MediaResolver,
+        record_id: str,
+        view_name: str,
+        camera: object,
+        shard: Path,
+        root: Path,
+    ) -> LanceModel:
+        from .layout import EpisodeCamera
+
+        assert isinstance(camera, EpisodeCamera)
+        resolved = resolver.resolve(str(shard.relative_to(root)))
+        width = height = 0
+        num_frames = 0
+        duration = 0.0
+        fps = layout.fps
+        if shard.is_file() and ffprobe_available():
+            probe = probe_video(shard)
+            width, height, fps = probe.width, probe.height, layout.fps or probe.fps
+            duration = camera.to_timestamp - camera.from_timestamp if camera.to_timestamp > 0 else probe.duration
+            num_frames = int(duration * fps) if fps else probe.num_frames
+        view_cls = info.views[view_name]
+        return view_cls(
+            id=stable_id(record_id, "view", view_name),
+            record_id=record_id,
+            logical_name=view_name,
+            uri=resolved.uri,
+            raw_bytes=resolved.raw_bytes,
+            fps=fps,
+            width=width,
+            height=height,
+            num_frames=num_frames,
+            duration=duration,
+            format=shard.suffix.removeprefix("."),
+            from_timestamp=camera.from_timestamp,
+            to_timestamp=camera.to_timestamp,
+        )
+
+
+def _detect(source: SourceRef) -> DetectResult | None:
+    return LeRobotImporter().probe(source)
+
+
+LEROBOT = DataFormat(
+    name="lerobot",
+    title="LeRobot (v2.1 / v3)",
+    importer_cls=LeRobotImporter,
+    capabilities=Capabilities(
+        media_kinds=frozenset({"sequence_frames", "video"}),
+        annotation_kinds=frozenset(),
+        source_kinds=frozenset({"local_dir"}),
+        supports_resume=True,
+        deterministic_ids=True,
+    ),
+    detect=_detect,
+)

--- a/src/pixano/datasets/io/formats/lerobot/layout.py
+++ b/src/pixano/datasets/io/formats/lerobot/layout.py
@@ -1,0 +1,171 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""LeRobot dataset layout parsing — pyarrow-only, no `lerobot` dependency (spec §7.3).
+
+Supports the v2.1 layout (one parquet/video file per episode) and the v3
+layout (episodes concatenated into shard files, located through the episodes
+metadata parquet with per-camera time windows).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ...errors import MetadataError
+from ...plan import Provenance
+
+
+@dataclass
+class EpisodeCamera:
+    """Where one camera's footage for one episode lives."""
+
+    video_path: str  # relative to the dataset root
+    from_timestamp: float = 0.0
+    to_timestamp: float = -1.0  # -1 = whole file (v2.1)
+
+
+@dataclass
+class Episode:
+    """One episode: record attrs plus per-camera video references."""
+
+    index: int
+    tasks: list[str] = field(default_factory=list)
+    length: int = 0
+    cameras: dict[str, EpisodeCamera] = field(default_factory=dict)
+
+
+@dataclass
+class LeRobotLayout:
+    """Parsed dataset structure shared by analyze and ingest."""
+
+    version: str
+    fps: float
+    video_keys: list[str]
+    episodes: list[Episode]
+    robot_type: str = ""
+
+
+def camera_view_name(video_key: str) -> str:
+    """Short logical view name for a camera key ('observation.images.top' -> 'top')."""
+    return video_key.rsplit(".", 1)[-1]
+
+
+def parse_layout(root: Path) -> LeRobotLayout:
+    """Parse meta/info.json and the episode metadata for v2.1 or v3 layouts."""
+    info_path = root / "meta" / "info.json"
+    if not info_path.is_file():
+        raise MetadataError("Not a LeRobot dataset: meta/info.json is missing.", Provenance(file=str(root)))
+    info = json.loads(info_path.read_text(encoding="utf-8"))
+    version = str(info.get("codebase_version", ""))
+    fps = float(info.get("fps", 0) or 0)
+    features = info.get("features", {}) or {}
+    video_keys = sorted(key for key, feature in features.items() if feature.get("dtype") == "video")
+
+    if version.startswith("v3"):
+        episodes = _parse_v3_episodes(root, info, video_keys)
+    elif version.startswith("v2"):
+        episodes = _parse_v21_episodes(root, info, video_keys)
+    else:
+        raise MetadataError(
+            f"Unsupported LeRobot codebase_version '{version}' (supported: v2.x, v3.x).",
+            Provenance(file=str(info_path)),
+        )
+    return LeRobotLayout(
+        version=version,
+        fps=fps,
+        video_keys=video_keys,
+        episodes=episodes,
+        robot_type=str(info.get("robot_type", "") or ""),
+    )
+
+
+def _parse_v21_episodes(root: Path, info: dict, video_keys: list[str]) -> list[Episode]:
+    episodes_file = root / "meta" / "episodes.jsonl"
+    if not episodes_file.is_file():
+        raise MetadataError("v2.1 layout: meta/episodes.jsonl is missing.", Provenance(file=str(episodes_file)))
+    template = str(
+        info.get("video_path", "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4")
+    )
+    chunks_size = int(info.get("chunks_size", 1000) or 1000)
+
+    episodes: list[Episode] = []
+    for line in episodes_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        index = int(payload["episode_index"])
+        cameras = {
+            key: EpisodeCamera(
+                video_path=template.format(episode_chunk=index // chunks_size, video_key=key, episode_index=index)
+            )
+            for key in video_keys
+        }
+        tasks = payload.get("tasks", [])
+        episodes.append(
+            Episode(
+                index=index,
+                tasks=list(tasks) if isinstance(tasks, list) else [str(tasks)],
+                length=int(payload.get("length", 0) or 0),
+                cameras=cameras,
+            )
+        )
+    return sorted(episodes, key=lambda episode: episode.index)
+
+
+def _parse_v3_episodes(root: Path, info: dict, video_keys: list[str]) -> list[Episode]:
+    import pyarrow.parquet as pq
+
+    episodes_dir = root / "meta" / "episodes"
+    parquet_files = sorted(episodes_dir.rglob("*.parquet"))
+    if not parquet_files:
+        raise MetadataError("v3 layout: no parquet files under meta/episodes/.", Provenance(file=str(episodes_dir)))
+    template = str(info.get("video_path", "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"))
+
+    episodes: list[Episode] = []
+    for parquet_file in parquet_files:
+        table = pq.read_table(parquet_file)
+        rows = table.to_pylist()
+        for payload in rows:
+            index = int(payload["episode_index"])
+            cameras: dict[str, EpisodeCamera] = {}
+            for key in video_keys:
+                cameras[key] = EpisodeCamera(
+                    video_path=template.format(
+                        video_key=key,
+                        chunk_index=int(payload.get(f"videos/{key}/chunk_index", 0) or 0),
+                        file_index=int(payload.get(f"videos/{key}/file_index", 0) or 0),
+                    ),
+                    from_timestamp=float(payload.get(f"videos/{key}/from_timestamp", 0.0) or 0.0),
+                    to_timestamp=float(payload.get(f"videos/{key}/to_timestamp", -1.0) or -1.0),
+                )
+            tasks = payload.get("tasks", [])
+            episodes.append(
+                Episode(
+                    index=index,
+                    tasks=list(tasks) if isinstance(tasks, list) else [str(tasks)],
+                    length=int(payload.get("length", 0) or 0),
+                    cameras=cameras,
+                )
+            )
+    return sorted(episodes, key=lambda episode: episode.index)
+
+
+def parse_episode_selection(selection: object, available: list[int]) -> list[int]:
+    """Resolve the `episodes` option: a list of ints or an inclusive 'start:end' range."""
+    if selection is None:
+        return available
+    if isinstance(selection, str):
+        start_str, _, end_str = selection.partition(":")
+        start = int(start_str) if start_str else min(available, default=0)
+        end = int(end_str) if end_str else max(available, default=-1)
+        return [index for index in available if start <= index <= end]
+    if isinstance(selection, (list, tuple)):
+        wanted = {int(value) for value in selection}
+        return [index for index in available if index in wanted]
+    raise MetadataError(f"Invalid episodes selection: {selection!r} (list of ints or 'start:end').")

--- a/src/pixano/datasets/io/importer.py
+++ b/src/pixano/datasets/io/importer.py
@@ -117,12 +117,13 @@ class DatasetImporter(ABC):
         """
         return None
 
-    def resolve_info(self, spec: "ImportSpec") -> "DatasetInfo":
+    def resolve_info(self, spec: "ImportSpec", source: SourceRef | None = None) -> "DatasetInfo":
         """Resolve the target schema for this format.
 
         The default honors the user's spec (schema block, manifest, or
         workspace preset). Formats with an intrinsic schema (COCO, LeRobot)
-        override this to supply it when the spec declares none.
+        override this to supply it when the spec declares none; ``source``
+        is provided so source-dependent schemas (LeRobot cameras) can look.
         """
         from .spec import resolve_dataset_info
 

--- a/src/pixano/datasets/io/media.py
+++ b/src/pixano/datasets/io/media.py
@@ -57,6 +57,11 @@ class ResolvedMedia:
     raw_bytes: bytes = b""
 
 
+def ffmpeg_available() -> bool:
+    """True when the ffmpeg binary is on PATH (frame extraction, clip embedding)."""
+    return shutil.which("ffmpeg") is not None
+
+
 def ffprobe_available() -> bool:
     """Whether the ffprobe binary is on PATH."""
     return shutil.which("ffprobe") is not None

--- a/tests/datasets/io/formats/test_lerobot_importer.py
+++ b/tests/datasets/io/formats/test_lerobot_importer.py
@@ -1,0 +1,210 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import json
+import shutil
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from pixano.datasets import Dataset
+from pixano.datasets.io import FORMATS, ImportSpec, SourceRef, ffmpeg_available, ffprobe_available, import_dataset
+from pixano.datasets.io.formats.lerobot import LeRobotImporter
+from pixano.datasets.io.formats.lerobot.layout import parse_episode_selection, parse_layout
+from tests.assets.sample_data.metadata import VIDEO_MP4_ASSET_URL, VIDEO_MP4_METADATA
+
+
+needs_ffmpeg = pytest.mark.skipif(
+    not (ffmpeg_available() and ffprobe_available()), reason="ffmpeg/ffprobe not installed"
+)
+
+CAMERA_KEY = "observation.images.top"
+FPS = VIDEO_MP4_METADATA["fps"]
+
+
+def make_v21_dataset(root: Path, episodes: int = 2) -> Path:
+    """Synthetic v2.1 layout: one video file per episode (copies of the sample video)."""
+    (root / "meta").mkdir(parents=True)
+    info = {
+        "codebase_version": "v2.1",
+        "robot_type": "so100",
+        "fps": FPS,
+        "chunks_size": 1000,
+        "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
+        "features": {CAMERA_KEY: {"dtype": "video"}, "action": {"dtype": "float32"}},
+        "total_episodes": episodes,
+    }
+    (root / "meta" / "info.json").write_text(json.dumps(info))
+    lines = [
+        json.dumps({"episode_index": index, "tasks": [f"task {index}"], "length": 100 + index})
+        for index in range(episodes)
+    ]
+    (root / "meta" / "episodes.jsonl").write_text("\n".join(lines) + "\n")
+    for index in range(episodes):
+        target = root / "videos" / "chunk-000" / CAMERA_KEY / f"episode_{index:06d}.mp4"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(VIDEO_MP4_ASSET_URL, target)
+    return root
+
+
+def make_v3_dataset(root: Path) -> Path:
+    """Synthetic v3 layout: two episodes as windows into one shared video shard."""
+    (root / "meta" / "episodes" / "chunk-000").mkdir(parents=True)
+    info = {
+        "codebase_version": "v3.0",
+        "fps": FPS,
+        "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        "features": {CAMERA_KEY: {"dtype": "video"}},
+        "total_episodes": 2,
+    }
+    (root / "meta" / "info.json").write_text(json.dumps(info))
+    table = pa.table(
+        {
+            "episode_index": [0, 1],
+            "tasks": [["pick"], ["place"]],
+            "length": [90, 88],
+            f"videos/{CAMERA_KEY}/chunk_index": [0, 0],
+            f"videos/{CAMERA_KEY}/file_index": [0, 0],
+            f"videos/{CAMERA_KEY}/from_timestamp": [0.0, 3.0],
+            f"videos/{CAMERA_KEY}/to_timestamp": [3.0, 6.5],
+        }
+    )
+    pq.write_table(table, root / "meta" / "episodes" / "chunk-000" / "file-000.parquet")
+    shard = root / "videos" / CAMERA_KEY / "chunk-000" / "file-000.mp4"
+    shard.parent.mkdir(parents=True)
+    shutil.copy(VIDEO_MP4_ASSET_URL, shard)
+    return root
+
+
+def _spec(name: str, **options) -> ImportSpec:
+    return ImportSpec.model_validate(
+        {
+            "dataset": {"name": name, "workspace": "video"},
+            "format": "lerobot",
+            "ids": {"namespace": "lr"},
+            "options": options,
+        }
+    )
+
+
+class TestLayoutParsing:
+    def test_v21_layout(self, tmp_path: Path):
+        layout = parse_layout(make_v21_dataset(tmp_path / "ds"))
+        assert layout.version == "v2.1" and layout.video_keys == [CAMERA_KEY]
+        assert [episode.index for episode in layout.episodes] == [0, 1]
+        camera = layout.episodes[1].cameras[CAMERA_KEY]
+        assert camera.video_path.endswith("episode_000001.mp4")
+        assert camera.to_timestamp == -1.0  # whole file
+
+    def test_v3_layout_windows(self, tmp_path: Path):
+        layout = parse_layout(make_v3_dataset(tmp_path / "ds"))
+        cameras = [episode.cameras[CAMERA_KEY] for episode in layout.episodes]
+        assert (cameras[0].from_timestamp, cameras[0].to_timestamp) == (0.0, 3.0)
+        assert (cameras[1].from_timestamp, cameras[1].to_timestamp) == (3.0, 6.5)
+        assert cameras[0].video_path == cameras[1].video_path  # shared shard
+
+    def test_episode_selection(self):
+        assert parse_episode_selection(None, [0, 1, 2]) == [0, 1, 2]
+        assert parse_episode_selection("1:2", [0, 1, 2]) == [1, 2]
+        assert parse_episode_selection([2, 0], [0, 1, 2]) == [0, 2]
+
+
+class TestLeRobotImport:
+    def test_detection(self, tmp_path: Path):
+        source = make_v21_dataset(tmp_path / "ds")
+        assert FORMATS.detect(SourceRef.from_string(str(source))).name == "lerobot"
+
+    @needs_ffmpeg
+    def test_v21_extract_default(self, tmp_path: Path):
+        source = make_v21_dataset(tmp_path / "ds")
+        spec = _spec("lr_v21", max_frames_per_episode=8)
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        dataset = Dataset(result.dataset_path)
+
+        assert dataset.open_table("records").count_rows() == 2
+        assert dataset.open_table("sequence_frames").count_rows() == 16  # 8 per episode (capped)
+        record = sorted(dataset.get_data("records"), key=lambda r: r.episode_index)[0]
+        assert record.tasks == ["task 0"] and record.length == 100
+        frame_row = (
+            dataset.open_table("sequence_frames")
+            .search()
+            .select(["raw_bytes", "format", "preview"])
+            .limit(1)
+            .to_list()[0]
+        )
+        assert frame_row["raw_bytes"] and frame_row["format"] == "JPEG"
+        assert frame_row["preview"]  # engine-stamped grid thumbnail
+        assert dataset.info.storage_mode == "embedded"
+
+    @needs_ffmpeg
+    def test_v3_windows_extract_disjoint_frames(self, tmp_path: Path):
+        source = make_v3_dataset(tmp_path / "ds")
+        spec = _spec("lr_v3", max_frames_per_episode=6)
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        dataset = Dataset(result.dataset_path)
+
+        assert dataset.open_table("records").count_rows() == 2
+        assert dataset.open_table("sequence_frames").count_rows() == 12
+        frames = dataset.get_data("sequence_frames", limit=20)
+        by_record: dict[str, list[float]] = {}
+        for frame in frames:
+            by_record.setdefault(frame.record_id, []).append(frame.timestamp)
+        first, second = sorted(by_record.values(), key=min)
+        assert max(first) < 3.05 and min(second) >= 2.95  # windows respected
+
+    @needs_ffmpeg
+    def test_episode_subset_and_idempotent_rerun(self, tmp_path: Path):
+        source = make_v21_dataset(tmp_path / "ds")
+        spec = _spec("lr_subset", episodes=[1], max_frames_per_episode=4)
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        dataset = Dataset(result.dataset_path)
+        assert dataset.open_table("records").count_rows() == 1
+        assert dataset.get_data("records")[0].episode_index == 1
+
+        add_spec = spec.model_copy(update={"mode": "add"})
+        import_dataset(source, tmp_path / "data", add_spec, importer=LeRobotImporter())
+        assert dataset.open_table("records").count_rows() == 1
+        assert dataset.open_table("sequence_frames").count_rows() == 4
+
+    @needs_ffmpeg
+    def test_reference_mode_emits_video_windows(self, tmp_path: Path):
+        source = make_v3_dataset(tmp_path / "ds")
+        spec = _spec("lr_ref", frames="reference")
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        dataset = Dataset(result.dataset_path)
+
+        assert dataset.open_table("records").count_rows() == 2
+        videos = sorted(
+            dataset.open_table("videos").search().select(["from_timestamp", "to_timestamp", "raw_bytes"]).to_list(),
+            key=lambda video: video["from_timestamp"],
+        )
+        assert [video["to_timestamp"] for video in videos] == [3.0, 6.5]
+        assert videos[0]["raw_bytes"]  # embed mode: shard bytes stored
+
+    def test_analyze_reports_plan(self, tmp_path: Path):
+        source = make_v21_dataset(tmp_path / "ds")
+        plan = LeRobotImporter().analyze(
+            SourceRef.from_string(str(source)),
+            _spec("lr_plan", max_frames_per_episode=8),
+            __import__("pixano.datasets.io.plan", fromlist=["AnalyzeLimits"]).AnalyzeLimits(),
+        )
+        assert plan.totals.records == 2
+        assert plan.report.is_valid
+        if ffprobe_available():
+            assert (plan.totals.media_bytes or 0) > 0  # extract-size estimate present
+
+    def test_invalid_frames_mode_rejected(self, tmp_path: Path):
+        from pixano.datasets.io.errors import MetadataError
+
+        source = make_v21_dataset(tmp_path / "ds")
+        with pytest.raises(MetadataError, match="frames mode"):
+            LeRobotImporter().analyze(
+                SourceRef.from_string(str(source)),
+                _spec("lr_bad", frames="explode"),
+                __import__("pixano.datasets.io.plan", fromlist=["AnalyzeLimits"]).AnalyzeLimits(),
+            )

--- a/tests/datasets/io/test_scale.py
+++ b/tests/datasets/io/test_scale.py
@@ -1,0 +1,98 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Scale and memory-boundedness tests (spec §13-P3; plan P3.6).
+
+All tests are marked `slow` — CI deselects them; run locally with
+`uv run pytest tests/datasets/io/test_scale.py -m slow`. Memory ceilings are
+deliberately generous (they catch O(dataset) blowups, not KB-level drift) and
+measure ru_maxrss deltas, so a fat baseline process cannot mask a leak.
+"""
+
+import resource
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets import Dataset
+from pixano.datasets.io import ImportSpec, import_dataset
+from pixano.datasets.io.reader import RecordBundleReader
+from tests.datasets.io._toy_importer import ToyImporter
+
+
+pytestmark = pytest.mark.slow
+
+
+def _rss_bytes() -> int:
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return raw if sys.platform == "darwin" else raw * 1024
+
+
+def _spec(name: str) -> ImportSpec:
+    return ImportSpec.model_validate({"dataset": {"name": name, "workspace": "image"}, "format": "auto"})
+
+
+def _import_toy(tmp_path: Path, name: str, num_records: int, image_kb: int = 8) -> Dataset:
+    importer = ToyImporter(num_records=num_records, batch_size=256, image_bytes=b"x" * (image_kb * 1024))
+    result = import_dataset(tmp_path / "src", tmp_path / f"data_{name}", _spec(name), importer=importer)
+    return Dataset(result.dataset_path)
+
+
+class TestImportMemoryBounds:
+    def test_import_rss_delta_is_bounded(self, tmp_path: Path):
+        # 20k records x 8KB embedded media = ~160MB of payload streamed through
+        # the engine; the process high-water mark must grow far less than the
+        # payload (flush-bounded buffering), not proportionally to it.
+        baseline = _rss_bytes()
+        dataset = _import_toy(tmp_path, "scale_import", num_records=20_000)
+        delta_mb = (_rss_bytes() - baseline) / (1024 * 1024)
+
+        assert dataset.open_table("records").count_rows() == 20_000
+        assert delta_mb < 600, f"import RSS grew by {delta_mb:.0f}MB for a 160MB payload"
+
+    def test_import_time_is_roughly_linear(self, tmp_path: Path):
+        def timed(name: str, count: int) -> float:
+            start = time.monotonic()
+            _import_toy(tmp_path, name, num_records=count, image_kb=1)
+            return time.monotonic() - start
+
+        small = timed("lin_small", 2_000)
+        large = timed("lin_large", 20_000)
+        # 10x the rows must cost well under 30x the time (superlinear blowups
+        # like per-row table scans show up as 50-100x here).
+        assert large < max(small, 0.5) * 30, f"2k: {small:.1f}s vs 20k: {large:.1f}s"
+
+
+class TestExportMemoryBounds:
+    def test_export_streams_blobs_under_byte_budget(self, tmp_path: Path):
+        dataset = _import_toy(tmp_path, "scale_export", num_records=5_000, image_kb=16)
+
+        from pixano.datasets.io.formats.pixano_jsonl.exporter import PixanoJsonlExporter
+
+        baseline = _rss_bytes()
+        reader = RecordBundleReader(page_size=512, max_bytes_in_flight=8 * 1024 * 1024)
+        exported = PixanoJsonlExporter(media="files", reader=reader).export(dataset, tmp_path / "exported")
+        delta_mb = (_rss_bytes() - baseline) / (1024 * 1024)
+
+        assert any(exported.glob("*/metadata.jsonl"))
+        # 5k x 16KB = 80MB of blobs; the reader pages them under an 8MB budget,
+        # never holding them all.
+        assert delta_mb < 400, f"export RSS grew by {delta_mb:.0f}MB for an 80MB blob payload"
+
+    def test_reader_query_count_scales_with_pages_not_records(self, tmp_path: Path):
+        dataset = _import_toy(tmp_path, "scale_reader", num_records=4_096, image_kb=1)
+        queries: list[str] = []
+        reader = RecordBundleReader(page_size=1_024, query_counter=queries.append)
+        bundle_count = sum(1 for _ in reader.iter_bundles(dataset))
+
+        assert bundle_count == 4_096
+        pages = 4  # 4096 / 1024
+        tables = len(dataset.info.tables)
+        # ids scan + per-page record fetch + per-page per-table component fetches
+        # (blob tables may sub-batch, hence the x4 headroom) — never per-record.
+        assert len(queries) <= 1 + pages + pages * tables * 4, f"{len(queries)} queries for {bundle_count} records"


### PR DESCRIPTION
## Issue

P3.4 of the 0.8.0 redesign (spec §7.3), with the agreed re-scope: **frame extraction is the default** so episodes are annotatable in the 0.8 UI — the Video-window path stays as an opt-in for browse-scale datasets. Based on `arch/data-import`; independent of #682.

## Description

- **Layout parsing, pyarrow-only** (no `lerobot` dependency): v2.1 (`meta/episodes.jsonl`, one video per episode) and v3 (episodes metadata parquet with per-camera `from/to_timestamp` windows into shared shards), both via the `video_path` templates in `meta/info.json`.
- **Default `frames: "extract"`** — ffmpeg decodes each episode's window at the dataset fps into embedded `SequenceFrame` rows (the DAVIS pattern: browse grid, timeline, bbox/mask/tracklet annotation all work today; previews stamp automatically). Scale guards: `max_frames_per_episode` uniform-stride cap and a JPEG **size estimate in the analyze plan** before anything is written.
- **Opt-in `frames: "reference"`** — `Video` time-window rows (v3 windows; v2.1 degenerate whole-file windows) for large datasets browsed without annotation.
- **`episodes` selection** (list or `"start:end"`), records carry `episode_index`/`tasks`/`length`, resume cursor per episode, deterministic ids.
- Analyze findings: `ffmpeg_required`, **AV1 codec warning** (extracts fine, Safari playback limitation documented), missing shards.
- `DatasetImporter.resolve_info` now receives the source, so source-dependent schemas (one view per camera) resolve cleanly — same hook COCO uses.

Options ride in `dataset.yaml`/spec `options:`, e.g. `options: {episodes: "0:9", max_frames_per_episode: 300}`.

10 tests over synthetic v2.1/v3 fixtures built from the sample video — including the window-math check that two episodes sharing one v3 shard produce disjoint frame timestamp ranges. Full suite green (596).

Remaining LeRobot scope (follow-up): `hub://` meta-only mode via `huggingface_hub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)