### PR TITLE
fix: serve every frame batch — filtered scans no longer cap at the table head

### DIFF
--- a/src/pixano/api/models.py
+++ b/src/pixano/api/models.py
@@ -376,6 +376,7 @@ class DatasetInfoResponse(DatasetInfo):
         "tracklet",
         "message",
         "text_span",
+        "timeseries",
         when_used="json",
     )
     def serialize_schema_slot(self, schema_cls: type[LanceModel] | None) -> dict[str, Any] | None:

--- a/src/pixano/datasets/dataset.py
+++ b/src/pixano/datasets/dataset.py
@@ -675,8 +675,7 @@ class Dataset:
         )
         assert where is not None
 
-        query = table.search(None).select(columns).where(where).limit(batch_size)
-        rows = query.to_list()
+        rows = TableQueryBuilder(table).select(columns).where(where).limit(batch_size).to_list()
         rows.sort(key=lambda row: int(row.get("frame_index", -1)))
 
         result = []

--- a/src/pixano/datasets/queries/table.py
+++ b/src/pixano/datasets/queries/table.py
@@ -230,15 +230,22 @@ class TableQueryBuilder:
         needs_duckdb = len(self._order_by) > 0 or (self._offset is not None and self._offset > 0)
 
         if not needs_duckdb:
-            # LanceDB native path — pushes predicates to storage layer, avoids full table materialization
-            if self._limit is None:
-                limit = self.table.count_rows(self._where) if self._where else self.table.count_rows()
+            # LanceDB native path. CAUTION: in lancedb 0.29 plain scans apply
+            # `limit` to the rows SCANNED, before the `where` filter — a filtered
+            # query whose matches are not at the head of the table silently
+            # under-returns. With a filter we must scan the whole table (late
+            # materialization keeps this cheap) and slice the limit afterwards.
+            if self._where is not None:
+                scan_limit = self.table.count_rows()
             else:
-                limit = self._limit
-            query = self.table.search(None).select(columns).limit(limit)
+                scan_limit = self._limit if self._limit is not None else self.table.count_rows()
+            query = self.table.search(None).select(columns).limit(scan_limit)
             if self._where is not None:
                 query = query.where(self._where)
-            return query.to_arrow()
+            result = query.to_arrow()
+            if self._where is not None and self._limit is not None:
+                result = result.slice(0, self._limit)
+            return result
         elif not has_count_join:
             # Optimized path: avoid full table.to_arrow() by fetching bounded set from LanceDB
             # then sorting/slicing with DuckDB over only that subset
@@ -246,17 +253,22 @@ class TableQueryBuilder:
             limit = self._limit
 
             if len(self._order_by) == 0:
-                # No ORDER BY, just OFFSET — use LanceDB native with overfetch + slice
-                fetch_limit = offset + limit if limit is not None else self.table.count_rows()
+                # No ORDER BY, just OFFSET — overfetch + slice. Same scan-limit
+                # caveat as the native path: with a filter, scan everything.
+                if self._where is not None:
+                    fetch_limit = self.table.count_rows()
+                else:
+                    fetch_limit = offset + limit if limit is not None else self.table.count_rows()
                 query = self.table.search(None).select(columns).limit(fetch_limit)
                 if self._where is not None:
                     query = query.where(self._where)
                 arrow_table = query.to_arrow()
-                return arrow_table.slice(offset, limit) if offset > 0 else arrow_table
+                return arrow_table.slice(offset, limit if limit is not None else max(arrow_table.num_rows - offset, 0))
             else:
                 # ORDER BY on a regular column — need to fetch all matching rows, sort, then slice
-                # But we only fetch the columns we need via LanceDB native (no full to_arrow())
-                total = self.table.count_rows(self._where) if self._where is not None else self.table.count_rows()
+                # But we only fetch the columns we need via LanceDB native (no full to_arrow()).
+                # Scan the FULL table when filtered (limit applies pre-filter, see above).
+                total = self.table.count_rows()
                 query = self.table.search(None).select(columns).limit(total)
                 if self._where is not None:
                     query = query.where(self._where)

--- a/tests/app/test_api_io.py
+++ b/tests/app/test_api_io.py
@@ -158,3 +158,112 @@ class TestLegacyAliasParity:
         client, _, _ = client_and_dirs
         assert client.post("/datasets/import", json={"source_dir": "/tmp", "import_type": "bogus"}).status_code == 400
         assert client.post("/datasets/import", json={"source_dir": "/nope/missing"}).status_code == 400
