### PR TITLE
feat: show list-valued record attributes (LeRobot tasks) in the explorer table

### DIFF
--- a/ui/apps/pixano/src/components/dataset/table/Table.svelte
+++ b/ui/apps/pixano/src/components/dataset/table/Table.svelte
@@ -48,7 +48,7 @@ License: CECILL-C
         const val = info.getValue();
         return val == null ? "" : String(val as string | number | boolean);
       },
-      enableSorting: col.type !== "image" && col.type !== "video",
+      enableSorting: col.type !== "image" && col.type !== "video" && col.type !== "list",
     }));
   };
 

--- a/ui/apps/pixano/src/components/dataset/table/TableCell.ts
+++ b/ui/apps/pixano/src/components/dataset/table/TableCell.ts
@@ -28,6 +28,7 @@ export const TableCell: Record<string, (value: CellValue) => ReturnType<typeof r
   float: createCellRenderer(NumberCell),
   bool: createCellRenderer(BooleanCell),
   str: createCellRenderer(TextCell),
+  list: createCellRenderer(TextCell),
   datetime: createCellRenderer(DateTimeCell),
   video: createCellRenderer(VideoCell),
   histogram: createCellRenderer(HistogramCell),

--- a/ui/apps/pixano/src/lib/api/__tests__/adapters.test.ts
+++ b/ui/apps/pixano/src/lib/api/__tests__/adapters.test.ts
@@ -1,0 +1,66 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import { toDatasetBrowser } from "../adapters";
+import type { PaginatedResponse, RecordResponse } from "../restTypes";
+
+const paginated = (items: RecordResponse[]): PaginatedResponse<RecordResponse> => ({
+  items,
+  total: items.length,
+  limit: 20,
+  offset: 0,
+});
+
+const columnType = (browser: ReturnType<typeof toDatasetBrowser>, name: string) =>
+  browser.table_data.columns.find((col) => col.name === name)?.type;
+
+describe("toDatasetBrowser list attributes", () => {
+  it("renders a string[] attribute as a joined 'list' column", () => {
+    const browser = toDatasetBrowser(
+      "ds",
+      paginated([{ id: "0", split: "train", episode_index: 3, tasks: ["pick up the block"] }]),
+    );
+    expect(columnType(browser, "tasks")).toBe("list");
+    expect(browser.table_data.rows[0].tasks).toBe("pick up the block");
+    // scalars keep their inferred types
+    expect(columnType(browser, "episode_index")).toBe("int");
+    expect(columnType(browser, "split")).toBe("str");
+    expect(browser.table_data.rows[0].episode_index).toBe(3);
+  });
+
+  it("joins multiple list items with '; '", () => {
+    const browser = toDatasetBrowser("ds", paginated([{ id: "0", tasks: ["a", "b"] }]));
+    expect(browser.table_data.rows[0].tasks).toBe("a; b");
+  });
+
+  it("keeps an empty list as an empty-string column", () => {
+    const browser = toDatasetBrowser("ds", paginated([{ id: "0", tasks: [] }]));
+    expect(columnType(browser, "tasks")).toBe("list");
+    expect(browser.table_data.rows[0].tasks).toBe("");
+  });
+
+  it("infers bool columns and never turns view_previews into a record column", () => {
+    const browser = toDatasetBrowser(
+      "ds",
+      paginated([
+        {
+          id: "0",
+          reviewed: true,
+          view_previews: {
+            image: { resource: "views", id: "v0", kind: "image", preview_url: "/blob/v0" },
+          },
+        },
+      ]),
+    );
+    expect(columnType(browser, "reviewed")).toBe("bool");
+    expect(columnType(browser, "view_previews")).toBeUndefined();
+    // the preview surfaces as its own column, typed by the preview kind
+    expect(columnType(browser, "image")).toBe("image");
+    expect(browser.table_data.rows[0].image).toBe("/blob/v0");
+  });
+});

--- a/ui/apps/pixano/src/lib/api/adapters.ts
+++ b/ui/apps/pixano/src/lib/api/adapters.ts
@@ -189,7 +189,15 @@ export function toDatasetBrowser(
   const rows: TableRow[] = items.map((record) => {
     const row: TableRow = {};
     for (const [key, value] of Object.entries(record)) {
-      if (typeof value === "object" && value !== null) continue;
+      if (Array.isArray(value)) {
+        // List attributes (e.g. LeRobot `tasks`) render as a joined string —
+        // the table can only show primitives, and an instruction reads best
+        // as text. The raw array stays available in the single-item view.
+        row[key] = value.map((item) => (item == null ? "" : String(item))).join("; ");
+        if (!columnsMap.has(key)) columnsMap.set(key, "list");
+        continue;
+      }
+      if (typeof value === "object" && value !== null) continue; // nested objects aren't renderable
       row[key] = (value ?? "") as string | number | boolean;
       if (!columnsMap.has(key)) {
         columnsMap.set(key, inferColumnType(value));


### PR DESCRIPTION
## Description

LeRobot datasets carry a natural-language task/instruction per episode. The importer already stores it as a record attribute `tasks: list[str]`, and it reaches the REST layer as a JSON array — but it never showed in the dataset explorer. The table adapter skips every object-typed value, and in JS `typeof [] === "object"`, so the `tasks` array was dropped before it could become a column.

This is a frontend-only fix (no importer change — `tasks` stays `list[str]`). The dataset table adapter now renders a record attribute that is an array of primitives as a joined-string column, so the instruction is visible. It generalizes to any list attribute; LeRobot `tasks` is the motivating case. A joined text string is the right rendering for an instruction (usually one per episode — a sentence, not a tag).

### Changes
- `adapters.ts` (`toDatasetBrowser`): arrays of primitives → `value.join("; ")` with a new `"list"` column type, before the existing nested-object skip (nested objects like `view_previews` stay skipped and are handled separately).
- `TableCell.ts`: map `list` → the existing `TextCell` (renders the joined string; no new component).
- `Table.svelte`: `list` columns are not server-sortable (ordering a lancedb `list<str>` column is undefined). Filtering already excludes non-`str/int/float` types.
- The raw array remains available verbatim in the single-item raw view (`toRawRecord`) and round-trips through pixano_jsonl export.

## Tests

- New `src/lib/api/__tests__/adapters.test.ts` (first coverage for `toDatasetBrowser`): `tasks: ["pick up the block"]` → a `list` column with the joined value; multi-element join; empty list; scalar type inference (`int`/`str`/`bool`); `view_previews` never becomes a record column but its preview surfaces as its own typed column.
- `pnpm test` 21 files / 122 tests green; `pnpm lint` + `pnpm format_check` clean; production build succeeds. Verified the linchpin over the Python REST model: a `list[str]` record attr serializes as a JSON array through `RecordResponse`.

## Manual check
Import a LeRobot dataset (hub `lerobot/pusht`, episodes `0:1`) via the wizard → open it in the explorer → the `tasks` column shows the instruction text; the header isn't sortable; other columns are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)