### PR TITLE
fix: default the dataset name from the source folder

### DIFF
--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -97,6 +97,9 @@ def import_dataset(
         info = resolved.resolve_info(spec, source_ref)
     if spec.dataset.name:
         info.name = spec.dataset.name
+    elif not info.name and source_ref.path is not None:
+        # No --name, no dataset.yaml: default from the source folder, like the id namespace.
+        info.name = source_ref.path.name
     if spec.dataset.description:
         info.description = spec.dataset.description
 

--- a/tests/datasets/io/formats/test_coco_importer.py
+++ b/tests/datasets/io/formats/test_coco_importer.py
@@ -179,3 +179,21 @@ class TestCocoRoundTrip:
         box_first = sorted(first.get_data("bboxes", limit=100), key=lambda b: b.coords[0])[0]
         box_second = sorted(second.get_data("bboxes", limit=100), key=lambda b: b.coords[0])[0]
         assert box_second.coords == pytest.approx(box_first.coords, abs=1e-3)
+
+
+class TestDefaultDatasetName:
+    def test_name_defaults_from_the_source_folder(self, tmp_path: Path):
+        from pixano.datasets import Dataset
+
+        source = tmp_path / "2014"
+        source.mkdir()
+        shutil.copy(FIXTURE / "instances_val.json", source / "instances_val.json")
+        (source / "val").mkdir()
+        for image in (FIXTURE / "image" / "val").iterdir():
+            shutil.copy(image, source / "val" / image.name)
+
+        spec = ImportSpec.model_validate({"format": "coco"})  # no name anywhere
+        result = import_dataset(source, tmp_path / "data", spec, importer=CocoImporter())
+        dataset = Dataset(result.dataset_path)
+        assert dataset.info.name == "2014"
+        assert result.dataset_path.name == "2014"


### PR DESCRIPTION
## Issue

Checkpoint-C finding: `pixano data import ./data ./mscoco/2014` with no `--name` and no `dataset.yaml` failed with `dataset.name must contain at least one alphanumeric character` — and only *after* the confirmation prompt.

## Description

The dataset name now defaults from the source folder name when neither `--name` nor a `dataset.yaml` provides one — the same defaulting rule the id namespace already uses. Explicit names still win. Regression test imports the COCO fixture from a folder literally named `2014` with a bare spec and gets a dataset named `2014`.

Full suite green (597).

🤖 Generated with [Claude Code](https://claude.com/claude-code)