### PR TITLE
feat: roll back completed add-mode imports

### DIFF
--- a/src/pixano/api/routers/data_io.py
+++ b/src/pixano/api/routers/data_io.py
@@ -237,10 +237,17 @@ def resume_job(job_id: str, settings: Annotated[Settings, Depends(get_settings)]
         raise HTTPException(status_code=409, detail=str(error)) from None
 
 
-@router.delete("/jobs/{job_id}", status_code=501, operation_id="rollback_io_job")
-def rollback_job(job_id: str) -> dict[str, str]:
-    """Rollback lands with the P5 hardening slice."""
-    return {"detail": "rollback is not implemented yet (planned: 0.8.x)"}
+@router.delete("/jobs/{job_id}", operation_id="rollback_io_job")
+def rollback_job(job_id: str, settings: Annotated[Settings, Depends(get_settings)]) -> JobResponse:
+    """Roll back a completed add-mode import (version restore, else namespace delete)."""
+    store, runner = _runner(settings)
+    try:
+        runner.rollback(job_id)
+    except (JobStateError, PixanoDataError) as error:
+        raise HTTPException(status_code=409, detail=str(error)) from None
+    job = store.get_job(job_id)
+    assert job is not None
+    return _job_response(job)
 
 
 # ----------------------------------------------------------------------

--- a/src/pixano/cli/data.py
+++ b/src/pixano/cli/data.py
@@ -242,7 +242,7 @@ def formats_command() -> None:
 @data_app.command(name="jobs")
 def jobs_command(
     data_dir: Path = typer.Argument(..., exists=True, file_okay=False, help="Pixano data directory."),
-    action: str = typer.Argument("list", help="list, show, cancel, or resume."),
+    action: str = typer.Argument("list", help="list, show, cancel, resume, or rollback."),
     job_id: str = typer.Argument("", help="Job id (for show/cancel)."),
 ) -> None:
     """Inspect the shared import/export job store (the same one the GUI polls)."""
@@ -254,7 +254,7 @@ def jobs_command(
             done = job.progress.get("done", "")
             typer.echo(f"{job.id}  {job.kind:<7} {job.status:<12} {job.dataset:<24} {done}")
         return
-    if action in ("show", "cancel", "resume") and not job_id:
+    if action in ("show", "cancel", "resume", "rollback") and not job_id:
         raise typer.BadParameter(f"'{action}' needs a job id.")
     if action == "show":
         shown = store.get_job(job_id)
@@ -287,7 +287,18 @@ def jobs_command(
         final = store.get_job(job_id)
         typer.echo(f"Job '{job_id}' -> {final.status if final else 'unknown'}.")
         return
-    raise typer.BadParameter(f"Unknown action '{action}' (list, show, cancel, resume).")
+    if action == "rollback":
+        from pixano.datasets.io.jobs import JobRunner
+
+        try:
+            removed = JobRunner(store, data_dir).rollback(job_id)
+        except PixanoDataError as error:
+            typer.echo(f"Error: {error}", err=True)
+            raise typer.Exit(code=1) from None
+        summary = ", ".join(f"{name}: -{count}" for name, count in removed.items()) or "version restore"
+        typer.echo(f"Job '{job_id}' rolled back ({summary}).")
+        return
+    raise typer.BadParameter(f"Unknown action '{action}' (list, show, cancel, resume, rollback).")
 
 
 @data_app.command(name="migrate-jsonl")

--- a/src/pixano/datasets/io/engine.py
+++ b/src/pixano/datasets/io/engine.py
@@ -366,7 +366,7 @@ class ImportEngine:
                 dataset_id=dataset.info.id,
                 spec_fingerprint=spec.fingerprint(),
                 plan_fingerprint=plan.plan_fingerprint,
-                id_namespace=spec.ids.namespace or "",
+                id_namespace=importer.effective_namespace(spec, source),
                 importer_version=importer.importer_version,
                 pre_import_versions={name: dataset.open_table(name).version for name in dataset.info.tables},
             )
@@ -626,6 +626,81 @@ class ImportEngine:
             sink.emit(
                 ProgressEvent(phase="ingest", done=done, total=plan.totals.records, table_counts=dict(table_counts))
             )
+
+    def rollback(self, target_dir: Path, job_id: str) -> dict[str, int]:
+        """Undo an add-mode import (spec §8, deviation D12).
+
+        Fast path: when every table still sits at the manifest's post-import
+        version, `checkout + restore` snaps back to the pre-import version.
+        Any drift (concurrent edits since the import) switches to the surgical
+        path: delete the import's namespace-prefixed rows in reverse FK order,
+        leaving later edits intact. Re-derives storage_mode afterwards.
+
+        Returns:
+            Rows removed per table (empty dict on the version-restore path).
+        """
+        from .ids import namespace_prefix
+
+        manifest_path = target_dir / "imports" / f"{job_id}.manifest.json"
+        if not manifest_path.is_file():
+            raise JobStateError(f"No import manifest for job '{job_id}' — only add-mode imports roll back.")
+        manifest = ImportManifest.load(manifest_path)
+        if not manifest.post_import_versions:
+            raise JobStateError(f"Job '{job_id}' never finished its first flush; nothing to roll back.")
+        dataset = Dataset(target_dir)
+
+        untouched = all(
+            dataset.open_table(name).version == version
+            for name, version in manifest.post_import_versions.items()
+            if name in dataset.info.tables
+        )
+        removed: dict[str, int] = {}
+        if untouched:
+            for name, pre_version in manifest.pre_import_versions.items():
+                if name not in dataset.info.tables:
+                    continue
+                table = dataset.open_table(name)
+                table.checkout(pre_version)
+                table.restore()
+        else:
+            prefix = namespace_prefix(manifest.id_namespace) if manifest.id_namespace else ""
+            if not prefix:
+                raise JobStateError(
+                    f"Job '{job_id}' has no id namespace recorded and the dataset changed since the "
+                    "import — cannot roll back safely."
+                )
+            for name in reversed(dataset._table_insert_order(list(dataset.info.tables))):
+                table = dataset.open_table(name)
+                predicate = f"id LIKE '{prefix}-%'"
+                before = table.count_rows(predicate)
+                if before:
+                    table.delete(predicate)
+                    removed[name] = before
+
+        self._restamp_storage_mode(dataset)
+        manifest_path.unlink(missing_ok=True)
+        Dataset.invalidate_caches(dataset.info.id)
+        return removed
+
+    def _restamp_storage_mode(self, dataset: Dataset) -> None:
+        """Re-derive storage_mode from the remaining view rows (cheap count pushdowns)."""
+        has_embedded = has_uri = False
+        for group_tables in (dataset.info.groups.get(SchemaGroup.VIEW, set()),):
+            for name in group_tables:
+                table = dataset.open_table(name)
+                if "uri" not in table.schema.names:
+                    continue
+                if table.count_rows("uri = ''"):
+                    has_embedded = True
+                if table.count_rows("uri != ''"):
+                    has_uri = True
+        if has_embedded and has_uri:
+            dataset.info.storage_mode = "mixed"
+        elif has_uri:
+            dataset.info.storage_mode = "filesystem"
+        elif has_embedded:
+            dataset.info.storage_mode = "embedded"
+        dataset.info.to_json(dataset._info_file)
 
     def _check_cancelled(self) -> None:
         if self.cancel_check is not None and self.cancel_check():

--- a/src/pixano/datasets/io/formats/coco/importer.py
+++ b/src/pixano/datasets/io/formats/coco/importer.py
@@ -278,7 +278,7 @@ class CocoImporter(DatasetImporter):
         """Two passes per split: index annotations, then stream images joining the index."""
         assert source.path is not None
         info = self.resolve_info(spec)
-        namespace = spec.ids.namespace or source.path.name
+        namespace = self.effective_namespace(spec, source)
         resolver = MediaResolver(spec.media, base_dir=source.path)
         resume_split = cursor.get("split") if cursor else None
         resume_ordinal = int(cursor.get("image_ordinal", 0)) if cursor else 0

--- a/src/pixano/datasets/io/formats/lerobot/importer.py
+++ b/src/pixano/datasets/io/formats/lerobot/importer.py
@@ -253,7 +253,7 @@ class LeRobotImporter(DatasetImporter):
             if mode == "extract":
                 needed |= {episode.data_path for episode in episodes if episode.data_path}
             root = materialize_files(source.url, sorted(needed))
-        namespace = spec.ids.namespace or (source.url or root.name).replace("/", "_")
+        namespace = self.effective_namespace(spec, source)
         resolver = MediaResolver(spec.media, base_dir=root)
         resume_ordinal = int(cursor.get("episode_ordinal", 0)) if cursor else 0
 

--- a/src/pixano/datasets/io/formats/pixano_jsonl/importer.py
+++ b/src/pixano/datasets/io/formats/pixano_jsonl/importer.py
@@ -100,7 +100,7 @@ class PixanoJsonlImporter(DatasetImporter):
             return plan
 
         info = resolve_dataset_info(spec)
-        namespace = spec.ids.namespace or source.path.name
+        namespace = self.effective_namespace(spec, source)
         total_records = 0
         media_probes = 0
         truncated = False
@@ -215,7 +215,7 @@ class PixanoJsonlImporter(DatasetImporter):
         """Stream rows split by split, line by line, resuming past the cursor."""
         assert source.path is not None
         info = resolve_dataset_info(spec)
-        namespace = spec.ids.namespace or source.path.name
+        namespace = self.effective_namespace(spec, source)
         resume_split = cursor.get("split") if cursor else None
         resume_line = int(cursor.get("line", 0)) if cursor else 0
 

--- a/src/pixano/datasets/io/importer.py
+++ b/src/pixano/datasets/io/importer.py
@@ -117,6 +117,18 @@ class DatasetImporter(ABC):
         """
         return None
 
+    def effective_namespace(self, spec: "ImportSpec", source: SourceRef) -> str:
+        """The id namespace actually used for derived ids (rollback anchor).
+
+        Defaults to the spec's namespace, else a source-derived identity —
+        the same rule every built-in importer applies.
+        """
+        if spec.ids.namespace:
+            return spec.ids.namespace
+        if source.path is not None:
+            return source.path.name
+        return (source.url or "source").replace("/", "_")
+
     def resolve_info(self, spec: "ImportSpec", source: SourceRef | None = None) -> "DatasetInfo":
         """Resolve the target schema for this format.
 

--- a/src/pixano/datasets/io/jobs.py
+++ b/src/pixano/datasets/io/jobs.py
@@ -429,6 +429,26 @@ class JobRunner:
                     },
                 )
 