+
+
+class TestTimeSeriesDatasetSerialization:
+    def test_datasets_listing_survives_a_timeseries_slot(self, tmp_path: Path):
+        # Regression: the timeseries slot class leaked into JSON serialization
+        # and 500'd GET /datasets for the whole library.
+        from pixano.datasets import Dataset, DatasetInfo
+        from pixano.schemas import Record, SequenceFrame, create_timeseries_schema
+
+        library = tmp_path / "lib" / "library"
+        library.mkdir(parents=True)
+        info = DatasetInfo(
+            name="robo",
+            record=Record,
+            timeseries=create_timeseries_schema({"action": 3, "observation_state": 3}),
+            views={"top": SequenceFrame},
+        )
+        Dataset.create(library / "robo", info)
+
+        settings = Settings(library_dir=str(library))
+        app = create_app(settings)
+        app.dependency_overrides[get_settings] = lambda: settings
+        client = TestClient(app)
+
+        listing = client.get("/datasets")
+        assert listing.status_code == 200
+        payload = listing.json()[0]
+        assert payload["timeseries"]["fields"]["action"]["type"] == "FixedSizeList"
+        assert payload["timeseries"]["fields"]["action"]["dim"] == 3
+
+        detail = client.get(f"/datasets/{payload['id']}/info")
+        assert detail.status_code == 200
+        assert detail.json()["timeseries"]["fields"]["observation_state"]["dim"] == 3
+
+
+class TestSframeBatchPagination:
+    def test_all_chunks_of_a_long_episode_are_served(self, tmp_path: Path):
+        # Regression: lancedb plain scans apply `limit` pre-filter, so batches
+        # past the first (and any record whose rows aren't at the table head)
+        # returned 404 — playback appeared truncated at 128 frames.
+        import io
+
+        from pixano.datasets import Dataset, DatasetInfo
+        from pixano.schemas import Record, SequenceFrame
+
+        library = tmp_path / "lib" / "library"
+        library.mkdir(parents=True)
+        info = DatasetInfo(name="clips", record=Record, views={"cam": SequenceFrame})
+        dataset = Dataset.create(library / "clips", info)
+
+        jpeg = PIL.Image.new("RGB", (4, 4), (5, 6, 7))
+        buffer = io.BytesIO()
+        jpeg.save(buffer, "JPEG")
+        blob = buffer.getvalue()
+        for record_index in range(2):
+            record = Record(id=f"rec{record_index}", split="train")
+            frames = [
+                SequenceFrame(
+                    id=f"r{record_index}f{i}",
+                    record_id=record.id,
+                    logical_name="cam",
+                    uri="",
+                    raw_bytes=blob,
+                    width=4,
+                    height=4,
+                    format="JPEG",
+                    frame_index=i,
+                    timestamp=i / 10,
+                )
+                for i in range(150)
+            ]
+            dataset.add_records({"records": record, "sequence_frames": frames}, check_integrity="none")
+
+        settings = Settings(library_dir=str(library))
+        app = create_app(settings)
+        app.dependency_overrides[get_settings] = lambda: settings
+        client = TestClient(app)
+        dataset_id = dataset.info.id
+
+        # rec1's rows live past the first 150 table rows — the old code 404'd
+        # for every one of its batches beyond the scan head.
+        for record_id, starts in (("rec0", (0, 128)), ("rec1", (0, 128))):
+            served = 0
+            for start in starts:
+                response = client.get(
+                    f"/datasets/{dataset_id}/records/{record_id}/sframes/batch",
+                    params={"view_name": "cam", "start_frame": start, "batch_size": 128},
+                )
+                assert response.status_code == 200, (record_id, start)
+                served += response.content.count(b"X-Frame-Index") + response.content.count(b"x-frame-index")
+            assert served == 150, record_id
+
+    def test_filtered_list_of_a_non_head_record_is_complete(self, tmp_path: Path):
+        from pixano.datasets import Dataset, DatasetInfo
+        from pixano.datasets.queries import TableQueryBuilder
+        from pixano.schemas import Entity, Record
+
+        library = tmp_path / "lib2" / "library"
+        library.mkdir(parents=True)
+        info = DatasetInfo(name="ents", record=Record, entity=Entity)
+        dataset = Dataset.create(library / "ents", info)
+        for record_index in range(3):
+            record = Record(id=f"rec{record_index}", split="train")
+            entities = [Entity(id=f"r{record_index}e{i}", record_id=record.id) for i in range(120)]
+            dataset.add_records({"records": record, "entities": entities}, check_integrity="none")
+
+        table = dataset.open_table("entities")
+        rows = TableQueryBuilder(table).select(["id"]).where("record_id = 'rec2'").limit(100).to_list()
+        assert len(rows) == 100  # previously 0: rec2's rows sit past the first 100 scanned


### PR DESCRIPTION
## Issue

Checkpoint-D finding: a re-imported LeRobot episode (400 frames, data verified complete in LanceDB) played **truncated at 128 frames** in the Pixano video player.

## Description

Two defects, both reproduced and verified fixed on the reporter's real library:

1. **Filtered scans capped at the table head** (the truncation): lancedb 0.29 plain scans apply `limit` to the rows *scanned*, before the `where` filter. `TableQueryBuilder`'s native/overfetch/order-by paths trusted `limit(N)` alongside a filter, so any filtered query whose matches aren't at the head of the table silently under-returned — frame batches past `start_frame=0` returned 404 (the player fetched one 128-frame chunk and stopped), and record-scoped listings of later records dropped rows. The builder now scans the full table when a filter is present (late materialization keeps the cost bounded) and slices the requested limit **after** filtering; `get_temporal_view_batch` routes through the builder.
2. **`GET /datasets` 500 with a timeseries dataset**: `DatasetInfoResponse.serialize_schema_slot` didn't list the new `timeseries` slot, so the raw schema class reached pydantic (`Unable to serialize ModelMetaclass`) and the datasets listing crashed for the whole library.

**Verified on the real `aloha_sim_insertion_scripted` import**: `GET /datasets` 200 with the timeseries schema serialized; sframes list 400/400; all four batch chunks (128/128/128/16) serve for both the **first and the last** episode (the last episode's rows sit at the table's end — the worst case for the old scan behavior).

Regression tests: multi-chunk batch serving across records, non-head-record filtered lists at the builder level, timeseries dataset serialization. Full suite green (629) incl. the slow scale suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)