### PR TITLE
perf: speed up embedded-media imports (draft previews, prefetch, bigger flushes)

### DIFF
--- a/src/pixano/datasets/io/engine.py
+++ b/src/pixano/datasets/io/engine.py
@@ -61,7 +61,7 @@ from .spec import ImportSpec
 logger = logging.getLogger(__name__)
 
 PIXANO_STATE_DIR = ".pixano"
-DEFAULT_FLUSH_ROWS = 1024
+DEFAULT_FLUSH_ROWS = 4096
 DEFAULT_FLUSH_BYTES = 256 * 1024 * 1024
 
 

--- a/src/pixano/datasets/io/formats/coco/importer.py
+++ b/src/pixano/datasets/io/formats/coco/importer.py
@@ -126,6 +126,34 @@ def _stream_array(json_path: Path, key: str) -> tuple[Iterator[dict], bool]:
         return iter(payload.get(key, [])), False
 
 
+def _prefetch_media(
+    numbered: "Iterator[tuple[int, dict]]", spec: ImportSpec, source_dir: Path, split: str, lookahead: int = 16
+) -> "Iterator[tuple[int, dict, bytes | None]]":
+    """Read image bytes ahead with a small thread pool (overlaps disk latency)."""
+    if spec.media.mode != "embed":
+        for ordinal, image in numbered:
+            yield ordinal, image, None
+        return
+
+    from collections import deque
+    from concurrent.futures import ThreadPoolExecutor
+
+    def read(image: dict) -> bytes | None:
+        local = CocoImporter._locate_image(source_dir, split, str(image.get("file_name", "")))
+        return local.read_bytes() if local is not None else None
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        window: deque = deque()
+        for ordinal, image in numbered:
+            window.append((ordinal, image, pool.submit(read, image)))
+            if len(window) >= lookahead:
+                queued_ordinal, queued_image, future = window.popleft()
+                yield queued_ordinal, queued_image, future.result()
+        while window:
+            queued_ordinal, queued_image, future = window.popleft()
+            yield queued_ordinal, queued_image, future.result()
+
+
 class CocoImporter(DatasetImporter):
     """Importer for COCO instances JSON (detection, segmentation, keypoints)."""
 
@@ -263,11 +291,14 @@ class CocoImporter(DatasetImporter):
                     index.add(str(annotation.get("image_id", "")), annotation)
 
                 images, _ = _stream_array(json_path, "images")
-                for ordinal, image in enumerate(images, start=1):
-                    if resume_split == split and ordinal <= resume_ordinal:
-                        continue
+                numbered = (
+                    (ordinal, image)
+                    for ordinal, image in enumerate(images, start=1)
+                    if not (resume_split == split and ordinal <= resume_ordinal)
+                )
+                for ordinal, image, media in _prefetch_media(numbered, spec, source.path, split):
                     tables = self._build_image(
-                        info, spec, resolver, source.path, namespace, split, image, index, categories
+                        info, spec, resolver, source.path, namespace, split, image, index, categories, media
                     )
                     yield BatchBundle(
                         tables=tables,
@@ -292,6 +323,7 @@ class CocoImporter(DatasetImporter):
         image: dict,
         index: _AnnotationIndex,
         categories: dict[int, dict],
+        media: bytes | None = None,
     ) -> dict[str, list[LanceModel]]:
         tables: dict[str, list[LanceModel]] = {}
         image_id = str(image.get("id", ""))
@@ -304,13 +336,17 @@ class CocoImporter(DatasetImporter):
         file_name = str(image.get("file_name", ""))
         if spec.media.mode == "uri":
             resolved_uri, raw_bytes = str(image.get("coco_url", "")), b""
+        elif media is not None:
+            resolved_uri, raw_bytes = "", media
         else:
             local = self._locate_image(source_dir, split, file_name)
             if local is None:
                 raise MetadataError(f"Image file '{file_name}' not found for split '{split}'.")
             resolved = resolver.resolve(str(local.relative_to(source_dir)))
             resolved_uri, raw_bytes = resolved.uri, resolved.raw_bytes
-            if not width or not height:
+        if not width or not height:
+            local = self._locate_image(source_dir, split, file_name)
+            if local is not None:
                 width, height, _ = probe_image(local)
         view_cls = info.views["image"]
         view_id = stable_id(record_id, "view", "image")

--- a/src/pixano/schemas/views/image.py
+++ b/src/pixano/schemas/views/image.py
@@ -30,6 +30,9 @@ def _generate_preview(pil_image: PILImage) -> bytes:
     Returns:
         PNG-encoded thumbnail bytes.
     """
+    # draft() decodes JPEGs directly at reduced scale (~8x faster); it is a
+    # no-op for other formats and must run before pixel access.
+    pil_image.draft("RGB", (64, 64))
     thumb = pil_image.copy()
     thumb.thumbnail((64, 64))
     buf = io.BytesIO()


### PR DESCRIPTION
## Issue

Checkpoint-C finding: MS COCO val2014 imported at 37 rec/s.

## Description

Profiled on the reporter's actual data (300-record subsets of val2014). Two internal costs and one environmental one:

1. **45% of CPU was full-resolution JPEG decode** for the 64 px preview thumbnails → `_generate_preview` now uses PIL **draft-mode decode** (JPEGs decode directly at reduced scale, ~8× faster; no-op for other formats). Benefits every importer.
2. **Small flush batches** (~45 records per flush on annotation-heavy data) → `DEFAULT_FLUSH_ROWS` 1024 → 4096; the 256 MB byte bound still caps memory, and imports produce 4× fewer lance fragments.
3. **Disk latency dominated the remainder** → the COCO importer prefetches image bytes with an 8-thread pool and 16-image lookahead, overlapping I/O with row building.

**Measured**: local SSD **184 → 275 rec/s**; USB-backed **37 → ~47 rec/s** — the raw read ceiling of that drive measured 40–57 files/s, so the import now runs at the hardware limit. For slow external drives, copying media to local disk first remains the real fix (~275 rec/s ⇒ full val2014 in ~2.5 min).

Full suite green (596) incl. the slow scale suite; preview/round-trip/idempotency tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)