+    def rollback(self, job_id: str) -> dict[str, int]:
+        """Roll back a finished add-mode import; the job flips to rolled_back."""
+        from pixano.utils import to_snake_case
+
+        from .engine import ImportEngine
+
+        job = self.store.get_job(job_id)
+        if job is None:
+            raise JobStateError(f"Unknown job '{job_id}'.")
+        if job.kind != "import" or job.status != "done":
+            raise JobStateError(f"Job '{job_id}' is {job.status}; only completed imports roll back.")
+        spec = job.spec
+        dataset_name = to_snake_case(str(spec.get("dataset", {}).get("name", "")) or job.dataset)
+        target_dir = self.data_dir / "library" / dataset_name
+        if job.manifest_path:
+            target_dir = Path(job.manifest_path).parent.parent
+        removed = ImportEngine(self.data_dir).rollback(target_dir, job_id)
+        self.store.update_job(job_id, status="rolled_back", progress={"phase": "rolled_back", "removed": removed})
+        return removed
+
     def join(self, timeout: float | None = None) -> None:
         """Wait for in-flight jobs (tests and CLI teardown)."""
         for thread in self._threads:

--- a/tests/app/test_api_io.py
+++ b/tests/app/test_api_io.py
@@ -110,10 +110,10 @@ class TestIoRoutes:
         restarted = TestClient(app2)
         assert restarted.get(f"/io/jobs/{orphan.id}").json()["status"] == "interrupted"
 
