### PR TITLE
fix: format-intrinsic imports default their natural UI workspace

### DIFF
--- a/src/pixano/datasets/io/formats/coco/importer.py
+++ b/src/pixano/datasets/io/formats/coco/importer.py
@@ -183,7 +183,10 @@ class CocoImporter(DatasetImporter):
         """COCO has an intrinsic schema; a user-declared schema block still wins."""
         if spec.schema_ is not None or spec.schema_manifest is not None:
             return resolve_dataset_info(spec)
-        payload = spec.model_dump(exclude_none=True, by_alias=True)
+        payload = spec.model_dump(mode="json", exclude_none=True, by_alias=True)
+        if payload.get("dataset", {}).get("workspace", "undefined") == "undefined":
+            # Formats know their natural UI workspace; an explicit --workspace wins.
+            payload.setdefault("dataset", {})["workspace"] = "image"
         payload["schema"] = _DEFAULT_SCHEMA
         return resolve_dataset_info(ImportSpec.model_validate(payload))
 

--- a/src/pixano/datasets/io/formats/lerobot/importer.py
+++ b/src/pixano/datasets/io/formats/lerobot/importer.py
@@ -77,7 +77,10 @@ class LeRobotImporter(DatasetImporter):
             return resolve_dataset_info(spec)
         layout = parse_layout(self._local_root(source))
         view_kind = "sequence_frames" if self._frames_mode(spec) == "extract" else "video"
-        payload = spec.model_dump(exclude_none=True, by_alias=True)
+        payload = spec.model_dump(mode="json", exclude_none=True, by_alias=True)
+        if payload.get("dataset", {}).get("workspace", "undefined") == "undefined":
+            # Formats know their natural UI workspace; an explicit --workspace wins.
+            payload.setdefault("dataset", {})["workspace"] = "video"
         payload["schema"] = {
             "views": {camera_view_name(key): {"kind": view_kind} for key in layout.video_keys},
             "record": {

--- a/tests/datasets/io/formats/test_coco_importer.py
+++ b/tests/datasets/io/formats/test_coco_importer.py
@@ -197,3 +197,13 @@ class TestDefaultDatasetName:
         dataset = Dataset(result.dataset_path)
         assert dataset.info.name == "2014"
         assert result.dataset_path.name == "2014"
+
+
+class TestCocoWorkspaceDefault:
+    def test_bare_spec_defaults_to_image_workspace(self, tmp_path: Path):
+        from pixano.datasets import Dataset
+        from pixano.datasets.workspaces import WorkspaceType
+
+        spec = ImportSpec.model_validate({"format": "coco"})
+        result = import_dataset(FIXTURE, tmp_path / "data", spec, importer=CocoImporter())
+        assert Dataset(result.dataset_path).info.workspace == WorkspaceType.IMAGE

--- a/tests/datasets/io/formats/test_lerobot_importer.py
+++ b/tests/datasets/io/formats/test_lerobot_importer.py
@@ -260,3 +260,23 @@ class TestHubSource:
         assert hub_module.is_hub_id("lerobot/pusht")
         assert not hub_module.is_hub_id("not a hub id")
         assert not hub_module.is_hub_id("/absolute/path")
+
+
+class TestWorkspaceDefault:
+    @needs_ffmpeg
+    def test_bare_spec_defaults_to_video_workspace(self, tmp_path: Path):
+        from pixano.datasets.workspaces import WorkspaceType
+
+        source = make_v21_dataset(tmp_path / "ds")
+        spec = ImportSpec.model_validate({"format": "lerobot", "options": {"max_frames_per_episode": 2}})
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        assert Dataset(result.dataset_path).info.workspace == WorkspaceType.VIDEO
+
+    def test_explicit_workspace_wins(self, tmp_path: Path):
+        from pixano.datasets.io import SourceRef
+        from pixano.datasets.workspaces import WorkspaceType
+
+        source = make_v21_dataset(tmp_path / "ds")
+        spec = ImportSpec.model_validate({"format": "lerobot", "dataset": {"name": "x", "workspace": "image_vqa"}})
+        info = LeRobotImporter().resolve_info(spec, SourceRef.from_string(str(source)))
+        assert info.workspace == WorkspaceType.IMAGE_VQA


### PR DESCRIPTION
## Issue

Checkpoint-D finding: a LeRobot v3 dataset (LIBERO) imported fine — multi-camera `SequenceFrame` views present — but opened in the **image** workspace instead of the **video** workspace.

## Description

Both `CocoImporter.resolve_info` and `LeRobotImporter.resolve_info` built their intrinsic schema payloads without setting `dataset.workspace`, so any import without an explicit `--workspace` was written as `undefined` and the UI fell back to the single-image layout — confirmed on the reporter's real library for **both** formats (`aloha_sim_insertion_scripted` and `coco_2014` both carried `workspace: undefined`).

`resolve_info` now defaults the workspace to the format's natural one — `video` for LeRobot, `image` for COCO — while an explicit `--workspace` or user schema block still wins. Regression tests cover both defaults and the override.

**Verified end-to-end** on a real Hub import: `pixano data import <data> lerobot/svla_so100_stacking --episodes 0:0 --max-frames 4` now writes `workspace: video`.

**Already-imported datasets need no re-import** — edit the dataset's `library/<name>/info.json` and set `"workspace": "video"` (LeRobot) or `"image"` (COCO); everything else is intact.

Full suite green (621).

🤖 Generated with [Claude Code](https://claude.com/claude-code)