### PR TITLE
fix: harden media-only import discovery and spec compilation

### DIFF
--- a/src/pixano/api/routers/data_io.py
+++ b/src/pixano/api/routers/data_io.py
@@ -259,7 +259,18 @@ def start_import(request: ImportRequestIO, settings: Annotated[Settings, Depends
     if request.plan_id and store.get_plan(request.plan_id) is None:
         raise HTTPException(status_code=409, detail=f"Plan '{request.plan_id}' not found or expired (re-analyze).")
     source = request.source or (store.get_plan(request.plan_id) or (None, ""))[1]
-    job = runner.submit_import(source, _spec_payload_for_source(source, request.spec), plan_id=request.plan_id)
+    spec_payload = _spec_payload_for_source(source, request.spec)
+    if not (spec_payload.get("dataset") or {}).get("name"):
+        try:
+            staged = Path(source).resolve().is_relative_to(_uploads_root(settings).resolve())
+        except (OSError, ValueError):
+            staged = False
+        if staged:
+            raise HTTPException(
+                status_code=422,
+                detail="Imports from a staged upload need dataset.name (the upload folder name is opaque).",
+            )
+    job = runner.submit_import(source, spec_payload, plan_id=request.plan_id)
     return _job_response(job)
 
 

--- a/src/pixano/datasets/io/formats/pixano_jsonl/importer.py
+++ b/src/pixano/datasets/io/formats/pixano_jsonl/importer.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 from pixano.datasets.dataset_info import DatasetInfo
 from pixano.schemas import canonical_table_name_for_schema, canonical_table_name_for_slot
 
-from ...errors import MetadataError, PixanoDataError, SpecValidationError
+from ...errors import MediaResolutionError, MetadataError, PixanoDataError, SpecValidationError
 from ...ids import stable_id
 from ...importer import BatchBundle, Cursor, DatasetImporter, DetectResult, SourceRef
 from ...media import MediaResolver, ffmpeg_available, ffprobe_available, probe_image, probe_video
@@ -206,6 +206,8 @@ class PixanoJsonlImporter(DatasetImporter):
                 'options {"frames": "reference"}.',
             )
 
+        self._check_media_only_record_attrs(spec, source, plan.report)
+        self._probe_media_only_files(layout, limits, plan.report)
         max_frames = self._max_frames_per_video(spec)
         estimate = 0
         for split in layout.splits:
@@ -235,6 +237,72 @@ class PixanoJsonlImporter(DatasetImporter):
         if estimate:
             plan.media_size_estimate_bytes = estimate
         return plan
+
+    def _check_media_only_record_attrs(self, spec: ImportSpec, source: SourceRef, report: PreflightReport) -> None:
+        """Media-only ingest builds records with no attr values: required record attrs can never be satisfied."""
+        from pixano.schemas import Record
+
+        try:
+            info = self.resolve_info(spec, source)
+        except (SpecValidationError, ValidationError):
+            return  # a broken spec surfaces through its own finding/error path
+        if info.record is None:
+            return
+        base_fields = set(Record.model_fields)
+        required = sorted(
+            name for name, field in info.record.model_fields.items() if name not in base_fields and field.is_required()
+        )
+        if required:
+            report.add(
+                "required_record_attr",
+                Provenance(file=source.location()),
+                suggestion="Media-only imports create records without attribute values; give "
+                f"{', '.join(repr(name) for name in required)} a default or drop 'required'.",
+            )
+
+    @staticmethod
+    def _probe_media_only_files(layout: Any, limits: AnalyzeLimits, report: PreflightReport) -> None:
+        """Bounded readability probes so bad media fails analyze, not mid-ingest."""
+        window = 64 * 1024
+        probes = 0
+        can_probe_video = ffprobe_available()
+        for split in layout.splits:
+            for group in split.records:
+                for view, media_file in sorted(group.files.items()):
+                    if probes >= limits.max_media_probes:
+                        return
+                    kind = layout.view_kinds.get(view)
+                    if kind == "text":
+                        probes += 1
+                        data = media_file.read_bytes()[:window]
+                        try:
+                            data.decode("utf-8")
+                        except UnicodeDecodeError as error:
+                            if len(data) == window and error.start >= window - 4:
+                                continue  # a multi-byte char cut by the probe window, not a bad file
+                            report.add(
+                                "unreadable_text",
+                                Provenance(file=str(media_file)),
+                                suggestion=f"'{media_file.name}' is not valid UTF-8; re-encode it or remove it.",
+                            )
+                    elif kind == "video" and can_probe_video:
+                        probes += 1
+                        try:
+                            probe = probe_video(media_file)
+                        except PixanoDataError as error:
+                            report.add(
+                                "unreadable_video",
+                                Provenance(file=str(media_file)),
+                                suggestion=f"'{media_file.name}' cannot be read as a video ({error}); "
+                                "re-encode it or remove it.",
+                            )
+                            continue
+                        if probe.num_frames <= 0:
+                            report.add(
+                                "unreadable_video",
+                                Provenance(file=str(media_file)),
+                                suggestion=f"'{media_file.name}' has no decodable frames; re-encode it or remove it.",
+                            )
 
     @staticmethod
     def _max_frames_per_video(spec: ImportSpec) -> int:
@@ -460,6 +528,8 @@ class PixanoJsonlImporter(DatasetImporter):
         rows: list[LanceModel] = []
         with tempfile.TemporaryDirectory(prefix="pixano-media-only-") as tmp:
             frame_files = decode_video_frames(video_file, tmp)
+            if not frame_files:
+                raise MediaResolutionError(f"'{video_file.name}' decoded to zero frames; re-encode it or remove it.")
             indices = list(range(len(frame_files)))
             if max_frames and len(indices) > max_frames:
                 stride = len(indices) / max_frames
@@ -666,7 +736,10 @@ class PixanoJsonlImporter(DatasetImporter):
         elif payload.uri.startswith(("http://", "https://", "s3://")):
             content, uri = "", payload.uri
         else:
-            content, uri = context.resolver.local_path(payload.uri).read_text(encoding="utf-8"), ""
+            try:
+                content, uri = context.resolver.local_path(payload.uri).read_text(encoding="utf-8"), ""
+            except UnicodeDecodeError as error:
+                raise MetadataError(f"Text file '{payload.uri}' is not valid UTF-8: {error}.") from None
         return view_cls(
             id=stable_id(record_id, "view", view_name),
             record_id=record_id,

--- a/src/pixano/datasets/io/formats/pixano_jsonl/media_only.py
+++ b/src/pixano/datasets/io/formats/pixano_jsonl/media_only.py
@@ -159,16 +159,34 @@ def discover_layout(source_dir: Path, declared_views: dict[str, str] | None, rep
 
 
 def _declared_layout(source_dir: Path, view_kinds: dict[str, str], report: PreflightReport) -> list[SplitLayout]:
+    reserved = sorted(name for name in view_kinds if name.lower() in _SPLIT_DIR_NAMES)
+    if reserved:
+        report.add(
+            "view_name_reserved",
+            Provenance(file=str(source_dir)),
+            suggestion=f"View name(s) {reserved} collide with split folder names "
+            f"({', '.join(sorted(_SPLIT_DIR_NAMES))}); rename the view(s).",
+        )
+        return []
+
     subdirs = _subdirs(source_dir)
     split_named = bool(subdirs) and all(d.name.lower() in _SPLIT_DIR_NAMES for d in subdirs)
 
     if len(view_kinds) >= 2:
-        matched = _match_view_dirs(source_dir, view_kinds)
+        matched = _match_view_dirs(source_dir, view_kinds, report)
+        if matched is None:
+            return []
         if matched and not split_named:
             # View folders at the root (missing ones surface per-view findings).
             return [_view_dir_split("default", source_dir, matched, view_kinds, report)]
         if split_named:
-            return [_view_dir_split(d.name, d, _match_view_dirs(d, view_kinds), view_kinds, report) for d in subdirs]
+            splits = []
+            for subdir in subdirs:
+                split_matched = _match_view_dirs(subdir, view_kinds, report)
+                if split_matched is None:
+                    return []
+                splits.append(_view_dir_split(subdir.name, subdir, split_matched, view_kinds, report))
+            return splits
         report.add(
             "view_folder_missing",
             Provenance(file=str(source_dir)),
@@ -181,8 +199,10 @@ def _declared_layout(source_dir: Path, view_kinds: dict[str, str], report: Prefl
     (view_name, file_kind) = next(iter(view_kinds.items()))
     if split_named:
         _warn_root_files(source_dir, report)
-        return [_flat_split(d.name, d, view_name, file_kind) for d in subdirs]
-    matched = _match_view_dirs(source_dir, view_kinds)
+        return [_flat_split(d.name, d, view_name, file_kind, report) for d in subdirs]
+    matched = _match_view_dirs(source_dir, view_kinds, report)
+    if matched is None:
+        return []
     if view_name in matched:
         # <source>/<view>/ at the root: one 'default' split (mirrors inference).
         per_view = {view_name: _keyed_files(matched[view_name], file_kind, report)}
@@ -190,17 +210,47 @@ def _declared_layout(source_dir: Path, view_kinds: dict[str, str], report: Prefl
     if subdirs:
         # Legacy layout: every subdir is a split, scanned recursively.
         _warn_root_files(source_dir, report)
-        return [_flat_split(d.name, d, view_name, file_kind) for d in subdirs]
-    return [_flat_split("default", source_dir, view_name, file_kind)]
+        for subdir in subdirs:
+            if subdir.name.lower() not in _SPLIT_DIR_NAMES:
+                report.add(
+                    "subdirs_treated_as_splits",
+                    Provenance(file=str(subdir)),
+                    severity="warning",
+                    suggestion=f"Folder '{subdir.name}' becomes a split because the schema declares the single "
+                    f"view '{view_name}' and no folder matches it; use split names (train/val/test) or a "
+                    f"'{view_name}/' folder if this is not intended.",
+                )
+        return [_flat_split(d.name, d, view_name, file_kind, report) for d in subdirs]
+    return [_flat_split("default", source_dir, view_name, file_kind, report)]
 
 
-def _match_view_dirs(root: Path, view_kinds: dict[str, str]) -> dict[str, Path]:
-    """Resolve declared view names to subfolders (exact or snake_cased folder names)."""
-    lookup: dict[str, Path] = {}
+def _match_view_dirs(root: Path, view_kinds: dict[str, str], report: PreflightReport) -> dict[str, Path] | None:
+    """Resolve declared view names to subfolders (exact or snake_cased folder names).
+
+    A declared name claimed by more than one folder (e.g. ``Left Cam/`` and
+    ``left_cam/`` both snake-casing to ``left_cam``) is reported as an error
+    and returns ``None`` — never a silent first-match pick.
+    """
+    claims: dict[str, list[Path]] = {}
     for subdir in _subdirs(root):
-        lookup.setdefault(subdir.name, subdir)
-        lookup.setdefault(to_snake_case(subdir.name), subdir)
-    return {name: lookup[name] for name in view_kinds if name in lookup}
+        for name in {subdir.name, to_snake_case(subdir.name)}:
+            claims.setdefault(name, []).append(subdir)
+    matched: dict[str, Path] = {}
+    collided = False
+    for name in view_kinds:
+        candidates = claims.get(name, [])
+        if len(candidates) > 1:
+            folders = ", ".join(f"'{d.name}'" for d in sorted(candidates))
+            report.add(
+                "view_name_collision",
+                Provenance(file=str(root)),
+                suggestion=f"Folders {folders} all match declared view '{name}'; rename or remove the extras.",
+            )
+            collided = True
+            continue
+        if candidates:
+            matched[name] = candidates[0]
+    return None if collided else matched
 
 
 def _view_dir_split(
@@ -224,9 +274,12 @@ def _view_dir_split(
     return SplitLayout(name=split_name, root=split_root, records=_group_by_key(per_view, report))
 
 
-def _flat_split(split_name: str, split_root: Path, view_name: str, file_kind: str) -> SplitLayout:
+def _flat_split(
+    split_name: str, split_root: Path, view_name: str, file_kind: str, report: PreflightReport
+) -> SplitLayout:
     """A recursively scanned single-view split, keyed by stem (the legacy grouping)."""
     files = _scan_files(split_root, file_kind)
+    _report_duplicate_stems(files, split_root, report)
     records = [
         RecordGroup(key=f.stem, ordinal=ordinal, files={view_name: f}) for ordinal, f in enumerate(files, start=1)
     ]
@@ -306,13 +359,24 @@ def _infer_split_views(
         return {kind: (kind, keyed)}
 
     views: dict[str, tuple[str, dict[str, Path]]] = {}
+    named_dirs: dict[str, Path] = {}
     for view_dir in sorted(view_dirs):
         files = sorted(p for p in view_dir.rglob("*") if p.is_file() and classify_media(p) is not None)
         kind = _sole_kind(files, view_dir, report)
         if kind is None:
             return None
+        name = to_snake_case(view_dir.name)
+        if name in views:
+            report.add(
+                "view_name_collision",
+                Provenance(file=str(view_dir)),
+                suggestion=f"Folders '{named_dirs[name].name}' and '{view_dir.name}' both map to view "
+                f"'{name}'; rename one.",
+            )
+            return None
         keyed = _keyed_files(view_dir, kind, report)
-        views[to_snake_case(view_dir.name)] = (kind, keyed)
+        views[name] = (kind, keyed)
+        named_dirs[name] = view_dir
     return views
 
 

--- a/src/pixano/datasets/io/spec.py
+++ b/src/pixano/datasets/io/spec.py
@@ -104,6 +104,10 @@ def _attr_field(attr_name: str, value: Any) -> tuple[Any, Any]:
     if payload.get("required"):
         return annotation, ...
     if "default" in payload:
+        if payload.get("collection") and not isinstance(payload["default"], list):
+            raise SpecValidationError(
+                f"Attr '{attr_name}': a collection default must be a list, got {payload['default']!r}."
+            )
         return annotation, payload["default"]
     if payload.get("collection"):
         # A plain [] default (pydantic v2 deep-copies) — default_factory does not
@@ -180,10 +184,11 @@ class SchemaSpec(BaseModel):
                 continue
             payload[slot] = getattr(info, slot)
 
+        # Attrs extend the preset's classes (e.g. MEL's MelEntity keeps its `name`), not the bare bases.
         if self.record.get("attrs"):
-            payload["record"] = _synthesize(Record, self.record["attrs"])
+            payload["record"] = _synthesize(info.record or Record, self.record["attrs"])
         if self.entity.get("attrs"):
-            payload["entity"] = _synthesize(Entity, self.entity["attrs"])
+            payload["entity"] = _synthesize(info.entity or Entity, self.entity["attrs"])
         if self.entity_dynamic_state is not None:
             payload["entity_dynamic_state"] = (
                 _synthesize(EntityDynamicState, self.entity_dynamic_state["attrs"])

--- a/tests/app/test_api_io.py
+++ b/tests/app/test_api_io.py
@@ -122,6 +122,21 @@ class TestIoRoutes:
         assert (data_dir / "library" / "uploaded_ds").is_dir()
         assert not source.exists()  # eager GC: the staged upload is disposable after import
 
+    def test_upload_import_without_dataset_name_is_rejected(self, client_and_dirs):
+        """A staged upload's folder name is an opaque id — never a dataset name."""
+        import io
+
+        client, _, _ = client_and_dirs
+        session = client.post("/io/uploads").json()
+        jpeg = io.BytesIO()
+        PIL.Image.new("RGB", (16, 16), (10, 120, 200)).save(jpeg, format="JPEG")
+        client.put(f"/io/uploads/{session['upload_id']}/files/a.jpg", content=jpeg.getvalue())
+
+        spec = {"format": "pixano_jsonl", "dataset": {"workspace": "image"}}
+        started = client.post("/io/imports", json={"source": session["source"], "spec": spec})
+        assert started.status_code == 422
+        assert "dataset.name" in started.json()["detail"]
+
     def test_upload_session_validation(self, client_and_dirs):
         client, _, _ = client_and_dirs
         session = client.post("/io/uploads").json()

--- a/tests/datasets/io/formats/test_media_only.py
+++ b/tests/datasets/io/formats/test_media_only.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from pixano.datasets.io import FORMATS, ImportSpec, SourceRef, analyze, ffmpeg_available, ffprobe_available
+from pixano.datasets.io.errors import MetadataError
 from pixano.datasets.io.formats.pixano_jsonl import PixanoJsonlImporter
 from pixano.datasets.io.formats.pixano_jsonl.media_only import discover_layout, is_media_only_source
 from pixano.datasets.io.plan import PreflightReport
@@ -91,6 +92,49 @@ class TestDiscovery:
         assert report.is_valid
         assert layout.total_records == 1
         assert set(layout.splits[0].records[0].files) == {"my_left", "my_right"}
+
+    def test_inferred_view_folder_collision_is_reported(self, tmp_path: Path):
+        """Two folders snake-casing to the same view must not silently drop one folder's files."""
+        _seed_images(tmp_path / "Left Cam", ("a",))
+        _seed_images(tmp_path / "left_cam", ("a",))
+        report = PreflightReport()
+        layout = discover_layout(tmp_path, None, report)
+        assert "view_name_collision" in report.findings
+        assert layout.total_records == 0  # ambiguous: nothing imports minus a view
+
+    def test_declared_view_matched_by_two_folders_is_reported(self, tmp_path: Path):
+        _seed_images(tmp_path / "Left Cam", ("a",))
+        _seed_images(tmp_path / "left_cam", ("a",))
+        report = PreflightReport()
+        layout = discover_layout(tmp_path, {"left_cam": "image", "right": "image"}, report)
+        assert "view_name_collision" in report.findings
+        assert layout.total_records == 0
+
+    def test_declared_split_named_view_is_rejected(self, tmp_path: Path):
+        _seed_images(tmp_path / "train", ("a",))
+        report = PreflightReport()
+        layout = discover_layout(tmp_path, {"train": "image"}, report)
+        assert "view_name_reserved" in report.findings
+        assert layout.total_records == 0
+
+    def test_single_declared_view_with_odd_subdirs_warns(self, tmp_path: Path):
+        """The legacy every-subdir-is-a-split behavior stays, but stops being silent."""
+        _seed_images(tmp_path / "day1", ("a",))
+        _seed_images(tmp_path / "day2", ("b",))
+        report = PreflightReport()
+        layout = discover_layout(tmp_path, {"image": "image"}, report)
+        assert report.findings["subdirs_treated_as_splits"].severity == "warning"
+        assert report.is_valid  # a warning, not an error: the layout still imports
+        assert {split.name for split in layout.splits} == {"day1", "day2"}
+        assert layout.total_records == 2
+
+    def test_flat_declared_view_duplicate_stems_are_reported(self, tmp_path: Path):
+        """The legacy stem-keyed path detects a.jpg + a.png like inference does."""
+        _seed_images(tmp_path, ("a",))
+        _seed_images(tmp_path, ("a",), asset=IMAGE_PNG_ASSET_URL)
+        report = PreflightReport()
+        discover_layout(tmp_path, {"image": "image"}, report)
+        assert "duplicate_view_stem" in report.findings
 
 
 class TestRawImages:
@@ -198,6 +242,17 @@ class TestRawVideos:
         assert all(row["timestamp"] >= 0 for row in frames)
 
     @needs_ffmpeg
+    def test_garbage_video_fails_analyze(self, tmp_path: Path):
+        """An unprobeable video is an analyze error, not a silent empty record at ingest."""
+        source = tmp_path / "vids"
+        source.mkdir()
+        shutil.copy(VIDEO_MP4_ASSET_URL, source / "ok.mp4")
+        (source / "bad.mp4").write_bytes(b"not really a video")
+        plan = analyze(source, _spec({"dataset": {"name": "vids"}}))
+        assert "unreadable_video" in plan.report.findings
+        assert not plan.report.is_valid
+
+    @needs_ffmpeg
     def test_reference_mode_emits_video_rows(self, tmp_path: Path):
         source = tmp_path / "vids"
         source.mkdir()
@@ -232,6 +287,55 @@ class TestRawText:
         case.assert_counts(dataset)
         contents = {row.content for row in dataset.get_data("texts")}
         assert contents == {"hello x", "hello y"}
+
+    def test_non_utf8_text_fails_analyze(self, tmp_path: Path):
+        source = tmp_path / "notes"
+        source.mkdir()
+        (source / "ok.txt").write_text("fine", encoding="utf-8")
+        (source / "bad.txt").write_bytes(b"\xff\xfe broken \xff")
+        plan = analyze(source, _spec({"dataset": {"name": "notes"}}))
+        assert "unreadable_text" in plan.report.findings
+        assert not plan.report.is_valid
+
+    def test_non_utf8_text_beyond_probe_budget_fails_at_ingest(self, tmp_path: Path):
+        """Past the bounded analyze probes, the ingest read still fails loudly, not with a stacktrace-less row."""
+        source = tmp_path / "notes"
+        source.mkdir()
+        for index in range(40):  # AnalyzeLimits.max_media_probes is 32
+            (source / f"n{index:03d}.txt").write_text("fine", encoding="utf-8")
+        (source / "z_bad.txt").write_bytes(b"\xff\xfe broken")
+        spec = _spec({"dataset": {"name": "notes"}})
+        plan = analyze(source, spec)
+        assert plan.report.is_valid  # the bad file sorts past the probe budget
+        case = DatasetImporterTestCase(importer=PixanoJsonlImporter(), source=source, spec=spec)
+        with pytest.raises(MetadataError, match="not valid UTF-8"):
+            case.run_import(tmp_path / "data")
+
+
+class TestRequiredRecordAttrs:
+    def test_required_record_attr_flagged_in_media_only_analyze(self, tmp_path: Path):
+        """Media-only ingest creates records with no attr values: a required record attr can never be satisfied."""
+        source = tmp_path / "raw"
+        _seed_images(source, ("a",))
+        spec = _spec(
+            {
+                "dataset": {"name": "raw", "workspace": "image"},
+                "schema": {"record": {"attrs": {"weather": {"type": "str", "required": True}}}},
+            }
+        )
+        plan = analyze(source, spec)
+        assert "required_record_attr" in plan.report.findings
+        assert not plan.report.is_valid
+
+    def test_defaulted_record_attr_is_fine(self, tmp_path: Path):
+        source = tmp_path / "raw"
+        _seed_images(source, ("a",))
+        spec = _spec(
+            {"dataset": {"name": "raw", "workspace": "image"}, "schema": {"record": {"attrs": {"weather": "str"}}}}
+        )
+        plan = analyze(source, spec)
+        assert plan.report.is_valid
+        assert "required_record_attr" not in plan.report.findings
 
 
 class TestInferredSchemaStamping:

--- a/tests/datasets/io/test_schema_spec.py
+++ b/tests/datasets/io/test_schema_spec.py
@@ -84,6 +84,32 @@ class TestSchemaSpecCompile:
         with pytest.raises(SpecValidationError, match="identical attrs"):
             schema.compile(WorkspaceType.IMAGE)
 
+    def test_mel_entity_attrs_extend_the_preset_entity(self):
+        """Entity attrs land on the workspace preset's entity class, not bare Entity (MEL keeps `name`)."""
+        schema = SchemaSpec.model_validate({"entity": {"attrs": {"category": "str"}}})
+        info = schema.compile(WorkspaceType.IMAGE_TEXT_ENTITY_LINKING)
+        assert "name" in info.entity.model_fields
+        assert "category" in info.entity.model_fields
+
+    def test_collection_default_must_be_list(self):
+        with pytest.raises(SpecValidationError, match="collection default must be a list"):
+            SchemaSpec.model_validate(
+                {"entity": {"attrs": {"tags": {"type": "str", "collection": True, "default": "foo"}}}}
+            ).compile(WorkspaceType.IMAGE)
+
+    def test_collection_list_default_compiles(self):
+        info = SchemaSpec.model_validate(
+            {"entity": {"attrs": {"tags": {"type": "str", "collection": True, "default": ["a"]}}}}
+        ).compile(WorkspaceType.IMAGE)
+        assert info.entity.model_fields["tags"].default == ["a"]
+
+    def test_vqa_annotations_list_controls_message_slot(self):
+        """A non-empty annotations list replaces the preset's slots — callers must re-list `message` to keep it."""
+        keeps = SchemaSpec.model_validate({"annotations": ["message"]}).compile(WorkspaceType.IMAGE_VQA)
+        assert keeps.message is not None
+        drops = SchemaSpec.model_validate({"annotations": ["bbox"]}).compile(WorkspaceType.IMAGE_VQA)
+        assert drops.message is None
+
 
 class TestFromDatasetInfoInverse:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Issue

Groundwork for the raw-media import improvements (5 GUI use cases: single/multi-view images, videos, VQA, MEL). No linked issue.

## Description

An adversarial audit of the media-only import path found silent failure modes that undermine the wizard's raw-media flow. This PR fixes the backend half; the workspace-first wizard follows in a separate frontend PR.

**Discovery findings instead of silence** (`media_only.py`):
- `view_name_collision` (error): two folders snake-casing to the same view (`Left Cam/` + `left_cam/`), or two folders matching one declared view, previously dropped a whole view's files via dict overwrite / first-match pick.
- `view_name_reserved` (error): a declared view named `train`/`val`/`test`... can never bind to a folder.
- `subdirs_treated_as_splits` (warning): the legacy single-declared-view layout silently turned every subdir into a split; the behavior stays (ids are stable) but is now announced.
- `duplicate_view_stem` in the legacy stem-keyed path (`_flat_split`): `a.jpg` + `a.png` previously became two records with the same key. Inference already detected this, but `resolve_info` discards its inference report and injects declared views, so the wizard path never hit the inference check.

**Fail fast on unreadable media** (`importer.py`):
- Analyze now probes text and video files (bounded by `AnalyzeLimits.max_media_probes`): `unreadable_text` for non-UTF-8, `unreadable_video` for unprobeable/zero-frame videos.
- Ingest raises `MetadataError` on non-UTF-8 text and `MediaResolutionError` on zero-frame decodes instead of building records with missing views.
- `required_record_attr` (error): media-only ingest creates records with no attr values, so a `required: true` record attr would crash every record at ingest with a raw pydantic error.

**Spec compilation fixes** (`spec.py`):
- Record/entity attrs now synthesize onto the workspace preset's classes: MEL entity attrs no longer silently drop `MelEntity.name` (the field the entity-linking UI reads).
- A collection attr default must be a list (`SpecValidationError` instead of a broken compiled schema).

**REST guard** (`data_io.py`): imports from a staged upload without `dataset.name` are rejected with 422 — the upload folder name is an opaque shortuuid, and datasets were silently named after it.

## Tests

- `tests/datasets/io/formats/test_media_only.py`: 10 new tests (collisions inferred+declared, reserved names, surprise-splits warning, flat duplicate stems, non-UTF-8 text at analyze and past the probe budget at ingest, garbage video, required record attrs).
- `tests/datasets/io/test_schema_spec.py`: MEL preset entity extension, collection-default validation, VQA `annotations`-replaces-preset contract lock.
- `tests/app/test_api_io.py`: staged import without name → 422.
- Full backend suite green: 250 io + 19 API + 433 remaining (11 skipped), pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)