-    def test_resume_conflicts_on_unknown_job_and_rollback_is_501(self, client_and_dirs):
+    def test_resume_and_rollback_conflict_on_unknown_jobs(self, client_and_dirs):
         client, _, _ = client_and_dirs
         assert client.post("/io/jobs/x/resume").status_code == 409  # unknown job
-        assert client.delete("/io/jobs/x").status_code == 501
+        assert client.delete("/io/jobs/x").status_code == 409  # unknown job
 
 
 class TestLegacyAliasParity:

--- a/tests/datasets/io/test_rollback.py
+++ b/tests/datasets/io/test_rollback.py
@@ -1,0 +1,132 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets import Dataset
+from pixano.datasets.io import ImportSpec, import_dataset
+from pixano.datasets.io.engine import ImportEngine
+from pixano.datasets.io.errors import JobStateError
+from tests.datasets.io._toy_importer import ToyImporter
+
+
+def _spec(name: str, mode: str = "create", namespace: str = "") -> ImportSpec:
+    payload: dict = {"dataset": {"name": name, "workspace": "image"}, "mode": mode}
+    if namespace:
+        payload["ids"] = {"namespace": namespace}
+    return ImportSpec.model_validate(payload)
+
+
+def _counts(dataset: Dataset) -> dict[str, int]:
+    return {name: dataset.open_table(name).count_rows() for name in dataset.info.tables}
+
+
+@pytest.fixture()
+def base_dataset(tmp_path: Path) -> tuple[Path, dict[str, int]]:
+    import_dataset(
+        tmp_path / "src", tmp_path / "data", _spec("ds", namespace="base"), importer=ToyImporter(num_records=10)
+    )
+    dataset = Dataset(tmp_path / "data" / "library" / "ds")
+    return tmp_path, _counts(dataset)
+
+
+class TestRollback:
+    def test_clean_add_rollback_restores_versions(self, base_dataset):
+        tmp_path, before = base_dataset
+        result = import_dataset(
+            tmp_path / "src2",
+            tmp_path / "data",
+            _spec("ds", mode="add", namespace="added"),
+            importer=ToyImporter(num_records=7),
+            job_id="addjob",
+        )
+        dataset = Dataset(result.dataset_path)
+        assert dataset.open_table("records").count_rows() == 17
+
+        removed = ImportEngine(tmp_path / "data").rollback(result.dataset_path, "addjob")
+        assert removed == {}  # fast path: version restore
+        assert _counts(Dataset(result.dataset_path)) == before
+        assert not (result.dataset_path / "imports" / "addjob.manifest.json").exists()
+
+    def test_rollback_after_concurrent_edit_takes_namespace_path(self, base_dataset):
+        tmp_path, before = base_dataset
+        result = import_dataset(
+            tmp_path / "src2",
+            tmp_path / "data",
+            _spec("ds", mode="add", namespace="added"),
+            importer=ToyImporter(num_records=7),
+            job_id="addjob2",
+        )
+        dataset = Dataset(result.dataset_path)
+
+        # Interleaved user edit: a GUI-created record AFTER the import.
+        from pixano.schemas import Record
+
+        dataset.add_records({"records": Record(id="user_manual_row")}, check_integrity="none")
+
+        removed = ImportEngine(tmp_path / "data").rollback(result.dataset_path, "addjob2")
+        assert removed and removed["records"] == 7  # surgical path: namespace delete
+        after = Dataset(result.dataset_path)
+        assert after.open_table("records").count_rows() == before["records"] + 1
+        assert after.get_data("records", ids="user_manual_row") is not None  # edit survives
+
+    def test_rollback_without_manifest_is_a_typed_error(self, base_dataset):
+        tmp_path, _ = base_dataset
+        with pytest.raises(JobStateError, match="manifest"):
+            ImportEngine(tmp_path / "data").rollback(tmp_path / "data" / "library" / "ds", "ghost")
+
+    def test_runner_rollback_flips_job_status(self, base_dataset):
+        tmp_path, before = base_dataset
+        from pixano.datasets.io.jobs import JobRunner, JobStore
+
+        store = JobStore.for_data_dir(tmp_path / "data")
+        runner = JobRunner(store, tmp_path / "data")
+        job = runner.submit_import(
+            str(tmp_path / "src3"),
+            {"dataset": {"name": "ds", "workspace": "image"}, "mode": "add", "ids": {"namespace": "j3"}},
+        )
+        # The registry can't detect a toy source; run the import directly instead.
+        runner.join(timeout=30)
+        final = store.get_job(job.id)
+        if final.status != "done":
+            import_dataset(
+                tmp_path / "src3",
+                tmp_path / "data",
+                _spec("ds", mode="add", namespace="j3"),
+                importer=ToyImporter(num_records=3),
+                job_id=job.id,
+            )
+            store.update_job(
+                job.id,
+                status="done",
+                manifest_path=str(tmp_path / "data" / "library" / "ds" / "imports" / f"{job.id}.manifest.json"),
+            )
+
+        runner.rollback(job.id)
+        assert store.get_job(job.id).status == "rolled_back"
+        assert Dataset(tmp_path / "data" / "library" / "ds").open_table("records").count_rows() == before["records"]
+
+    def test_rollback_restamps_storage_mode(self, tmp_path: Path):
+        # Base: embedded-only. Add: uri-mode rows -> mixed. Rollback -> embedded again.
+        import_dataset(
+            tmp_path / "src",
+            tmp_path / "data",
+            _spec("mix", namespace="base"),
+            importer=ToyImporter(num_records=4, media="embed"),
+        )
+        result = import_dataset(
+            tmp_path / "src2",
+            tmp_path / "data",
+            _spec("mix", mode="add", namespace="added"),
+            importer=ToyImporter(num_records=3, media="uri"),
+            job_id="mixjob",
+        )
+        assert Dataset(result.dataset_path).info.storage_mode == "mixed"
+
+        ImportEngine(tmp_path / "data").rollback(result.dataset_path, "mixjob")
+        assert Dataset(result.dataset_path).info.storage_mode == "embedded"


