### PR TITLE
feat: resume interrupted imports from the last committed checkpoint

### DIFF
--- a/src/pixano/api/routers/data_io.py
+++ b/src/pixano/api/routers/data_io.py
@@ -227,10 +227,14 @@ def cancel_job(job_id: str, settings: Annotated[Settings, Depends(get_settings)]
         raise HTTPException(status_code=409, detail=str(error)) from None
 
 
-@router.post("/jobs/{job_id}/resume", status_code=501, operation_id="resume_io_job")
-def resume_job(job_id: str) -> dict[str, str]:
-    """Resume lands with the P5 checkpointing slice."""
-    return {"detail": "resume is not implemented yet (planned: 0.8.x)"}
+@router.post("/jobs/{job_id}/resume", status_code=202, operation_id="resume_io_job")
+def resume_job(job_id: str, settings: Annotated[Settings, Depends(get_settings)]) -> JobResponse:
+    """Resume an interrupted/errored import from its last committed checkpoint."""
+    _, runner = _runner(settings)
+    try:
+        return _job_response(runner.submit_resume(job_id))
+    except (JobStateError, PixanoDataError) as error:
+        raise HTTPException(status_code=409, detail=str(error)) from None
 
 
 @router.delete("/jobs/{job_id}", status_code=501, operation_id="rollback_io_job")

--- a/src/pixano/cli/data.py
+++ b/src/pixano/cli/data.py
@@ -242,7 +242,7 @@ def formats_command() -> None:
 @data_app.command(name="jobs")
 def jobs_command(
     data_dir: Path = typer.Argument(..., exists=True, file_okay=False, help="Pixano data directory."),
-    action: str = typer.Argument("list", help="list, show, or cancel."),
+    action: str = typer.Argument("list", help="list, show, cancel, or resume."),
     job_id: str = typer.Argument("", help="Job id (for show/cancel)."),
 ) -> None:
     """Inspect the shared import/export job store (the same one the GUI polls)."""
@@ -254,7 +254,7 @@ def jobs_command(
             done = job.progress.get("done", "")
             typer.echo(f"{job.id}  {job.kind:<7} {job.status:<12} {job.dataset:<24} {done}")
         return
-    if action in ("show", "cancel") and not job_id:
+    if action in ("show", "cancel", "resume") and not job_id:
         raise typer.BadParameter(f"'{action}' needs a job id.")
     if action == "show":
         shown = store.get_job(job_id)
@@ -271,7 +271,23 @@ def jobs_command(
             raise typer.Exit(code=1) from None
         typer.echo(f"Job '{job_id}' -> {job.status}.")
         return
-    raise typer.BadParameter(f"Unknown action '{action}' (list, show, cancel).")
+    if action == "resume":
+        from pixano.datasets.io.jobs import JobRunner
+
+        runner = JobRunner(store, data_dir)
+        try:
+            job = runner.submit_resume(job_id)
+        except PixanoDataError as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(code=1) from None
+        typer.echo(
+            f"Job '{job_id}' resuming (status: {job.status}). Poll with: pixano data jobs {data_dir} show {job_id}"
+        )
+        runner.join()
+        final = store.get_job(job_id)
+        typer.echo(f"Job '{job_id}' -> {final.status if final else 'unknown'}.")
+        return
+    raise typer.BadParameter(f"Unknown action '{action}' (list, show, cancel, resume).")
 
 
 @data_app.command(name="migrate-jsonl")

--- a/src/pixano/datasets/io/api.py
+++ b/src/pixano/datasets/io/api.py
@@ -66,6 +66,8 @@ def import_dataset(
     importer: DatasetImporter | None = None,
     sinks: Sequence[ProgressSink] = (),
     engine: ImportEngine | None = None,
+    job_id: str | None = None,
+    resume_cursor: dict | None = None,
 ) -> ImportResult:
     """Import a source into the data directory's library (analyze → validate → ingest).
 
@@ -78,6 +80,8 @@ def import_dataset(
         importer: Explicit importer instance (advanced; bypasses the registry).
         sinks: Progress sinks (e.g. a tqdm sink).
         engine: Preconfigured engine (jobs wire checkpoints/cancellation through it).
+        job_id: External job id (names the staging dir so crashed builds resume).
+        resume_cursor: Last committed cursor; re-enters the importer past done work.
 
     Returns:
         The import result (dataset id/path, per-table row counts).
@@ -108,7 +112,7 @@ def import_dataset(
         info.description = spec.dataset.description
 
     engine = engine or ImportEngine(Path(data_dir))
-    return engine.run(resolved, source_ref, spec, plan, info, sinks=sinks)
+    return engine.run(resolved, source_ref, spec, plan, info, sinks=sinks, job_id=job_id, resume_cursor=resume_cursor)
 
 
 def export_dataset(

--- a/src/pixano/datasets/io/engine.py
+++ b/src/pixano/datasets/io/engine.py
@@ -49,7 +49,7 @@ from pixano.schemas import SchemaGroup, is_image, is_sequence_frame, is_view, sc
 from pixano.schemas.views.image import _generate_preview
 from pixano.utils import to_snake_case
 
-from .errors import JobStateError, SpecValidationError, UnsupportedStorageError
+from .errors import JobStateError, ResumeError, SpecValidationError, UnsupportedStorageError
 from .ids import IdLedger
 from .importer import Cursor, DatasetImporter, SourceRef
 from .manifest import ImportManifest
@@ -61,6 +61,12 @@ from .spec import ImportSpec
 logger = logging.getLogger(__name__)
 
 PIXANO_STATE_DIR = ".pixano"
+
+
+class _CancelledImport(JobStateError):
+    """Cooperative cancellation observed at a flush boundary (deliberate stop)."""
+
+
 DEFAULT_FLUSH_ROWS = 4096
 DEFAULT_FLUSH_BYTES = 256 * 1024 * 1024
 
@@ -178,10 +184,23 @@ class ImportEngine:
         plan: ImportPlan,
         info: DatasetInfo,
         sinks: Sequence[ProgressSink] = (),
+        job_id: str | None = None,
+        resume_cursor: Cursor | None = None,
     ) -> ImportResult:
-        """Execute the plan: stream, validate, write, finalize — atomically per mode."""
+        """Execute the plan: stream, validate, write, finalize — atomically per mode.
+
+        ``job_id`` lets a job store name the run (staging dirs become
+        discoverable for resume); ``resume_cursor`` re-enters the importer past
+        already-committed work — requires ``importer.supports_resume`` and
+        ``deterministic_ids`` (boundary flushes upsert, so replays converge).
+        """
         started_at = time.monotonic()
-        job_id = shortuuid.uuid()
+        job_id = job_id or shortuuid.uuid()
+        if resume_cursor is not None and not (importer.supports_resume and importer.deterministic_ids):
+            raise ResumeError(
+                f"Format '{importer.format_name}' does not support resume "
+                "(needs supports_resume and deterministic ids); restart the import instead."
+            )
         dataset_name = to_snake_case(spec.dataset.name or info.name)
         if not dataset_name:
             raise SpecValidationError("dataset.name must contain at least one alphanumeric character.")
@@ -190,8 +209,22 @@ class ImportEngine:
         replay_journals(self.data_dir)
 
         if spec.mode == "add":
-            return self._run_add(importer, source, spec, plan, job_id, target_dir, sinks, started_at)
-        return self._run_build(importer, source, spec, plan, info, job_id, dataset_name, target_dir, sinks, started_at)
+            return self._run_add(
+                importer, source, spec, plan, job_id, target_dir, sinks, started_at, resume_cursor=resume_cursor
+            )
+        return self._run_build(
+            importer,
+            source,
+            spec,
+            plan,
+            info,
+            job_id,
+            dataset_name,
+            target_dir,
+            sinks,
+            started_at,
+            resume_cursor=resume_cursor,
+        )
 
     # ------------------------------------------------------------------
     # create / overwrite: staged build + atomic promotion
@@ -209,8 +242,9 @@ class ImportEngine:
         target_dir: Path,
         sinks: Sequence[ProgressSink],
         started_at: float,
+        resume_cursor: Cursor | None = None,
     ) -> ImportResult:
-        if spec.mode == "create" and target_dir.exists():
+        if spec.mode == "create" and target_dir.exists() and resume_cursor is None:
             raise SpecValidationError(
                 f"Dataset '{dataset_name}' already exists at '{target_dir}'. Use mode 'overwrite' or 'add'."
             )
@@ -220,22 +254,50 @@ class ImportEngine:
         self.library_dir.mkdir(parents=True, exist_ok=True)
         self._assert_same_filesystem(staging_dir.parent, self.library_dir)
 
-        if not info.id:
-            info.id = shortuuid.uuid()
-        dataset = Dataset.create(staging_dir, info)
+        resuming = resume_cursor is not None and staging_dir.exists()
+        if resume_cursor is not None and not staging_dir.exists():
+            raise ResumeError(
+                f"No staging directory for job '{job_id}' — the build cannot resume; restart the import."
+            )
+        if resuming:
+            # Continue inside the never-promoted staging dataset; boundary
+            # flushes upsert, so the last (possibly replayed) bundle converges.
+            dataset = Dataset(staging_dir)
+            dataset.create_scalar_indexes()
+        else:
+            if not info.id:
+                info.id = shortuuid.uuid()
+            dataset = Dataset.create(staging_dir, info)
         ledger = IdLedger(spill_dir=staging_dir / ".ledger")
         table_counts: dict[str, int] = {}
         census = _MediaCensus()
 
         try:
-            for cursor in self._stream(importer, source, spec, plan, dataset, ledger, table_counts, census, sinks):
+            for cursor in self._stream(
+                importer,
+                source,
+                spec,
+                plan,
+                dataset,
+                ledger,
+                table_counts,
+                census,
+                sinks,
+                add_mode=resuming,  # resumed flushes upsert (at-least-once -> exactly-once)
+                start_cursor=resume_cursor,
+            ):
                 if self.checkpoint is not None:
                     self.checkpoint(cursor, dict(table_counts))
                 self._check_cancelled()
             self._finalize(dataset, spec, plan, importer, job_id, table_counts, census, sinks, add_mode=False)
-        except BaseException:
+        except _CancelledImport:
             ledger.close()
-            shutil.rmtree(staging_dir, ignore_errors=True)
+            shutil.rmtree(staging_dir, ignore_errors=True)  # cancel = deliberate: drop staging
+            raise
+        except BaseException:
+            # Preserve staging: a crashed/failed build resumes from the last
+            # committed flush (trash GC reclaims abandoned staging dirs).
+            ledger.close()
             raise
         ledger.close()
         shutil.rmtree(staging_dir / ".ledger", ignore_errors=True)
@@ -287,22 +349,28 @@ class ImportEngine:
         target_dir: Path,
         sinks: Sequence[ProgressSink],
         started_at: float,
+        resume_cursor: Cursor | None = None,
     ) -> ImportResult:
         if not target_dir.exists():
             raise SpecValidationError(f"Dataset '{target_dir.name}' does not exist; use mode 'create'.")
         dataset = Dataset(target_dir)
 
-        manifest = ImportManifest(
-            job_id=job_id,
-            dataset_id=dataset.info.id,
-            spec_fingerprint=spec.fingerprint(),
-            plan_fingerprint=plan.plan_fingerprint,
-            id_namespace=spec.ids.namespace or "",
-            importer_version=importer.importer_version,
-            pre_import_versions={name: dataset.open_table(name).version for name in dataset.info.tables},
-        )
         manifest_path = target_dir / "imports" / f"{job_id}.manifest.json"
-        manifest.save(manifest_path)
+        if resume_cursor is not None and manifest_path.is_file():
+            # Resume: keep the original manifest so pre-import versions (the
+            # rollback anchor) still describe the state before the FIRST run.
+            manifest = ImportManifest.load(manifest_path)
+        else:
+            manifest = ImportManifest(
+                job_id=job_id,
+                dataset_id=dataset.info.id,
+                spec_fingerprint=spec.fingerprint(),
+                plan_fingerprint=plan.plan_fingerprint,
+                id_namespace=spec.ids.namespace or "",
+                importer_version=importer.importer_version,
+                pre_import_versions={name: dataset.open_table(name).version for name in dataset.info.tables},
+            )
+            manifest.save(manifest_path)
 
         # Indexes make the upserting merge path scale past full-table scans.
         dataset.create_scalar_indexes()
@@ -312,7 +380,17 @@ class ImportEngine:
         census = _MediaCensus()
         try:
             for cursor in self._stream(
-                importer, source, spec, plan, dataset, ledger, table_counts, census, sinks, add_mode=True
+                importer,
+                source,
+                spec,
+                plan,
+                dataset,
+                ledger,
+                table_counts,
+                census,
+                sinks,
+                add_mode=True,
+                start_cursor=resume_cursor,
             ):
                 if self.checkpoint is not None:
                     self.checkpoint(cursor, dict(table_counts))
@@ -351,6 +429,7 @@ class ImportEngine:
         census: "_MediaCensus",
         sinks: Sequence[ProgressSink],
         add_mode: bool = False,
+        start_cursor: Cursor | None = None,
     ) -> Iterator[Cursor]:
         """Consume importer bundles through bounded buffers; yield committed cursors."""
         row_buffers: dict[str, list[LanceModel]] = {}
@@ -368,7 +447,7 @@ class ImportEngine:
             buffered_bytes = 0
             self._emit_progress(sinks, plan, table_counts)
 
-        for bundle in importer.iter_batches(source, spec, plan):
+        for bundle in importer.iter_batches(source, spec, plan, cursor=start_cursor):
             for table_name, payload in bundle.tables.items():
                 if isinstance(payload, (pa.RecordBatch, pa.Table)):
                     # Arrow payloads are pre-batched by the importer: write through.
@@ -550,7 +629,7 @@ class ImportEngine:
 
     def _check_cancelled(self) -> None:
         if self.cancel_check is not None and self.cancel_check():
-            raise JobStateError("Import cancelled.")
+            raise _CancelledImport("Import cancelled.")
 
     def _assert_same_filesystem(self, staging_parent: Path, library_dir: Path) -> None:
         if staging_parent.stat().st_dev != library_dir.stat().st_dev:

--- a/src/pixano/datasets/io/jobs.py
+++ b/src/pixano/datasets/io/jobs.py
@@ -285,14 +285,52 @@ class JobRunner:
     def submit_import(self, source: str, spec_payload: dict[str, Any], plan_id: str = "") -> JobRecord:
         """Create a pending import job and start it on the worker thread."""
         job = self.store.create_job(
-            "import", dataset=str(spec_payload.get("dataset", {}).get("name", "")), spec=spec_payload, plan_id=plan_id
+            "import",
+            dataset=str(spec_payload.get("dataset", {}).get("name", "")),
+            spec={**spec_payload, "__source": source},  # resume needs the source; stripped before validation
+            plan_id=plan_id,
         )
         thread = threading.Thread(target=self._run_import, args=(job.id, source, spec_payload, plan_id), daemon=True)
         self._threads.append(thread)
         thread.start()
         return job
 
-    def _run_import(self, job_id: str, source: str, spec_payload: dict[str, Any], plan_id: str) -> None:
+    def submit_resume(self, job_id: str) -> JobRecord:
+        """Resume an interrupted/errored job from its last committed cursor."""
+        job = self.store.get_job(job_id)
+        if job is None:
+            raise JobStateError(f"Unknown job '{job_id}'.")
+        if job.kind != "import" or job.status not in ("interrupted", "error"):
+            raise JobStateError(f"Job '{job_id}' is {job.status}; only interrupted/errored imports resume.")
+        if not job.cursor:
+            raise JobStateError(f"Job '{job_id}' has no committed checkpoint; restart the import instead.")
+        source = str(job.spec.get("__source", "")) or ""
+        stored_plan = self.store.get_plan(job.plan_id) if job.plan_id else None
+        if not source and stored_plan is not None:
+            source = stored_plan[1]
+        if not source:
+            raise JobStateError(f"Job '{job_id}' recorded no source; restart the import instead.")
+        self.store.update_job(job_id, status="pending", error={})
+        thread = threading.Thread(
+            target=self._run_import,
+            args=(job_id, source, {k: v for k, v in job.spec.items() if k != "__source"}, job.plan_id),
+            kwargs={"resume_cursor": dict(job.cursor)},
+            daemon=True,
+        )
+        self._threads.append(thread)
+        thread.start()
+        refreshed = self.store.get_job(job_id)
+        assert refreshed is not None
+        return refreshed
+
+    def _run_import(
+        self,
+        job_id: str,
+        source: str,
+        spec_payload: dict[str, Any],
+        plan_id: str,
+        resume_cursor: dict[str, Any] | None = None,
+    ) -> None:
         from .api import import_dataset
         from .engine import ImportEngine
         from .spec import ImportSpec
@@ -303,7 +341,7 @@ class JobRunner:
                 return
             self.store.update_job(job_id, status="running", pid=os.getpid(), heartbeat=time.time())
             try:
-                spec = ImportSpec.model_validate(spec_payload)
+                spec = ImportSpec.model_validate({k: v for k, v in spec_payload.items() if k != "__source"})
                 plan = None
                 if plan_id:
                     stored = self.store.get_plan(plan_id)
@@ -317,7 +355,16 @@ class JobRunner:
                     cancel_check=lambda: self.store.cancel_requested(job_id),
                 )
                 sink = JobSink(self.store, job_id)
-                result = import_dataset(source, self.data_dir, spec, plan=plan, sinks=[sink], engine=engine)
+                result = import_dataset(
+                    source,
+                    self.data_dir,
+                    spec,
+                    plan=plan,
+                    sinks=[sink],
+                    engine=engine,
+                    job_id=job_id,
+                    resume_cursor=resume_cursor,
+                )
                 sink.close()
                 self.store.update_job(
                     job_id,

--- a/tests/app/test_api_io.py
+++ b/tests/app/test_api_io.py
@@ -110,9 +110,9 @@ class TestIoRoutes:
         restarted = TestClient(app2)
         assert restarted.get(f"/io/jobs/{orphan.id}").json()["status"] == "interrupted"
 
-    def test_resume_and_rollback_are_501(self, client_and_dirs):
+    def test_resume_conflicts_on_unknown_job_and_rollback_is_501(self, client_and_dirs):
         client, _, _ = client_and_dirs
-        assert client.post("/io/jobs/x/resume").status_code == 501
+        assert client.post("/io/jobs/x/resume").status_code == 409  # unknown job
         assert client.delete("/io/jobs/x").status_code == 501
 
 

--- a/tests/datasets/io/test_resume.py
+++ b/tests/datasets/io/test_resume.py
@@ -1,0 +1,223 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets import Dataset
+from pixano.datasets.io import ImportSpec, import_dataset
+from pixano.datasets.io.engine import ImportEngine, state_dir
+from pixano.datasets.io.errors import ResumeError
+from pixano.datasets.io.jobs import JobRunner, JobStore
+from tests.datasets.io._toy_importer import ToyImporter
+
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _spec(name: str, mode: str = "create") -> ImportSpec:
+    return ImportSpec.model_validate({"dataset": {"name": name, "workspace": "image"}, "format": "auto", "mode": mode})
+
+
+def _sorted_ids(dataset: Dataset) -> dict[str, list[str]]:
+    return {
+        name: sorted(r["id"] for r in dataset.open_table(name).search().select(["id"]).limit(None).to_list())
+        for name in dataset.info.tables
+    }
+
+
+class TestEngineResume:
+    def test_resume_completes_a_failed_build_exactly(self, tmp_path: Path):
+        # Control: uninterrupted import of the same source.
+        control = ToyImporter(num_records=60, batch_size=5)
+        result = import_dataset(tmp_path / "src", tmp_path / "control", _spec("ds"), importer=control)
+        control_ids = _sorted_ids(Dataset(result.dataset_path))
+
+        # Failing run: importer dies mid-stream after some flushes committed.
+        class DiesAt(ToyImporter):
+            def iter_batches(self, source, spec, plan, cursor=None):
+                for bundle in super().iter_batches(source, spec, plan, cursor=cursor):
+                    if bundle.cursor and int(bundle.cursor.get("ordinal", 0)) == 40 and cursor is None:
+                        raise RuntimeError("simulated crash")
+                    yield bundle
+
+        cursors: list[dict] = []
+        engine = ImportEngine(tmp_path / "data", flush_rows=16, checkpoint=lambda c, n: cursors.append(dict(c)))
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            import_dataset(
+                tmp_path / "src",
+                tmp_path / "data",
+                _spec("ds"),
+                importer=DiesAt(num_records=60, batch_size=5),
+                engine=engine,
+                job_id="job1",
+            )
+        # Staging preserved with committed flushes.
+        staging = state_dir(tmp_path / "data") / "staging" / "ds-job1"
+        assert staging.exists() and cursors, "staging must survive a crash after committed flushes"
+
+        # Resume from the last committed cursor; boundary bundles replay as upserts.
+        engine2 = ImportEngine(tmp_path / "data", flush_rows=16)
+        resumed = import_dataset(
+            tmp_path / "src",
+            tmp_path / "data",
+            _spec("ds"),
+            importer=ToyImporter(num_records=60, batch_size=5),
+            engine=engine2,
+            job_id="job1",
+            resume_cursor=cursors[-1],
+        )
+        assert not staging.exists()  # promoted
+        resumed_ids = _sorted_ids(Dataset(resumed.dataset_path))
+        assert resumed_ids == control_ids  # zero duplicates, zero gaps
+
+    def test_resume_without_staging_is_a_typed_error(self, tmp_path: Path):
+        with pytest.raises(ResumeError, match="staging"):
+            import_dataset(
+                tmp_path / "src",
+                tmp_path / "data",
+                _spec("ds2"),
+                importer=ToyImporter(num_records=4),
+                job_id="ghost",
+                resume_cursor={"ordinal": 2},
+            )
+
+    def test_non_resumable_importer_is_refused(self, tmp_path: Path):
+        class NoResume(ToyImporter):
+            supports_resume = False
+
+        with pytest.raises(ResumeError, match="does not support resume"):
+            import_dataset(
+                tmp_path / "src",
+                tmp_path / "data",
+                _spec("ds3"),
+                importer=NoResume(num_records=4),
+                job_id="j",
+                resume_cursor={"ordinal": 1},
+            )
+
+    def test_add_mode_resume_preserves_manifest_anchor(self, tmp_path: Path):
+        base = ToyImporter(num_records=10, batch_size=5)
+        first = import_dataset(tmp_path / "src", tmp_path / "data", _spec("ds4"), importer=base)
+        dataset = Dataset(first.dataset_path)
+        pre_versions = {n: dataset.open_table(n).version for n in dataset.info.tables}
+
+        # Interrupted add: manifest written, some rows in.
+        class DiesAt(ToyImporter):
+            def iter_batches(self, source, spec, plan, cursor=None):
+                for bundle in super().iter_batches(source, spec, plan, cursor=cursor):
+                    if bundle.cursor and int(bundle.cursor.get("ordinal", 0)) == 30 and cursor is None:
+                        raise RuntimeError("boom")
+                    yield bundle
+
+        cursors: list[dict] = []
+        engine = ImportEngine(tmp_path / "data", flush_rows=8, checkpoint=lambda c, n: cursors.append(dict(c)))
+        with pytest.raises(RuntimeError):
+            import_dataset(
+                tmp_path / "src",
+                tmp_path / "data",
+                _spec("ds4", mode="add"),
+                importer=DiesAt(num_records=40, batch_size=5),
+                engine=engine,
+                job_id="addjob",
+            )
+        assert cursors
+
+        resumed = import_dataset(
+            tmp_path / "src",
+            tmp_path / "data",
+            _spec("ds4", mode="add"),
+            importer=ToyImporter(num_records=40, batch_size=5),
+            engine=ImportEngine(tmp_path / "data", flush_rows=8),
+            job_id="addjob",
+            resume_cursor=cursors[-1],
+        )
+        from pixano.datasets.io.manifest import ImportManifest
+
+        manifest = ImportManifest.load(Path(resumed.manifest_path))
+        assert manifest.pre_import_versions == pre_versions  # rollback anchor survives the resume
+        assert Dataset(resumed.dataset_path).open_table("records").count_rows() == 40
+
+
+class TestKill9Resume:
+    def test_sigkill_mid_import_then_resume_matches_control(self, tmp_path: Path):
+        # Control run in-process.
+        control = import_dataset(
+            tmp_path / "src", tmp_path / "control", _spec("k9"), importer=ToyImporter(num_records=80, batch_size=4)
+        )
+        control_ids = _sorted_ids(Dataset(control.dataset_path))
+
+        # Victim run in a subprocess through the JOB RUNNER (cursor persisted in the store).
+        data_dir = tmp_path / "data"
+        (data_dir / "library").mkdir(parents=True)
+        script = f"""
+import sys
+sys.path.insert(0, {str(REPO_ROOT)!r})
+from pathlib import Path
+from pixano.datasets.io import ImportSpec, import_dataset
+from pixano.datasets.io.engine import ImportEngine
+from pixano.datasets.io.jobs import JobStore
+from tests.datasets.io._toy_importer import ToyImporter
+import time
+
+data_dir = Path({str(data_dir)!r})
+store = JobStore.for_data_dir(data_dir)
+job = store.create_job("import", dataset="k9")
+store.update_job(job.id, status="running")
+print(job.id, flush=True)
+
+class Slow(ToyImporter):
+    def iter_batches(self, source, spec, plan, cursor=None):
+        for bundle in super().iter_batches(source, spec, plan, cursor=cursor):
+            time.sleep(0.02)
+            yield bundle
+
+engine = ImportEngine(data_dir, flush_rows=8,
+                      checkpoint=lambda c, n: store.update_job(job.id, cursor=dict(c)))
+import_dataset({str(tmp_path / "src")!r}, data_dir,
+               ImportSpec.model_validate({{"dataset": {{"name": "k9", "workspace": "image"}}, "mode": "create"}}),
+               importer=Slow(num_records=80, batch_size=4), engine=engine, job_id=job.id)
+"""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        )
+        assert proc.stdout is not None
+        job_id = proc.stdout.readline().strip()
+        deadline = time.monotonic() + 30
+        store = JobStore.for_data_dir(data_dir)
+        while time.monotonic() < deadline:
+            job = store.get_job(job_id)
+            if job and job.cursor and int(job.cursor.get("ordinal", 0)) >= 24:
+                break
+            time.sleep(0.05)
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=10)
+
+        job = store.get_job(job_id)
+        assert job is not None and job.cursor, "a checkpoint must have been persisted before the kill"
+        flipped = store.mark_interrupted_on_boot(pid_check=lambda pid: False)
+        assert job_id in flipped
+
+        # Resume in-process from the persisted cursor.
+        resumed = import_dataset(
+            tmp_path / "src",
+            data_dir,
+            _spec("k9"),
+            importer=ToyImporter(num_records=80, batch_size=4),
+            engine=ImportEngine(data_dir, flush_rows=8),
+            job_id=job_id,
+            resume_cursor=dict(job.cursor),
+        )
+        assert _sorted_ids(Dataset(resumed.dataset_path)) == control_ids


### PR DESCRIPTION
## Issue

P5.1 of the 0.8.0 redesign (spec §8) — the first slice of the final backend lane.

## Description

The engine already persisted a cursor after every committed flush (via the job store since P4); this activates **re-entry**:

- **`ImportEngine.run(job_id=…, resume_cursor=…)`** — an external job id makes staging dirs discoverable (`.pixano/staging/{name}-{job_id}`); resume demands `supports_resume` + `deterministic_ids` (typed `ResumeError` otherwise — restart-only formats fail loud).
- **create/overwrite**: a failed build now **preserves** its staging dir (cancellation still deletes it — that's a deliberate stop). Resume reopens the never-promoted staging dataset, indexes it, and streams from the cursor with **upserting flushes** — the boundary bundle replays as a merge, so at-least-once delivery + deterministic ids = exactly-once.
- **add mode**: resume reloads the existing `ImportManifest`, keeping the pre-import table versions (the rollback anchor) anchored to the state before the *first* run.
- **Surfaces**: `JobRunner.submit_resume` (interrupted/errored jobs with a persisted cursor), `POST /io/jobs/{id}/resume` flips 501 → 202, and `pixano data jobs DATA_DIR resume JOB_ID`.

**The P5-exit acceptance test runs for real**: a subprocess import is SIGKILLed mid-stream, marked `interrupted` at boot, then resumed — per-table sorted ids come out **identical to an uninterrupted control run** (zero duplicates, zero gaps). Additional coverage: staging-lost and non-resumable-format typed errors, add-mode manifest anchoring.

Full suite green (634). Next in the lane: P5.2 add-mode rollback (`DELETE /io/jobs/{id}`), then the hardening matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)