### PR TITLE
perf: keep the API responsive while imports run in the background

### DIFF
--- a/src/pixano/api/main.py
+++ b/src/pixano/api/main.py
@@ -5,8 +5,10 @@
 # =====================================
 
 import logging
+from contextlib import asynccontextmanager
 from pathlib import Path
 
+import anyio.to_thread
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
@@ -16,6 +18,38 @@ from starlette.middleware.gzip import GZipMiddleware
 from pixano.__version__ import __version__
 from pixano.api.routers import include_api_routers
 from pixano.api.settings import Settings
+
+
+# Media blobs are already compressed (JPEG/PNG/MP4); running them through gzip
+# burns request-thread CPU (which competes with background import jobs) for no
+# size win. Bypass by route shape — cheaper than sniffing content types.
+_GZIP_BYPASS_SUFFIXES = ("/blob", "/preview")
+_GZIP_BYPASS_SEGMENTS = ("/sframes/batch", "/media/")
+
+
+class SelectiveGZipMiddleware(GZipMiddleware):
+    """GZip that leaves blob and frame-stream routes uncompressed."""
+
+    async def __call__(self, scope, receive, send):
+        """Bypass compression for media routes; defer to gzip elsewhere."""
+        if scope["type"] == "http":
+            path = scope.get("path", "")
+            if path.endswith(_GZIP_BYPASS_SUFFIXES) or any(seg in path for seg in _GZIP_BYPASS_SEGMENTS):
+                await self.app(scope, receive, send)
+                return
+        await super().__call__(scope, receive, send)
+
+
+@asynccontextmanager
+async def _widen_threadpool(_: FastAPI):
+    """Raise the sync-endpoint threadpool above anyio's 40-token default.
+
+    Every data endpoint is sync `def`, and blob/frame downloads hold a token
+    for their full duration — a gallery plus a video workspace plus job polling
+    exhausts 40 while a background import competes for CPU.
+    """
+    anyio.to_thread.current_default_thread_limiter().total_tokens = 100
+    yield
 
 
 def create_app(settings: Settings = Settings()) -> FastAPI:
@@ -28,7 +62,9 @@ def create_app(settings: Settings = Settings()) -> FastAPI:
         The Pixano app.
     """
     # Create app
-    app = FastAPI(title="Pixano", version=__version__, default_response_class=ORJSONResponse)
+    app = FastAPI(
+        title="Pixano", version=__version__, default_response_class=ORJSONResponse, lifespan=_widen_threadpool
+    )
 
     # Boot recovery: replay interrupted staging journals and mark orphaned
     # import jobs as interrupted (spec §8/§9).
@@ -39,7 +75,7 @@ def create_app(settings: Settings = Settings()) -> FastAPI:
             boot_recover(settings.library_dir.parent)
         except Exception:  # pragma: no cover - recovery must never block boot
             logging.getLogger(__name__).warning("Data IO boot recovery failed", exc_info=True)
-    app.add_middleware(GZipMiddleware, minimum_size=500)
+    app.add_middleware(SelectiveGZipMiddleware, minimum_size=500)
     if settings.cors_origins:
         app.add_middleware(
             CORSMiddleware,

--- a/src/pixano/api/routers/data_io.py
+++ b/src/pixano/api/routers/data_io.py
@@ -350,17 +350,14 @@ def legacy_start_import(
 
     name = request.dataset_name.strip() or source_dir.name
     staging = Path(tempfile.mkdtemp(prefix="pixano-gui-import-"))
-    try:
-        source, dataset_extras = _prepare_legacy_source(source_dir, request.import_type, staging)
-    except (PixanoDataError, ImportError) as error:
-        job = store.create_job("import", dataset=to_snake_case(name))
-        store.update_job(job.id, status="error", error={"message": str(error)})
-        refreshed = store.get_job(job.id)
-        assert refreshed is not None
-        return _legacy_response(refreshed)
 
-    spec_payload = {"dataset": {"name": name, **dataset_extras}, "format": "pixano_jsonl"}
-    job = runner.submit_import(str(source), spec_payload)
+    def prepare() -> tuple[str, dict[str, Any]]:
+        # Frame extraction (cv2) is heavy — it runs on the job thread, never here.
+        source, dataset_extras = _prepare_legacy_source(source_dir, request.import_type, staging)
+        return str(source), dataset_extras
+
+    spec_payload = {"dataset": {"name": name}, "format": "pixano_jsonl"}
+    job = runner.submit_import(str(source_dir), spec_payload, prepare=prepare)
     return _legacy_response(job)
 
 

--- a/src/pixano/api/routers/datasets.py
+++ b/src/pixano/api/routers/datasets.py
@@ -11,8 +11,9 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 
 from pixano.api.models import DatasetInfoResponse, DatasetResponse
+from pixano.api.routers._deps import get_dataset_dep
 from pixano.api.settings import Settings, get_settings
-from pixano.datasets import Dataset, DatasetInfo
+from pixano.datasets import DatasetInfo
 from pixano.schemas.schema_group import SchemaGroup
 
 
@@ -94,10 +95,7 @@ def get_dataset_stats(
     Returns:
         Dict of group_name -> {table_name: count}.
     """