### PR DESCRIPTION
## Issue

P5.2 of the 0.8.0 redesign (spec §8, deviation D12).

**⚠️ Stacked on #691** — merge #691 first; I'll rebase this one after (the usual squash fix-up).

## Description

- **`DatasetImporter.effective_namespace`** — the id namespace actually used for derived ids, now one rule shared by all importers, and recorded in the add-mode `ImportManifest` (previously `""` for default-namespace imports, which would have left the fallback delete with no anchor).
- **`ImportEngine.rollback(target_dir, job_id)`** — two paths, chosen by a version guard:
  - *Fast*: every table still at the manifest's post-import version → `checkout + restore` to the pre-import version.
  - *Surgical*: any drift (concurrent edits since the import) → delete the import's namespace-prefixed rows in **reverse FK order**, leaving later edits intact.
  - Either way: `storage_mode` re-derived (a rolled-back mixed add no longer strands a stale `"mixed"`), manifest consumed, caches invalidated.
- **Surfaces**: `DELETE /io/jobs/{id}` goes 501 → live (409 on unknown/incomplete jobs), job flips to `rolled_back`, and `pixano data jobs DATA_DIR rollback JOB_ID`.

Tests cover both paths (including an interleaved GUI-style edit that **survives** the namespace rollback), typed errors, the job-status flip, and the storage-mode restamp. Full suite green (639).

🤖 Generated with [Claude Code](https://claude.com/claude-code)