### PR TITLE
feat: LeRobot row-aligned frame sampling + timeseries vector tables

### DIFF
--- a/src/pixano/api/models.py
+++ b/src/pixano/api/models.py
@@ -27,6 +27,7 @@ from pixano.schemas import (
     Record,
     Relation,
     TextSpan,
+    TimeSeries,
     Tracklet,
 )
 
@@ -353,6 +354,8 @@ EmbeddingCreate = _create_transport_model(
     required_fields={"id"},
 )
 EmbeddingResponse = _create_transport_model("EmbeddingResponse", Embedding, exclude_fields={"vector"})
+
+TimeSeriesResponse = _create_transport_model("TimeSeriesResponse", TimeSeries)
 
 
 class DatasetInfoResponse(DatasetInfo):

--- a/src/pixano/api/resources.py
+++ b/src/pixano/api/resources.py
@@ -26,6 +26,7 @@ from pixano.schemas import (
     Relation,
     SchemaGroup,
     TextSpan,
+    TimeSeries,
     Tracklet,
     canonical_table_name_for_schema,
 )
@@ -66,6 +67,7 @@ from .models import (
     TextSpanCreate,
     TextSpanResponse,
     TextSpanUpdate,
+    TimeSeriesResponse,
     TrackletCreate,
     TrackletResponse,
     TrackletUpdate,
@@ -333,6 +335,22 @@ MESSAGE_RESOURCE = ResourceSpec(
     validate_create=_validate_message_create,
 )
 
+TIMESERIES_RESOURCE = ResourceSpec(
+    name="timeseries",
+    path="timeseries",
+    tag="Time Series",
+    schema_group=SchemaGroup.TIMESERIES,
+    schema_cls=TimeSeries,
+    canonical_table_name=canonical_table_name_for_schema(TimeSeries),
+    create_model=None,
+    update_model=None,
+    response_model=TimeSeriesResponse,
+    list_filters=("record_id", "view_name", "frame_index", "where"),
+    allow_create=False,
+    allow_update=False,
+    allow_delete=False,
+)
+
 EMBEDDING_RESOURCE = ResourceSpec(
     name="embedding",
     path="embeddings",
@@ -391,6 +409,7 @@ RESOURCE_SPECS: tuple[ResourceSpec, ...] = (
     RELATION_RESOURCE,
     MESSAGE_RESOURCE,
     TEXT_SPAN_RESOURCE,
+    TIMESERIES_RESOURCE,
     EMBEDDING_RESOURCE,
 )
 
@@ -399,6 +418,7 @@ __all__ = [
     "BBOX_RESOURCE",
     "CLASSIFICATION_RESOURCE",
     "EMBEDDING_RESOURCE",
+    "TIMESERIES_RESOURCE",
     "ENTITY_DYNAMIC_STATE_RESOURCE",
     "ENTITY_RESOURCE",
     "RECORD_RESOURCE",

--- a/src/pixano/api/routers/__init__.py
+++ b/src/pixano/api/routers/__init__.py
@@ -25,6 +25,7 @@ from pixano.api.routers.multi_paths import router as multi_paths_router
 from pixano.api.routers.records import router as records_router
 from pixano.api.routers.relation import router as relation_router
 from pixano.api.routers.text_spans import router as text_spans_router
+from pixano.api.routers.timeseries import router as timeseries_router
 from pixano.api.routers.tracklets import router as tracklets_router
 from pixano.api.routers.views import router as views_router
 
@@ -45,6 +46,7 @@ RESOURCE_ROUTERS: tuple[APIRouter, ...] = (
     conversations_router,
     text_spans_router,
     embeddings_router,
+    timeseries_router,
 )
 
 API_ROUTERS: tuple[APIRouter, ...] = (

--- a/src/pixano/api/routers/timeseries.py
+++ b/src/pixano/api/routers/timeseries.py
@@ -1,0 +1,13 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Time series REST resource (read-only)."""
+
+from pixano.api.resources import TIMESERIES_RESOURCE
+from pixano.api.routers.resources import create_resource_router
+
+
+router = create_resource_router(TIMESERIES_RESOURCE)

--- a/src/pixano/datasets/dataset.py
+++ b/src/pixano/datasets/dataset.py
@@ -930,6 +930,7 @@ class Dataset:
     _INSERT_ORDER: list[SchemaGroup] = [
         SchemaGroup.RECORD,
         SchemaGroup.VIEW,
+        SchemaGroup.TIMESERIES,
         SchemaGroup.ENTITY,
         SchemaGroup.ENTITY_DYNAMIC_STATE,
         SchemaGroup.ANNOTATION,

--- a/src/pixano/datasets/dataset_info.py
+++ b/src/pixano/datasets/dataset_info.py
@@ -38,6 +38,7 @@ from pixano.schemas import (
     RecordComponent,
     Relation,
     TextSpan,
+    TimeSeries,
     Tracklet,
     View,
     canonical_table_name_for_schema,
@@ -64,6 +65,7 @@ _DATASET_INFO_SLOT_TYPES: dict[str, type[LanceModel]] = {
     "relation": Relation,
     "tracklet": Tracklet,
     "message": Message,
+    "timeseries": TimeSeries,
     "text_span": TextSpan,
 }
 
@@ -118,6 +120,7 @@ class DatasetInfo(BaseModel):
     relation: type[Relation] | None = None
     tracklet: type[Tracklet] | None = None
     message: type[Message] | None = None
+    timeseries: type[TimeSeries] | None = None
     text_span: type[TextSpan] | None = None
     views: dict[str, type[View]] = Field(default_factory=dict)
     tables: dict[str, type[LanceModel]] = Field(default_factory=dict, exclude=True)

--- a/src/pixano/datasets/io/formats/lerobot/importer.py
+++ b/src/pixano/datasets/io/formats/lerobot/importer.py
@@ -215,8 +215,10 @@ class LeRobotImporter(DatasetImporter):
         episodes = self._select_episodes(layout, spec)
         mode = self._frames_mode(spec)
         if source.kind == "hf_hub" and source.url:
-            needed = sorted({camera.video_path for episode in episodes for camera in episode.cameras.values()})
-            root = materialize_files(source.url, needed)
+            needed = {camera.video_path for episode in episodes for camera in episode.cameras.values()}
+            if mode == "extract":
+                needed |= {episode.data_path for episode in episodes if episode.data_path}
+            root = materialize_files(source.url, sorted(needed))
         namespace = spec.ids.namespace or (source.url or root.name).replace("/", "_")
         resolver = MediaResolver(spec.media, base_dir=root)
         resume_ordinal = int(cursor.get("episode_ordinal", 0)) if cursor else 0
@@ -237,12 +239,21 @@ class LeRobotImporter(DatasetImporter):
                     )
                 ]
             }
+            data_rows = self._episode_rows(root, layout, episode) if mode == "extract" else []
             for key, camera in sorted(episode.cameras.items()):
                 view_name = camera_view_name(key)
                 shard = root / camera.video_path
                 if mode == "extract":
                     rows = self._extract_frames(
-                        info, layout, spec, record_id, view_name, shard, camera.from_timestamp, camera.to_timestamp
+                        info,
+                        layout,
+                        spec,
+                        record_id,
+                        view_name,
+                        shard,
+                        camera.from_timestamp,
+                        camera.to_timestamp,
+                        data_rows,
                     )
                 else:
                     rows = [self._video_row(info, layout, resolver, record_id, view_name, camera, shard, root)]
@@ -254,6 +265,28 @@ class LeRobotImporter(DatasetImporter):
                 provenance=Provenance(file=str(source.path), record_key=str(episode.index)),
             )
 
+    @staticmethod
+    def _episode_rows(root: Path, layout: LeRobotLayout, episode: "Episode") -> list[dict]:
+        """The episode's data-parquet rows (timestamp + float features), frame order.
+
+        These per-row timestamps are LeRobot's ground truth — the values
+        `delta_timestamps` indexes against — so frames and vectors align 1:1.
+        """
+        import pyarrow.parquet as pq
+
+        data_file = root / episode.data_path
+        if not data_file.is_file():
+            raise MetadataError(f"Episode data parquet not found: {data_file}")
+        available = set(pq.read_schema(data_file).names)
+        columns = [name for name in ("timestamp", "frame_index", *layout.feature_dims) if name in available]
+        filters = [("episode_index", "==", episode.index)] if "episode_index" in available else None
+        table = pq.read_table(data_file, columns=columns, filters=filters)
+        rows = table.to_pylist()
+        rows.sort(key=lambda row: row.get("frame_index", row.get("timestamp", 0.0)))
+        if not rows:
+            raise MetadataError(f"No data rows for episode {episode.index} in {data_file}.")
+        return rows
+
     def _extract_frames(
         self,
         info: DatasetInfo,
@@ -264,11 +297,14 @@ class LeRobotImporter(DatasetImporter):
         shard: Path,
         from_timestamp: float,
         to_timestamp: float,
+        data_rows: list[dict],
     ) -> list[LanceModel]:
         if not shard.is_file():
             raise MetadataError(f"Video shard not found: {shard}")
         probe = probe_video(shard)
         fps = layout.fps or probe.fps
+        if not fps:
+            raise MetadataError(f"No fps in meta/info.json or the probe for '{shard.name}'.")
 
         with tempfile.TemporaryDirectory(prefix="pixano-lerobot-") as tmp:
             command = ["ffmpeg", "-nostdin", "-v", "error"]
@@ -277,32 +313,52 @@ class LeRobotImporter(DatasetImporter):
             command += ["-i", str(shard)]
             if to_timestamp > 0:
                 command += ["-t", f"{to_timestamp - from_timestamp:.6f}"]
-            command += ["-vf", f"fps={fps}", "-q:v", "2", f"{tmp}/%06d.jpg"]
+            # Passthrough: every encoded frame, no resampling — frame k sits at
+            # window time k/fps, and rows map onto frames by their own timestamps.
+            command += ["-fps_mode", "passthrough", "-q:v", "2", f"{tmp}/%06d.jpg"]
             result = subprocess.run(command, capture_output=True, text=True)
+            if result.returncode != 0 and "fps_mode" in (result.stderr or ""):
+                command[command.index("-fps_mode")] = "-vsync"  # pre-5.1 ffmpeg
+                result = subprocess.run(command, capture_output=True, text=True)
             if result.returncode != 0:
                 raise MetadataError(f"ffmpeg frame extraction failed on '{shard.name}': {result.stderr.strip()[:200]}")
 
             frame_files = sorted(Path(tmp).glob("*.jpg"))
+            tolerance = 1.0 / (2.0 * fps)
+            selected = data_rows
             cap = self._max_frames(spec)
-            if cap and len(frame_files) > cap:
-                stride = len(frame_files) / cap
-                frame_files = [frame_files[int(position * stride)] for position in range(cap)]
+            if cap and len(selected) > cap:
+                stride = len(selected) / cap
+                selected = [selected[int(position * stride)] for position in range(cap)]
 
             view_cls = info.views[view_name]
             rows: list[LanceModel] = []
-            for frame_index, frame_file in enumerate(frame_files):
+            for ordinal, data_row in enumerate(selected):
+                row_timestamp = float(data_row.get("timestamp", ordinal / fps))
+                k = round(row_timestamp * fps)
+                if abs(k / fps - row_timestamp) > tolerance:
+                    raise MetadataError(
+                        f"timestamp_alignment: row t={row_timestamp:.6f}s is not on the {fps}fps grid "
+                        f"of '{shard.name}' (tolerance {tolerance:.6f}s)."
+                    )
+                if not 0 <= k < len(frame_files):
+                    raise MetadataError(
+                        f"timestamp_alignment: row t={row_timestamp:.6f}s maps to frame {k} but "
+                        f"'{shard.name}' window decoded {len(frame_files)} frames."
+                    )
+                frame_index = int(data_row.get("frame_index", ordinal))
                 rows.append(
                     view_cls(
                         id=stable_id(record_id, "view", view_name, frame_index),
                         record_id=record_id,
                         logical_name=view_name,
                         uri="",
-                        raw_bytes=frame_file.read_bytes(),
+                        raw_bytes=frame_files[k].read_bytes(),
                         width=probe.width,
                         height=probe.height,
                         format="JPEG",
                         frame_index=frame_index,
-                        timestamp=from_timestamp + frame_index / fps if fps else float(frame_index),
+                        timestamp=row_timestamp,
                     )
                 )
             return rows

--- a/src/pixano/datasets/io/formats/lerobot/importer.py
+++ b/src/pixano/datasets/io/formats/lerobot/importer.py
@@ -92,7 +92,41 @@ class LeRobotImporter(DatasetImporter):
             },
             "annotations": ["bbox", "mask", "tracklet"],
         }
-        return resolve_dataset_info(ImportSpec.model_validate(payload))
+        info = resolve_dataset_info(ImportSpec.model_validate(payload))
+        if layout.feature_dims and self._frames_mode(spec) == "extract":
+            # State/action vectors ride a timeseries table (fixed-size Vector
+            # columns are outside the YAML dialect, so attach programmatically).
+            from pixano.schemas import create_timeseries_schema
+            from pixano.utils import to_snake_case
+
+            vector_fields = {to_snake_case(key.replace(".", "_")): dim for key, dim in layout.feature_dims.items()}
+            slots = {
+                slot: getattr(info, slot)
+                for slot in (
+                    "record",
+                    "entity",
+                    "entity_dynamic_state",
+                    "bbox",
+                    "mask",
+                    "multi_path",
+                    "keypoint",
+                    "classification",
+                    "relation",
+                    "tracklet",
+                    "message",
+                    "text_span",
+                )
+                if getattr(info, slot, None) is not None
+            }
+            info = DatasetInfo(
+                name=info.name,
+                description=info.description,
+                workspace=info.workspace,
+                views=info.views,
+                timeseries=create_timeseries_schema(vector_fields),
+                **slots,
+            )
+        return info
 
     @staticmethod
     def _frames_mode(spec: ImportSpec) -> str:
@@ -240,6 +274,31 @@ class LeRobotImporter(DatasetImporter):
                 ]
             }
             data_rows = self._episode_rows(root, layout, episode) if mode == "extract" else []
+            if data_rows and info.timeseries is not None and layout.feature_dims:
+                from pixano.utils import to_snake_case
+
+                cap = self._max_frames(spec)
+                selected = data_rows
+                if cap and len(selected) > cap:
+                    stride = len(selected) / cap
+                    selected = [selected[int(position * stride)] for position in range(cap)]
+                series_rows = []
+                for ordinal, data_row in enumerate(selected):
+                    frame_index = int(data_row.get("frame_index", ordinal))
+                    values = {
+                        to_snake_case(key.replace(".", "_")): [float(v) for v in data_row.get(key, [])]
+                        for key in layout.feature_dims
+                    }
+                    series_rows.append(
+                        info.timeseries(
+                            id=stable_id(record_id, "ts", frame_index),
+                            record_id=record_id,
+                            frame_index=frame_index,
+                            timestamp=float(data_row.get("timestamp", ordinal)),
+                            **values,
+                        )
+                    )
+                tables["timeseries"] = series_rows
             for key, camera in sorted(episode.cameras.items()):
                 view_name = camera_view_name(key)
                 shard = root / camera.video_path
@@ -324,7 +383,9 @@ class LeRobotImporter(DatasetImporter):
                 raise MetadataError(f"ffmpeg frame extraction failed on '{shard.name}': {result.stderr.strip()[:200]}")
 
             frame_files = sorted(Path(tmp).glob("*.jpg"))
-            tolerance = 1.0 / (2.0 * fps)
+            # LeRobot's delta_timestamps discipline: row timestamps must sit ON
+            # the decoded frame grid (default tolerance_s=1e-4, like LeRobot).
+            tolerance = float(spec.options.get("tolerance_s", 1e-4))
             selected = data_rows
             cap = self._max_frames(spec)
             if cap and len(selected) > cap:
@@ -338,8 +399,9 @@ class LeRobotImporter(DatasetImporter):
                 k = round(row_timestamp * fps)
                 if abs(k / fps - row_timestamp) > tolerance:
                     raise MetadataError(
-                        f"timestamp_alignment: row t={row_timestamp:.6f}s is not on the {fps}fps grid "
-                        f"of '{shard.name}' (tolerance {tolerance:.6f}s)."
+                        f"timestamp_alignment: row t={row_timestamp:.6f}s is not on the {fps}fps frame grid "
+                        f"of '{shard.name}' (off by {abs(k / fps - row_timestamp):.6f}s > tolerance {tolerance}s). "
+                        "Set options.tolerance_s to relax."
                     )
                 if not 0 <= k < len(frame_files):
                     raise MetadataError(

--- a/src/pixano/datasets/io/formats/lerobot/layout.py
+++ b/src/pixano/datasets/io/formats/lerobot/layout.py
@@ -32,12 +32,13 @@ class EpisodeCamera:
 
 @dataclass
 class Episode:
-    """One episode: record attrs plus per-camera video references."""
+    """One episode: record attrs plus per-camera video and data references."""
 
     index: int
     tasks: list[str] = field(default_factory=list)
     length: int = 0
     cameras: dict[str, EpisodeCamera] = field(default_factory=dict)
+    data_path: str = ""  # parquet holding this episode's rows, relative to the root
 
 
 @dataclass
@@ -49,6 +50,22 @@ class LeRobotLayout:
     video_keys: list[str]
     episodes: list[Episode]
     robot_type: str = ""
+    feature_dims: dict[str, int] = field(default_factory=dict)  # 1-D float features -> vector dim
+
+
+_BOOKKEEPING_KEYS = frozenset({"timestamp", "frame_index", "episode_index", "index", "task_index"})
+
+
+def float_feature_dims(info: dict) -> dict[str, int]:
+    """1-D float features (action, observation.state, ...) -> vector dim, bookkeeping excluded."""
+    dims: dict[str, int] = {}
+    for key, feature in (info.get("features", {}) or {}).items():
+        shape = feature.get("shape") or []
+        if key in _BOOKKEEPING_KEYS or feature.get("dtype") not in ("float32", "float64"):
+            continue
+        if len(shape) == 1 and int(shape[0]) > 1:
+            dims[key] = int(shape[0])
+    return dims
 
 
 def camera_view_name(video_key: str) -> str:
@@ -82,6 +99,7 @@ def parse_layout(root: Path) -> LeRobotLayout:
         video_keys=video_keys,
         episodes=episodes,
         robot_type=str(info.get("robot_type", "") or ""),
+        feature_dims=float_feature_dims(info),
     )
 
 
@@ -92,6 +110,7 @@ def _parse_v21_episodes(root: Path, info: dict, video_keys: list[str]) -> list[E
     template = str(
         info.get("video_path", "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4")
     )
+    data_template = str(info.get("data_path", "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"))
     chunks_size = int(info.get("chunks_size", 1000) or 1000)
 
     episodes: list[Episode] = []
@@ -113,6 +132,7 @@ def _parse_v21_episodes(root: Path, info: dict, video_keys: list[str]) -> list[E
                 tasks=list(tasks) if isinstance(tasks, list) else [str(tasks)],
                 length=int(payload.get("length", 0) or 0),
                 cameras=cameras,
+                data_path=data_template.format(episode_chunk=index // chunks_size, episode_index=index),
             )
         )
     return sorted(episodes, key=lambda episode: episode.index)
@@ -126,6 +146,7 @@ def _parse_v3_episodes(root: Path, info: dict, video_keys: list[str]) -> list[Ep
     if not parquet_files:
         raise MetadataError("v3 layout: no parquet files under meta/episodes/.", Provenance(file=str(episodes_dir)))
     template = str(info.get("video_path", "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"))
+    data_template = str(info.get("data_path", "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"))
 
     episodes: list[Episode] = []
     for parquet_file in parquet_files:
@@ -151,6 +172,10 @@ def _parse_v3_episodes(root: Path, info: dict, video_keys: list[str]) -> list[Ep
                     tasks=list(tasks) if isinstance(tasks, list) else [str(tasks)],
                     length=int(payload.get("length", 0) or 0),
                     cameras=cameras,
+                    data_path=data_template.format(
+                        chunk_index=int(payload.get("data/chunk_index", 0) or 0),
+                        file_index=int(payload.get("data/file_index", 0) or 0),
+                    ),
                 )
             )
     return sorted(episodes, key=lambda episode: episode.index)

--- a/src/pixano/schemas/__init__.py
+++ b/src/pixano/schemas/__init__.py
@@ -66,6 +66,7 @@ from .table_names import (
     supported_dataset_info_slots,
     validate_canonical_table_map,
 )
+from .timeseries import TimeSeries, create_timeseries_schema
 from .views import (
     PDF,
     BaseIntrinsics,
@@ -123,6 +124,7 @@ __all__ = [
     "MultiPath",
     "QuestionType",
     "TextSpan",
+    "TimeSeries",
     "PDF",
     "PointCloud",
     "PointCloudFrame",
@@ -150,6 +152,7 @@ __all__ = [
     "create_point_cloud_frame",
     "create_relation",
     "create_text",
+    "create_timeseries_schema",
     "create_video",
     "create_view_embedding_function",
     "canonical_table_name_for_schema",

--- a/src/pixano/schemas/schema_group.py
+++ b/src/pixano/schemas/schema_group.py
@@ -26,6 +26,7 @@ from .annotations import (
 from .embeddings import Embedding, ViewEmbedding
 from .entities import Entity, EntityDynamicState
 from .records import Record
+from .timeseries import TimeSeries
 from .views import PDF, CamCalibration, Image, PointCloud, PointCloudFrame, SequenceFrame, Text, Video, View
 
 
@@ -37,6 +38,7 @@ class SchemaGroup(Enum):
     RECORD = "records"
     ENTITY = "entities"
     ENTITY_DYNAMIC_STATE = "entity_dynamic_states"
+    TIMESERIES = "timeseries"
     VIEW = "views"
 
     @classmethod
@@ -53,6 +55,7 @@ _SCHEMA_GROUP_TO_SCHEMA_DICT = {
     SchemaGroup.RECORD: Record,
     SchemaGroup.ENTITY: Entity,
     SchemaGroup.ENTITY_DYNAMIC_STATE: EntityDynamicState,
+    SchemaGroup.TIMESERIES: TimeSeries,
     SchemaGroup.ANNOTATION: EntityAnnotation,
     SchemaGroup.VIEW: View,
 }
@@ -70,6 +73,7 @@ CANONICAL_SCHEMA_TYPES = (
     Video,
     Entity,
     EntityDynamicState,
+    TimeSeries,
     EntityAnnotation,
     EntityGroupAnnotation,
     BBox,
@@ -105,6 +109,8 @@ def schema_to_group(schema_type: LanceModel | type) -> SchemaGroup:
         return SchemaGroup.RECORD
     if isinstance(schema_type, EntityDynamicState) or is_class and issubclass(schema_type, EntityDynamicState):
         return SchemaGroup.ENTITY_DYNAMIC_STATE
+    if isinstance(schema_type, TimeSeries) or is_class and issubclass(schema_type, TimeSeries):
+        return SchemaGroup.TIMESERIES
     if isinstance(schema_type, Entity) or is_class and issubclass(schema_type, Entity):
         return SchemaGroup.ENTITY
     # Check EntityAnnotation and EntityGroupAnnotation (both are annotation groups)
@@ -127,6 +133,8 @@ def group_to_str(group: SchemaGroup, plural: bool = False) -> str:
         return "entities" if plural else "entity"
     if group == SchemaGroup.ENTITY_DYNAMIC_STATE:
         return "entity_dynamic_states" if plural else "entity_dynamic_state"
+    if group == SchemaGroup.TIMESERIES:
+        return "timeseries"
     if group == SchemaGroup.VIEW:
         return "views" if plural else "view"
     if group == SchemaGroup.ANNOTATION:

--- a/src/pixano/schemas/table_names.py
+++ b/src/pixano/schemas/table_names.py
@@ -25,6 +25,7 @@ from .embeddings import Embedding
 from .entities import Entity, EntityDynamicState
 from .records import Record
 from .schema_group import SchemaGroup
+from .timeseries import TimeSeries
 from .views import PDF, Image, PointCloud, SequenceFrame, Text, Video, View
 
 
@@ -74,6 +75,7 @@ _CANONICAL_RESOURCE_FAMILIES: tuple[CanonicalResourceFamily, ...] = (
     CanonicalResourceFamily("video", "videos", "videos", SchemaGroup.VIEW, Video),
     CanonicalResourceFamily("point_cloud", "point-clouds", "point_clouds", SchemaGroup.VIEW, PointCloud),
     CanonicalResourceFamily("pdf", "pdfs", "pdfs", SchemaGroup.VIEW, PDF, public_api=False),
+    CanonicalResourceFamily("timeseries", "timeseries", "timeseries", SchemaGroup.TIMESERIES, TimeSeries),
     CanonicalResourceFamily("embedding", "embeddings", "embeddings", SchemaGroup.EMBEDDING, Embedding),
 )
 
@@ -104,6 +106,7 @@ def supported_dataset_info_slots() -> tuple[str, ...]:
             "relation",
             "tracklet",
             "message",
+            "timeseries",
             "text_span",
         }
     )

--- a/src/pixano/schemas/timeseries.py
+++ b/src/pixano/schemas/timeseries.py
@@ -1,0 +1,51 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Per-frame time series with fixed-size vector columns (robot state/action).
+
+One row per (record, frame); each numeric feature is a LanceDB
+fixed-size-list column stamped with its dimension at import time (the same
+mechanism view embeddings use), so rows align 1:1 with sequence frames and
+stay queryable as vectors.
+"""
+
+from typing import Any
+
+from lancedb.pydantic import Vector
+from pydantic import create_model
+
+from pixano.schemas.records import RecordComponent
+
+
+class TimeSeries(RecordComponent):
+    """Base per-frame time-series row (concrete schemas add Vector columns).
+
+    Attributes:
+        view_id: Optional view the series is tied to ("" when record-global).
+        frame_id: The matching sequence-frame row id ("" when not linked).
+        frame_index: Frame position within the sequence.
+        timestamp: Time in seconds (episode-relative for robot datasets).
+    """
+
+    view_id: str = ""
+    frame_id: str = ""
+    frame_index: int = -1
+    timestamp: float = -1.0
+
+
+def create_timeseries_schema(vector_fields: dict[str, int]) -> type[TimeSeries]:
+    """Create a concrete TimeSeries schema with one Vector column per feature.
+
+    Args:
+        vector_fields: Column name -> fixed vector dimension
+            (e.g. ``{"action": 7, "observation_state": 7}``).
+
+    Returns:
+        The dynamically created schema class (named ``TimeSeries`` so the
+        info.json manifest resolves its canonical base).
+    """
+    fields: dict[str, Any] = {name: (Vector(dim), ...) for name, dim in vector_fields.items()}
+    return create_model("TimeSeries", __base__=TimeSeries, **fields)

--- a/tests/datasets/io/formats/test_lerobot_importer.py
+++ b/tests/datasets/io/formats/test_lerobot_importer.py
@@ -36,7 +36,13 @@ def make_v21_dataset(root: Path, episodes: int = 2) -> Path:
         "fps": FPS,
         "chunks_size": 1000,
         "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
-        "features": {CAMERA_KEY: {"dtype": "video"}, "action": {"dtype": "float32"}},
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "features": {
+            CAMERA_KEY: {"dtype": "video"},
+            "action": {"dtype": "float32", "shape": [6]},
+            "observation.state": {"dtype": "float32", "shape": [6]},
+            "timestamp": {"dtype": "float32", "shape": [1]},
+        },
         "total_episodes": episodes,
     }
     (root / "meta" / "info.json").write_text(json.dumps(info))
@@ -49,7 +55,25 @@ def make_v21_dataset(root: Path, episodes: int = 2) -> Path:
         target = root / "videos" / "chunk-000" / CAMERA_KEY / f"episode_{index:06d}.mp4"
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(VIDEO_MP4_ASSET_URL, target)
+        _write_data_parquet(
+            root / "data" / "chunk-000" / f"episode_{index:06d}.parquet", index, rows=200, dim=6
+        )
     return root
+
+
+def _write_data_parquet(path: Path, episode_index: int, rows: int, dim: int, t0: float = 0.0) -> None:
+    """LeRobot-shaped data rows: episode-relative timestamps on the fps grid."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.table(
+        {
+            "episode_index": pa.array([episode_index] * rows, pa.int64()),
+            "frame_index": pa.array(list(range(rows)), pa.int64()),
+            "timestamp": pa.array([t0 + i / FPS for i in range(rows)], pa.float32()),
+            "action": pa.array([[float(episode_index), float(i)] + [0.0] * (dim - 2) for i in range(rows)]),
+            "observation.state": pa.array([[float(i)] * dim for i in range(rows)]),
+        }
+    )
+    pq.write_table(table, path)
 
 
 def make_v3_dataset(root: Path) -> Path:
@@ -59,7 +83,12 @@ def make_v3_dataset(root: Path) -> Path:
         "codebase_version": "v3.0",
         "fps": FPS,
         "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
-        "features": {CAMERA_KEY: {"dtype": "video"}},
+        "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+        "features": {
+            CAMERA_KEY: {"dtype": "video"},
+            "action": {"dtype": "float32", "shape": [4]},
+            "observation.state": {"dtype": "float32", "shape": [4]},
+        },
         "total_episodes": 2,
     }
     (root / "meta" / "info.json").write_text(json.dumps(info))
@@ -67,7 +96,9 @@ def make_v3_dataset(root: Path) -> Path:
         {
             "episode_index": [0, 1],
             "tasks": [["pick"], ["place"]],
-            "length": [90, 88],
+            "length": [85, 100],
+            "data/chunk_index": [0, 0],
+            "data/file_index": [0, 0],
             f"videos/{CAMERA_KEY}/chunk_index": [0, 0],
             f"videos/{CAMERA_KEY}/file_index": [0, 0],
             f"videos/{CAMERA_KEY}/from_timestamp": [0.0, 3.0],
@@ -78,6 +109,23 @@ def make_v3_dataset(root: Path) -> Path:
     shard = root / "videos" / CAMERA_KEY / "chunk-000" / "file-000.mp4"
     shard.parent.mkdir(parents=True)
     shutil.copy(VIDEO_MP4_ASSET_URL, shard)
+    # One shared data shard holding both episodes' rows (episode-relative timestamps).
+    data_file = root / "data" / "chunk-000" / "file-000.parquet"
+    data_file.parent.mkdir(parents=True)
+    tables = []
+    for episode_index, rows in ((0, 85), (1, 100)):
+        tables.append(
+            pa.table(
+                {
+                    "episode_index": pa.array([episode_index] * rows, pa.int64()),
+                    "frame_index": pa.array(list(range(rows)), pa.int64()),
+                    "timestamp": pa.array([i / FPS for i in range(rows)], pa.float32()),
+                    "action": pa.array([[float(episode_index), float(i), 0.0, 0.0] for i in range(rows)]),
+                    "observation.state": pa.array([[float(i)] * 4 for i in range(rows)]),
+                }
+            )
+        )
+    pq.write_table(pa.concat_tables(tables), data_file)
     return root
 
 
@@ -142,7 +190,7 @@ class TestLeRobotImport:
         assert dataset.info.storage_mode == "embedded"
 
     @needs_ffmpeg
-    def test_v3_windows_extract_disjoint_frames(self, tmp_path: Path):
+    def test_v3_windows_extract_row_aligned(self, tmp_path: Path):
         source = make_v3_dataset(tmp_path / "ds")
         spec = _spec("lr_v3", max_frames_per_episode=6)
         result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
@@ -151,11 +199,16 @@ class TestLeRobotImport:
         assert dataset.open_table("records").count_rows() == 2
         assert dataset.open_table("sequence_frames").count_rows() == 12
         frames = dataset.get_data("sequence_frames", limit=20)
-        by_record: dict[str, list[float]] = {}
+        by_record: dict[str, list] = {}
         for frame in frames:
-            by_record.setdefault(frame.record_id, []).append(frame.timestamp)
-        first, second = sorted(by_record.values(), key=min)
-        assert max(first) < 3.05 and min(second) >= 2.95  # windows respected
+            by_record.setdefault(frame.record_id, []).append(frame)
+        for record_frames in by_record.values():
+            for frame in record_frames:
+                # Timestamps are the data rows' own (episode-relative, on the fps grid).
+                assert frame.timestamp == pytest.approx(frame.frame_index / FPS, abs=1e-3)
+        # The two windows decode different footage even though timestamps restart at 0.
+        lengths = sorted(max(f.frame_index for f in v) for v in by_record.values())
+        assert lengths[0] <= 85 and lengths[1] <= 100
 
     @needs_ffmpeg
     def test_episode_subset_and_idempotent_rerun(self, tmp_path: Path):
@@ -246,7 +299,9 @@ class TestHubSource:
         spec = _spec("hub_subset", episodes=[1], max_frames_per_episode=4)
         result = import_dataset("hub://acme/robo", tmp_path / "data", spec, importer=LeRobotImporter())
 
-        assert fake_hub["files"] == [[f"videos/chunk-000/{CAMERA_KEY}/episode_000001.mp4"]]
+        assert fake_hub["files"] == [
+            ["data/chunk-000/episode_000001.parquet", f"videos/chunk-000/{CAMERA_KEY}/episode_000001.mp4"]
+        ]
         dataset = Dataset(result.dataset_path)
         assert dataset.open_table("records").count_rows() == 1
         assert dataset.get_data("records")[0].episode_index == 1

--- a/tests/datasets/io/formats/test_lerobot_importer.py
+++ b/tests/datasets/io/formats/test_lerobot_importer.py
@@ -55,9 +55,7 @@ def make_v21_dataset(root: Path, episodes: int = 2) -> Path:
         target = root / "videos" / "chunk-000" / CAMERA_KEY / f"episode_{index:06d}.mp4"
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(VIDEO_MP4_ASSET_URL, target)
-        _write_data_parquet(
-            root / "data" / "chunk-000" / f"episode_{index:06d}.parquet", index, rows=200, dim=6
-        )
+        _write_data_parquet(root / "data" / "chunk-000" / f"episode_{index:06d}.parquet", index, rows=200, dim=6)
     return root
 
 
@@ -335,3 +333,110 @@ class TestWorkspaceDefault:
         spec = ImportSpec.model_validate({"format": "lerobot", "dataset": {"name": "x", "workspace": "image_vqa"}})
         info = LeRobotImporter().resolve_info(spec, SourceRef.from_string(str(source)))
         assert info.workspace == WorkspaceType.IMAGE_VQA
+
+
+class TestRowAlignedSampling:
+    @needs_ffmpeg
+    def test_frame_timestamps_are_the_data_rows_own(self, tmp_path: Path):
+        source = make_v3_dataset(tmp_path / "ds")
+        spec = _spec("lr_align")  # no cap: every row becomes a frame
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        dataset = Dataset(result.dataset_path)
+
+        # 85 + 100 rows -> exactly that many frames ("sample every frame").
+        assert dataset.open_table("sequence_frames").count_rows() == 185
+        frames = dataset.get_data("sequence_frames", limit=300)
+        for frame in frames:
+            assert frame.timestamp == pytest.approx(frame.frame_index / FPS, abs=1e-3)
+
+    @needs_ffmpeg
+    def test_off_grid_timestamp_is_a_hard_error(self, tmp_path: Path):
+        from pixano.datasets.io.errors import MetadataError
+
+        source = make_v21_dataset(tmp_path / "ds", episodes=1)
+        # Corrupt one timestamp far off the fps grid.
+        data_file = source / "data" / "chunk-000" / "episode_000000.parquet"
+        table = pq.read_table(data_file).to_pylist()
+        table[5]["timestamp"] = table[5]["timestamp"] + 0.4 * (1.0 / FPS)
+        pq.write_table(pa.Table.from_pylist(table), data_file)
+
+        spec = _spec("lr_offgrid")
+        with pytest.raises(MetadataError, match="timestamp_alignment"):
+            list(
+                LeRobotImporter().iter_batches(
+                    SourceRef.from_string(str(source)),
+                    spec,
+                    __import__("pixano.datasets.io.plan", fromlist=["ImportPlan"]).ImportPlan(
+                        format="lerobot", importer_version="1.0.0"
+                    ),
+                )
+            )
+
+
+class TestTimeSeriesTable:
+    @needs_ffmpeg
+    def test_vectors_align_with_frames(self, tmp_path: Path):
+        source = make_v3_dataset(tmp_path / "ds")
+        spec = _spec("lr_ts", max_frames_per_episode=10)
+        result = import_dataset(source, tmp_path / "data", spec, importer=LeRobotImporter())
+        dataset = Dataset(result.dataset_path)
+
+        assert dataset.open_table("timeseries").count_rows() == 20  # 10 per episode
+        rows = (
+            dataset.open_table("timeseries")
+            .search()
+            .select(["record_id", "frame_index", "timestamp", "action", "observation_state"])
+            .limit(None)
+            .to_list()
+        )
+        for row in rows:
+            assert len(row["action"]) == 4 and len(row["observation_state"]) == 4
+            # values encode (episode, frame): action = [ep, i, 0, 0]; state = [i]*4
+            assert row["action"][1] == row["frame_index"]
+            assert row["observation_state"][0] == row["frame_index"]
+            assert row["timestamp"] == pytest.approx(row["frame_index"] / FPS, abs=1e-3)
+
+        # timeseries rows pair exactly with kept frames (same stride).
+        frame_indices = sorted(
+            f["frame_index"]
+            for f in dataset.open_table("sequence_frames")
+            .search()
+            .select(["frame_index", "record_id"])
+            .limit(None)
+            .to_list()
+        )
+        series_indices = sorted(r["frame_index"] for r in rows)
+        assert series_indices == frame_indices
+
+    @needs_ffmpeg
+    def test_vector_schema_survives_reopen(self, tmp_path: Path):
+        source = make_v3_dataset(tmp_path / "ds")
+        result = import_dataset(
+            source, tmp_path / "data", _spec("lr_reopen", max_frames_per_episode=4), importer=LeRobotImporter()
+        )
+        reopened = Dataset(result.dataset_path)  # info.json manifest round-trip
+        fields = reopened.info.tables["timeseries"].model_fields
+        assert "action" in fields and "observation_state" in fields
+
+    @needs_ffmpeg
+    def test_rest_timeseries_route(self, tmp_path: Path):
+        from fastapi.testclient import TestClient
+
+        from pixano.api.main import create_app
+        from pixano.api.settings import Settings, get_settings
+
+        source = make_v3_dataset(tmp_path / "ds")
+        (tmp_path / "data" / "library").mkdir(parents=True)
+        result = import_dataset(
+            source, tmp_path / "data", _spec("lr_rest", max_frames_per_episode=4), importer=LeRobotImporter()
+        )
+        settings = Settings(library_dir=str(tmp_path / "data" / "library"))
+        app = create_app(settings)
+        app.dependency_overrides[get_settings] = lambda: settings
+        client = TestClient(app)
+
+        dataset_id = Dataset(result.dataset_path).info.id
+        response = client.get(f"/datasets/{dataset_id}/timeseries")
+        assert response.status_code == 200
+        items = response.json()["items"]
+        assert items and len(items[0]["action"]) == 4

--- a/tests/datasets/test_dataset_info.py
+++ b/tests/datasets/test_dataset_info.py
@@ -52,6 +52,7 @@ class TestDatasetInfo:
             "relation",
             "tracklet",
             "message",
+            "timeseries",
             "text_span",
             "views",
             "tables",
@@ -114,6 +115,7 @@ class TestDatasetInfo:
     "message": null,
     "multi_path": null,
     "text_span": null,
+    "timeseries": null,
     "views": {
         "image": {
             "base": "Image",
@@ -151,6 +153,7 @@ class TestDatasetInfo:
     "tracklet": null,
     "message": null,
     "text_span": null,
+    "timeseries": null,
     "views": {
         "image": {
             "base": "Image",
@@ -288,13 +291,13 @@ class TestDatasetInfo:
         ).to_json(info_fp)
 
         payload = json.loads(info_fp.read_text(encoding="utf-8"))
-        payload["views"]["timeseries"] = {"base": "TimeSeries", "fields": {}}
+        payload["views"]["hologram"] = {"base": "HologramView", "fields": {}}
         info_fp.write_text(json.dumps(payload, indent=4), encoding="utf-8")
 
         info = DatasetInfo.from_json(info_fp)
 
         assert "image" in info.views
-        assert "timeseries" not in info.views
+        assert "hologram" not in info.views
 
     def test_load_id(self):
         temp_dir = Path(tempfile.TemporaryDirectory().name)

--- a/tests/datasets/test_merge_records.py
+++ b/tests/datasets/test_merge_records.py
@@ -211,7 +211,7 @@ class TestValidateBatchFkLookup:
             {},
             dataset,
             raise_or_warn="raise",
-            fk_lookup=lambda table, values: {value: True for value in values},
+            fk_lookup=lambda table, values: dict.fromkeys(values, True),
         )
 
         # Ledger says they don't: same call fails.
@@ -222,7 +222,7 @@ class TestValidateBatchFkLookup:
                 {},
                 dataset,
                 raise_or_warn="raise",
-                fk_lookup=lambda table, values: {value: False for value in values},
+                fk_lookup=lambda table, values: dict.fromkeys(values, False),
             )
 
 


### PR DESCRIPTION
## Issue

Checkpoint-D findings on real v3 datasets (LIBERO-class): (1) frames were resampled by ffmpeg's fps filter with synthetic timestamps instead of sampling 1:1 with the data rows LeRobot's `delta_timestamps` indexes against; (2) `action`/`observation.state` were dropped entirely.

**⚠️ Stacked on #688** — merge order: #688 → this.

## Description

**Commit 1 — row-timestamp-aligned sampling** (verified against a real cached v3 snapshot's column names):
- The layout parses each episode's **data parquet** location (v3: `data/chunk_index` + `data/file_index`; v2.1: the per-episode template) and reads its rows (`timestamp`, `frame_index`, float features) with pyarrow only.
- Extraction decodes the window with `-fps_mode passthrough` (every encoded frame, no resampling) and maps each data row to its frame with LeRobot's tolerance discipline (`options.tolerance_s`, default 1e-4 — off-grid rows are a hard `timestamp_alignment` error, never a silently shifted frame). **One `SequenceFrame` per data row**, carrying the row's own `frame_index` and episode-relative `timestamp`.
- Hub ingest also fetches the selected episodes' data parquets.

**Commit 2 — `timeseries` canonical family**:
- `TimeSeries(RecordComponent)` + `create_timeseries_schema(...)` stamping one **fixed-size `Vector(dim)`** column per feature (the view-embedding mechanism); registered end-to-end (schema group, declarable slot, insert order, read-only REST at `/datasets/{id}/timeseries`); Vector columns round-trip through the `info.json` manifest.
- The LeRobot importer detects 1-D float features and emits one timeseries row per data row; the `--max-frames` cap strides frames and vectors identically so they stay paired.

**Verified on the real `nvidia/BridgeData2_LeRobot_v3`** (fps 5): episode 0 → 23 rows → 23 frames × 4 cameras with the parquet's own float32 timestamps (0.0, 0.2, …), plus a 23-row `timeseries` table with real `Vector(7)` `action`/`observation_state` values, workspace `video`.

20 LeRobot tests (5 new); full suite green (626).

🤖 Generated with [Claude Code](https://claude.com/claude-code)