-    try:
-        dataset = Dataset.find(id, settings.library_dir)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"Dataset '{id}' not found.") from exc
+    dataset = get_dataset_dep(id, settings)
     result: dict[str, dict[str, int]] = {}
     for group, tables in dataset.info.groups.items():
         if group == SchemaGroup.RECORD:
@@ -128,8 +126,5 @@ def get_dataset(
     Returns:
         Dataset model.
     """
-    try:
-        dataset = Dataset.find(id, settings.library_dir)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"Dataset '{id}' not found.") from exc
+    dataset = get_dataset_dep(id, settings)
     return DatasetResponse.from_dataset(dataset)

--- a/src/pixano/api/routers/views.py
+++ b/src/pixano/api/routers/views.py
@@ -7,11 +7,10 @@
 """Subtype-specific view routers."""
 
 import hashlib
-import io
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response
 
 from pixano.api.media import MULTIPART_BOUNDARY, iter_multipart_frames, media_type_from_format
 from pixano.api.models import ImageResponse, PaginatedResponse, SFrameResponse, TextResponse
@@ -79,7 +78,7 @@ def _get_row(dataset: Dataset, table_name: str, row_id: str) -> Any:
     return row
 
 
-def _stream_blob(dataset: Dataset, table_name: str, row_id: str) -> StreamingResponse:
+def _stream_blob(dataset: Dataset, table_name: str, row_id: str) -> Response:
     try:
         result = dataset.get_view_binary(table_name, row_id)
     except DatasetAccessError as err:
@@ -89,14 +88,11 @@ def _stream_blob(dataset: Dataset, table_name: str, row_id: str) -> StreamingRes
         raise HTTPException(status_code=404, detail=f"Resource '{row_id}' has no embedded blob.")
 
     blob_data, fmt = result
-    return StreamingResponse(
-        io.BytesIO(blob_data),
-        media_type=media_type_from_format(fmt),
-        headers={"Content-Length": str(len(blob_data))},
-    )
+    # In-memory bytes: a plain Response avoids per-chunk threadpool hops.
+    return Response(content=blob_data, media_type=media_type_from_format(fmt))
 
 
-def _stream_preview(dataset: Dataset, table_name: str, row_id: str) -> StreamingResponse:
+def _stream_preview(dataset: Dataset, table_name: str, row_id: str) -> Response:
     row = _get_row(dataset, table_name, row_id)
     preview = getattr(row, "preview", b"") or b""
     preview_format = getattr(row, "preview_format", "") or ""
@@ -104,11 +100,10 @@ def _stream_preview(dataset: Dataset, table_name: str, row_id: str) -> Streaming
         raise HTTPException(status_code=404, detail=f"Resource '{row_id}' has no preview.")
 
     etag = hashlib.sha1(preview).hexdigest()  # noqa: S324
-    return StreamingResponse(
-        io.BytesIO(preview),
+    return Response(
+        content=preview,
         media_type=media_type_from_format(preview_format),
         headers={
-            "Content-Length": str(len(preview)),
             "Cache-Control": "public, max-age=3600",
             "ETag": f'"{etag}"',
         },
@@ -265,13 +260,13 @@ def get_image(id: str, dataset_id: str, dataset: Dataset = Depends(get_dataset_d
 
 
 @router.get("/images/{id}/blob", operation_id="get_image_blob")
-def get_image_blob(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> StreamingResponse:
+def get_image_blob(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Response:
     """Stream the raw binary blob of an image."""
     return _stream_blob(dataset, IMAGE_TABLE, id)
 
 
 @router.get("/images/{id}/preview", operation_id="get_image_preview")
-def get_image_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> StreamingResponse:
+def get_image_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Response:
     """Stream the preview thumbnail of an image."""
     return _stream_preview(dataset, IMAGE_TABLE, id)
 
@@ -327,13 +322,13 @@ def get_sframe(id: str, dataset_id: str, dataset: Dataset = Depends(get_dataset_
 
 
 @router.get("/sframes/{id}/blob", operation_id="get_sframe_blob")
-def get_sframe_blob(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> StreamingResponse:
+def get_sframe_blob(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Response:
     """Stream the raw binary blob of a sequence frame."""
     return _stream_blob(dataset, SFRAME_TABLE, id)
 
 
 @router.get("/sframes/{id}/preview", operation_id="get_sframe_preview")
-def get_sframe_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> StreamingResponse:
+def get_sframe_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Response:
     """Stream the preview thumbnail of a sequence frame."""
     return _stream_preview(dataset, SFRAME_TABLE, id)
 
@@ -424,7 +419,7 @@ def get_record_sframe_batch(
     view_name: str | None = None,
     start_frame: Annotated[int, Query(ge=0)] = 0,
     batch_size: Annotated[int, Query(ge=1, le=1000)] = 100,
-) -> StreamingResponse:
+) -> Response:
     """Stream a batch of temporal frames as a multipart binary response."""
     try:
         frames = dataset.get_temporal_view_batch(
@@ -441,8 +436,11 @@ def get_record_sframe_batch(
         raise HTTPException(status_code=404, detail="No frames found for the given parameters.")
 
     payloads = [(frame_index, data, media_type_from_format(fmt)) for frame_index, data, fmt in frames]
-    return StreamingResponse(
-        iter_multipart_frames(payloads),
+    # The batch is already fully materialized; one Response body avoids a
+    # threadpool hop per multipart chunk (128 hops ~ 30ms of pure overhead).
+    body = b"".join(iter_multipart_frames(payloads))
+    return Response(
+        content=body,
         media_type=f"multipart/x-mixed-replace; boundary={MULTIPART_BOUNDARY.decode()}",
         headers={
             "X-Total-Frames": str(len(frames)),

--- a/src/pixano/cli/data.py
+++ b/src/pixano/cli/data.py
@@ -239,6 +239,26 @@ def formats_command() -> None:
     typer.echo("(pixano_jsonl also exports through 'pixano data export'.)")
 
 
+@data_app.command(name="optimize")
+def optimize_dataset(
+    data_dir: Path = typer.Argument(..., help="Pixano data directory."),
+    dataset: str = typer.Argument(..., help="Dataset name (library folder name)."),
+) -> None:
+    """Index the standard filter columns and compact a dataset (fast filtered pagination)."""
+    from pixano.datasets import Dataset
+
+    target = data_dir / "library" / dataset
+    if not target.is_dir():
+        typer.echo(f"Error: no dataset at '{target}'.", err=True)
+        raise typer.Exit(code=1)
+    ds = Dataset(target)
+    ds.create_scalar_indexes()
+    for name in ds.info.tables:
+        ds.open_table(name).optimize()
+    Dataset.invalidate_caches(ds.info.id)
+    typer.echo(f"Dataset '{dataset}' optimized ({len(ds.info.tables)} table(s) indexed and compacted).")
+
+
 @data_app.command(name="jobs")
 def jobs_command(
     data_dir: Path = typer.Argument(..., exists=True, file_okay=False, help="Pixano data directory."),

--- a/src/pixano/datasets/dataset.py
+++ b/src/pixano/datasets/dataset.py
@@ -133,6 +133,7 @@ class Dataset:
         self.path = path
 
         self._info_file = self.path / self._INFO_FILE
+        self._table_handles: dict[str, LanceTable] = {}
         self._features_values_file = self.path / self._FEATURES_VALUES_FILE
         self._stat_file = self.path / self._STAT_FILE
         self._thumb_file = self.path / self._THUMB_FILE
@@ -185,11 +186,14 @@ class Dataset:
             try:
                 table.add_columns(missing)
             except Exception:
+                self._table_handles.pop(table_name, None)  # re-read the live schema, not a cached handle
                 still_missing = [
                     column for column in missing if column not in self.open_table(table_name).schema.names
                 ]
                 if still_missing:
                     raise
+            finally:
+                self._table_handles.pop(table_name, None)
 
         # Patch the raw JSON rather than re-serializing self.info: from_json drops
         # views it cannot deserialize, and a re-serialization would persist that loss.
@@ -476,6 +480,9 @@ class Dataset:
         if name not in self.info.tables:
             raise DatasetAccessError(f"Table {name} not found in dataset")
 
+        cached = self._table_handles.get(name)
+        if cached is not None:
+            return cached
         table = self._db_connection.open_table(name)
 
         schema_table = self.info.tables[name]
@@ -485,6 +492,9 @@ class Dataset:
                 schema_table.get_embedding_fn_from_table(self, name, table.schema.metadata)
             except TypeError:  # no embedding function
                 pass
+        # Handles read the latest table version per query, so caching is safe;
+        # Dataset-level cache invalidation drops the whole instance anyway.
+        self._table_handles[name] = table
         return table
 
     @overload
@@ -1185,21 +1195,40 @@ class Dataset:
                 arrow_table = arrow_table.append_column(field, pa.array([now] * arrow_table.num_rows, type=field.type))
         return arrow_table
 
+    # Standard filter columns the REST/query layers put in where clauses, with
+    # the index type suited to their cardinality. When EVERY predicate column
+    # of a query is index-covered, lancedb applies limit/offset after the
+    # filter — TableQueryBuilder's fast path depends on this census.
+    FILTER_INDEX_COLUMNS: ClassVar[dict[str, str]] = {
+        "id": "BTREE",
+        "record_id": "BTREE",
+        "entity_id": "BTREE",
+        "view_id": "BTREE",
+        "frame_id": "BTREE",
+        "tracklet_id": "BTREE",
+        "frame_index": "BTREE",
+        "logical_name": "BITMAP",
+        "split": "BITMAP",
+        "source_type": "BITMAP",
+    }
+
     def create_scalar_indexes(
         self,
-        columns: Sequence[str] = ("id", "record_id"),
+        columns: Sequence[str] | None = None,
         tables: Sequence[str] | None = None,
     ) -> None:
-        """Create BTree scalar indexes on the given columns of the given tables.
+        """Create scalar indexes on the given columns of the given tables.
 
         Idempotent: columns that are already indexed or absent from a table's
         schema are skipped. Indexes make ``merge_insert``, foreign-key lookups,
-        export paging, and ``record_id`` filters scale past full-table scans.
+        export paging, and filtered pagination scale past full-table scans.
 
         Args:
-            columns: Column names to index where present.
+            columns: Column names to index where present. Defaults to the
+                standard filter columns (``FILTER_INDEX_COLUMNS``).
             tables: Table names to index. Defaults to every dataset table.
         """
+        wanted = list(columns) if columns is not None else list(self.FILTER_INDEX_COLUMNS)
         table_names = list(tables) if tables is not None else list(self.info.tables.keys())
         for table_name in table_names:
             table = self.open_table(table_name)
@@ -1207,9 +1236,9 @@ class Dataset:
             for index in table.list_indices():
                 indexed_columns.update(getattr(index, "columns", None) or [])
             schema_names = set(table.schema.names)
-            for column in columns:
+            for column in wanted:
                 if column in schema_names and column not in indexed_columns:
-                    table.create_scalar_index(column, index_type="BTREE")
+                    table.create_scalar_index(column, index_type=self.FILTER_INDEX_COLUMNS.get(column, "BTREE"))
 
     # ------------------------------------------------------------------
     # Cross-process cache invalidation

--- a/src/pixano/datasets/io/engine.py
+++ b/src/pixano/datasets/io/engine.py
@@ -751,7 +751,13 @@ def _stamp_image_previews(dataset: Dataset, table_name: str, rows: list[LanceMod
     schema = dataset.info.tables.get(table_name)
     if schema is None or not (is_image(schema) or is_sequence_frame(schema)):
         return
+    sequence = is_sequence_frame(schema)
     for row in rows:
+        # The browse grid shows ONE preview per record/view (the first frame);
+        # stamping all 400+ frames of an episode is pure GIL burn in the import
+        # thread that starves concurrent API requests.
+        if sequence and getattr(row, "frame_index", 0) != 0:
+            continue
         raw_bytes = getattr(row, "raw_bytes", b"")
         if not raw_bytes or row.preview:
             continue

--- a/src/pixano/datasets/io/jobs.py
+++ b/src/pixano/datasets/io/jobs.py
@@ -283,15 +283,43 @@ class JobRunner:
         self._lock = threading.Lock()
         self._threads: list[threading.Thread] = []
 
-    def submit_import(self, source: str, spec_payload: dict[str, Any], plan_id: str = "") -> JobRecord:
-        """Create a pending import job and start it on the worker thread."""
+    def submit_import(
+        self,
+        source: str,
+        spec_payload: dict[str, Any],
+        plan_id: str = "",
+        prepare: Callable[[], tuple[str, dict[str, Any]]] | None = None,
+    ) -> JobRecord:
+        """Create a pending import job and start it on the worker thread.
+
+        ``prepare`` (optional) runs FIRST on the job thread and returns the
+        real (source, dataset-extras) pair — heavy source arrangement (e.g.
+        the legacy alias's frame extraction) must never run on a request
+        thread. A prepare failure marks the job errored.
+        """
         job = self.store.create_job(
             "import",
             dataset=str(spec_payload.get("dataset", {}).get("name", "")),
             spec={**spec_payload, "__source": source},  # resume needs the source; stripped before validation
             plan_id=plan_id,
         )
-        thread = threading.Thread(target=self._run_import, args=(job.id, source, spec_payload, plan_id), daemon=True)
+
+        def run() -> None:
+            resolved_source, payload = source, spec_payload
+            if prepare is not None:
+                try:
+                    resolved_source, extras = prepare()
+                    payload = {
+                        **spec_payload,
+                        "dataset": {**spec_payload.get("dataset", {}), **extras},
+                    }
+                    self.store.update_job(job.id, spec={**payload, "__source": resolved_source})
+                except Exception as error:  # noqa: BLE001 - surfaced on the job record
+                    self.store.update_job(job.id, status="error", error={"message": str(error)})
+                    return
+            self._run_import(job.id, resolved_source, payload, plan_id)
+
+        thread = threading.Thread(target=run, daemon=True)
         self._threads.append(thread)
         thread.start()
         return job

--- a/src/pixano/datasets/io/registry.py
+++ b/src/pixano/datasets/io/registry.py
@@ -122,8 +122,7 @@ class FormatRegistry:
         if not candidates:
             known = ", ".join(self.names()) or "<none>"
             raise FormatDetectionError(
-                f"Could not detect the data format of '{source.location()}'. "
-                f"Pass an explicit format (known: {known})."
+                f"Could not detect the data format of '{source.location()}'. Pass an explicit format (known: {known})."
             )
         candidates.sort(key=lambda c: c[0], reverse=True)
         if len(candidates) > 1 and candidates[0][0] == candidates[1][0]:

--- a/src/pixano/datasets/queries/table.py
+++ b/src/pixano/datasets/queries/table.py
@@ -4,6 +4,7 @@
 # License: CECILL-C
 # =====================================
 
+import re
 from typing import Any, TypeVar
 
 import duckdb
@@ -194,6 +195,29 @@ class TableQueryBuilder:
         self._descending = descending
         return self
 
+    def _filter_is_index_covered(self) -> bool:
+        """True when every column the where clause references has a scalar index.
+
+        Conservative: identifier tokens are matched against the table schema;
+        any schema column appearing in the filter must be indexed. Unknown or
+        unparsable filters return False (callers fall back to the full scan).
+        """
+        if self._where is None:
+            return True
+        try:
+            schema_names = set(self.table.schema.names)
+            referenced = {
+                token for token in re.findall(r"[A-Za-z_][A-Za-z0-9_.]*", self._where) if token in schema_names
+            }
+            if not referenced:
+                return False
+            indexed: set[str] = set()
+            for index in self.table.list_indices():
+                indexed.update(getattr(index, "columns", None) or [])
+            return referenced <= indexed
+        except Exception:  # pragma: no cover - lancedb introspection failure
+            return False
+
     def _execute(self) -> pa.Table:
         """Builds the LanceQueryBuilder.
 
@@ -228,20 +252,26 @@ class TableQueryBuilder:
 
         # Determine if we need the DuckDB path
         needs_duckdb = len(self._order_by) > 0 or (self._offset is not None and self._offset > 0)
+        if needs_duckdb and len(self._order_by) == 0 and self._filter_is_index_covered():
+            # Indexed filters page natively (limit/offset apply post-filter).
+            needs_duckdb = False
 
         if not needs_duckdb:
             # LanceDB native path. CAUTION: in lancedb 0.29 plain scans apply
-            # `limit` to the rows SCANNED, before the `where` filter — a filtered
-            # query whose matches are not at the head of the table silently
-            # under-returns. With a filter we must scan the whole table (late
-            # materialization keeps this cheap) and slice the limit afterwards.
-            if self._where is not None:
+            # `limit` BEFORE any non-index-covered part of the `where` filter —
+            # a filtered query whose matches are not at the head of the table
+            # silently under-returns. When every predicate column carries a
+            # scalar index the limit/offset apply post-filter (fast path);
+            # otherwise scan the whole table and slice afterwards.
+            if self._where is not None and not self._filter_is_index_covered():
                 scan_limit = self.table.count_rows()
             else:
                 scan_limit = self._limit if self._limit is not None else self.table.count_rows()
             query = self.table.search(None).select(columns).limit(scan_limit)
             if self._where is not None:
                 query = query.where(self._where)
+            if self._offset:
+                query = query.offset(self._offset)
             result = query.to_arrow()
             if self._where is not None and self._limit is not None:
                 result = result.slice(0, self._limit)
@@ -254,7 +284,8 @@ class TableQueryBuilder:
 
             if len(self._order_by) == 0:
                 # No ORDER BY, just OFFSET — overfetch + slice. Same scan-limit
-                # caveat as the native path: with a filter, scan everything.
+                # caveat as the native path: with a non-index-covered filter,
+                # scan everything (index-covered filters took the native path).
                 if self._where is not None:
                     fetch_limit = self.table.count_rows()
                 else:

--- a/tests/datasets/io/test_engine.py
+++ b/tests/datasets/io/test_engine.py
@@ -164,3 +164,54 @@ class TestLibraryGlobHardening:
     def test_workspace_flows_through(self, tmp_path: Path):
         result = _import(tmp_path, ToyImporter(num_records=2), _spec())
         assert Dataset(result.dataset_path).info.workspace == WorkspaceType.IMAGE
+
+
+class TestConcurrencyOptimizations:
+    def test_import_creates_filter_indexes(self, tmp_path):
+        from pixano.datasets import Dataset
+        from pixano.datasets.io import ImportSpec, import_dataset
+        from tests.datasets.io._toy_importer import ToyImporter
+
+        spec = ImportSpec.model_validate({"dataset": {"name": "idx", "workspace": "image"}})
+        result = import_dataset(tmp_path / "src", tmp_path / "data", spec, importer=ToyImporter(num_records=3))
+        dataset = Dataset(result.dataset_path)
+        table = dataset.open_table("images")
+        indexed = {c for i in table.list_indices() for c in (getattr(i, "columns", None) or [])}
+        assert {"id", "record_id"} <= indexed
+        # standard filter columns present in the schema are indexed too
+        assert "record_id" in indexed
+
+    def test_sequence_frames_only_first_frame_gets_a_preview(self, tmp_path):
+        import io as io_module
+
+        import PIL.Image
+
+        from pixano.datasets import Dataset, DatasetInfo
+        from pixano.datasets.io.engine import _stamp_image_previews
+        from pixano.schemas import Record, SequenceFrame
+
+        library = tmp_path / "lib"
+        info = DatasetInfo(name="seq", record=Record, views={"cam": SequenceFrame})
+        dataset = Dataset.create(library / "seq", info)
+
+        buffer = io_module.BytesIO()
+        PIL.Image.new("RGB", (32, 32), (1, 2, 3)).save(buffer, "JPEG")
+        blob = buffer.getvalue()
+        rows = [
+            SequenceFrame(
+                id=f"f{i}",
+                record_id="r",
+                logical_name="cam",
+                uri="",
+                raw_bytes=blob,
+                width=32,
+                height=32,
+                format="JPEG",
+                frame_index=i,
+                timestamp=i / 10,
+            )
+            for i in range(5)
+        ]
+        _stamp_image_previews(dataset, "sequence_frames", rows)
+        assert rows[0].preview  # the grid's poster frame
+        assert all(not row.preview for row in rows[1:])  # no per-frame GIL burn

--- a/tests/datasets/io/test_previews.py
+++ b/tests/datasets/io/test_previews.py
@@ -32,10 +32,20 @@ class TestPreviewStamping:
             assert thumbnail.format == "PNG"
             assert max(thumbnail.size) <= 64
 
-    def test_sequence_frames_carry_thumbnails(self, tmp_path: Path):
+    def test_only_first_sequence_frames_carry_thumbnails(self, tmp_path: Path):
+        # One poster per record/view is all the grid uses; stamping every frame
+        # is per-row PIL work that starves concurrent API requests during imports.
         dataset = _import_corpus("frames_masks", tmp_path)
-        rows = dataset.open_table("sequence_frames").search().select(["preview_format"]).limit(None).to_list()
-        assert rows and all(row["preview_format"] == "png" for row in rows)
+        rows = (
+            dataset.open_table("sequence_frames")
+            .search()
+            .select(["frame_index", "preview_format"])
+            .limit(None)
+            .to_list()
+        )
+        assert rows
+        assert all(row["preview_format"] == "png" for row in rows if row["frame_index"] == 0)
+        assert all(row["preview_format"] == "" for row in rows if row["frame_index"] != 0)
 
     def test_uri_mode_rows_have_no_thumbnail(self, tmp_path: Path):
         dataset = _import_corpus("lerobot_window", tmp_path)  # remote videos, nothing embedded

--- a/tests/datasets/queries/__init__.py
+++ b/tests/datasets/queries/__init__.py
@@ -1,0 +1,5 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================

--- a/tests/datasets/queries/test_indexed_pagination.py
+++ b/tests/datasets/queries/test_indexed_pagination.py
@@ -1,0 +1,67 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Filtered pagination: index-covered fast path vs full-scan fallback (P0 concurrency work)."""
+
+from pathlib import Path
+
+import lancedb
+import pyarrow as pa
+import pytest
+
+from pixano.datasets.queries import TableQueryBuilder
+
+
+@pytest.fixture()
+def multi_camera_table(tmp_path: Path):
+    """Interleaved 2-camera frames across 3 records — the LIBERO shape."""
+    db = lancedb.connect(tmp_path / "db")
+    rows = []
+    for rec in ("recA", "recB", "recC"):
+        for i in range(300):
+            for cam in ("cam_a", "cam_b"):
+                rows.append(
+                    {"id": f"{rec}-{cam}-{i}", "record_id": rec, "logical_name": cam, "frame_index": i, "extra": i}
+                )
+    table = db.create_table("frames", pa.Table.from_pylist(rows))
+    table.create_scalar_index("record_id", index_type="BTREE")
+    table.create_scalar_index("frame_index", index_type="BTREE")
+    table.create_scalar_index("logical_name", index_type="BITMAP")
+    return table
+
+
+class TestIndexCoveredFastPath:
+    def test_mid_table_batch_is_exact(self, multi_camera_table):
+        where = "record_id = 'recB' and logical_name = 'cam_b' and frame_index >= 128 and frame_index < 256"
+        rows = TableQueryBuilder(multi_camera_table).select(["frame_index"]).where(where).limit(128).to_list()
+        assert sorted(r["frame_index"] for r in rows) == list(range(128, 256))
+
+    def test_offset_pages_are_exact_and_disjoint(self, multi_camera_table):
+        where = "record_id = 'recC' and logical_name = 'cam_a'"
+        page1 = (
+            TableQueryBuilder(multi_camera_table).select(["frame_index"]).where(where).limit(100).offset(0).to_list()
+        )
+        page2 = (
+            TableQueryBuilder(multi_camera_table).select(["frame_index"]).where(where).limit(100).offset(100).to_list()
+        )
+        got = sorted(r["frame_index"] for r in page1) + sorted(r["frame_index"] for r in page2)
+        assert got == list(range(0, 200))
+
+    def test_unindexed_predicate_falls_back_to_full_scan(self, multi_camera_table):
+        # 'extra' has no scalar index -> the fast path must NOT be used, and the
+        # fallback must still return exact results for mid-table matches.
+        where = "record_id = 'recB' and extra >= 100 and extra < 150 and logical_name = 'cam_a'"
+        builder = TableQueryBuilder(multi_camera_table).select(["frame_index"]).where(where).limit(50)
+        assert not builder._filter_is_index_covered()
+        rows = builder.to_list()
+        assert sorted(r["frame_index"] for r in rows) == list(range(100, 150))
+
+    def test_covered_check(self, multi_camera_table):
+        covered = TableQueryBuilder(multi_camera_table).select(["id"]).where("record_id = 'recA'").limit(1)
+        assert covered._filter_is_index_covered()
+        # filters referencing no known schema column conservatively refuse the fast path
+        odd = TableQueryBuilder(multi_camera_table).select(["id"]).where("true").limit(1)
+        assert not odd._filter_is_index_covered()

--- a/tests/datasets/test_merge_records.py
+++ b/tests/datasets/test_merge_records.py
@@ -149,11 +149,17 @@ class TestCreateScalarIndexes:
 
         bbox_indices = list(dataset.open_table("bboxes").list_indices())
         indexed_columns = sorted(column for index in bbox_indices for column in index.columns)
-        assert indexed_columns == ["id", "record_id"]
+        # every standard filter column present in the schema gets an index
+        assert "id" in indexed_columns and "record_id" in indexed_columns
+        expected = sorted(
+            column for column in Dataset.FILTER_INDEX_COLUMNS if column in dataset.open_table("bboxes").schema.names
+        )
+        assert indexed_columns == expected
 
-        # Records table has no record_id column: only id is indexed, absent columns skipped.
+        # Records table has no record_id column: absent columns are skipped.
         record_indices = list(dataset.open_table("records").list_indices())
-        assert sorted(column for index in record_indices for column in index.columns) == ["id"]
+        record_indexed = sorted(column for index in record_indices for column in index.columns)
+        assert "id" in record_indexed and "record_id" not in record_indexed
 
 
 class TestCacheInvalidation:


### PR DESCRIPTION
## Issue

Checkpoint-E finding after backgrounding imports (#695): with a job running, navigation and data loading degrade — the backend wasn't ready for parallel work. Two audits (API concurrency architecture + import-thread GIL behavior) and live benchmarks (temp server, 16k-row frame table, probes idle vs mid-ingest) traced the causes.

## Description

### Index-covered filtered pagination (the big one)
lancedb 0.29 applies `limit`/`offset` **after** the index-resolved part of a filter. The #690 correctness fix had worked around pre-filter limits with a **full-table scan per filtered query** — 52 ms per 128-frame batch on 16k rows, O(table) growth, plus a `count_rows()` per request.

- `Dataset.create_scalar_indexes` now indexes every standard filter column, typed by cardinality (BTREE: ids/`frame_index`; BITMAP: `logical_name`/`split`/`source_type`); the engine's finalize covers all new imports.
- `TableQueryBuilder` gains a **guarded fast path**: when every column a where clause references carries a scalar index, `limit`/`offset` run natively — verified **exact** on interleaved multi-camera tables (the LIBERO shape) for mid-table windows and offset pages. Everything else keeps the full-scan fallback (older datasets, arbitrary columns).
- `pixano data optimize DATA_DIR DATASET` retrofits existing libraries.

### Response-path overhead
- The multipart frame batch and blob/preview endpoints returned in-memory bytes through sync-iterator `StreamingResponse`s — **one threadpool hop per chunk** (~30 ms per 128-frame batch). Plain `Response`s now.
- Gzip no longer recompresses media routes (`/blob`, `/preview`, `/sframes/batch`, `/media`) — pure CPU burn on JPEG/PNG.
- The sync-endpoint threadpool rises from anyio's 40-token default to 100 (each in-flight blob download holds a token for its whole duration).
- `/datasets/{id}` and `/stats` reuse the shared dataset cache instead of fresh lancedb connections per call; `Dataset` memoizes table handles (handles read the latest version per query; migration drops its handle around schema alters).

### Import-thread GIL relief
- Sequence-frame tables stamp the 64px grid preview **only on frame 0** — the grid shows one poster per record/view; stamping all 400+ frames of an episode was a PIL decode+encode per frame inside the import thread. Side effect: a 50-episode LeRobot ingest dropped from 40+ s to ~15 s.
- The legacy import alias ran **cv2 frame extraction on a request thread** before submitting the job; preparation now runs first on the job thread (`submit_import` grew a `prepare` hook).

### Measured
| probe | before | after (idle) | after (during 50-ep ingest) |
|---|---|---|---|
| 128-frame batch | 54 ms (full scan) | **10.7 ms** | 22.9 ms |
| records page | 6.5 ms | 8.4 ms | 9.2 ms |
| image blob | — | 5.6 ms | 6.0 ms |

New tests: multi-camera indexed pagination (exact mid-table windows, disjoint offset pages, un-indexed fallback), filter-index census on import, first-frame-only preview stamping. Full suite green (653 + slow scale suite); mypy/ruff/hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)