### PR TITLE
feat: workspace-first raw import wizard

### DIFF
--- a/ui/apps/pixano/src/components/library/import-wizard/AnnotationSlotsPicker.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/AnnotationSlotsPicker.svelte
@@ -8,11 +8,14 @@ License: CECILL-C
   interface Props {
     choices: string[];
     selected: string[];
+    /** Slots the use case cannot work without — always selected, not toggleable. */
+    locked?: string[];
   }
 
-  let { choices, selected = $bindable() }: Props = $props();
+  let { choices, selected = $bindable(), locked = [] }: Props = $props();
 
   function toggle(slot: string) {
+    if (locked.includes(slot)) return;
     selected = selected.includes(slot) ? selected.filter((s) => s !== slot) : [...selected, slot];
   }
 </script>
@@ -21,18 +24,21 @@ License: CECILL-C
   <p class="text-xs text-muted-foreground">Annotation types you plan to create in Pixano.</p>
   <div class="flex flex-wrap gap-1.5">
     {#each choices as slot (slot)}
-      {@const active = selected.includes(slot)}
+      {@const isLocked = locked.includes(slot)}
+      {@const active = isLocked || selected.includes(slot)}
       <button
         type="button"
         class={`rounded-full border px-2.5 py-1 font-mono text-[11px] transition-colors ${
           active
             ? "border-primary bg-primary/10 text-primary"
             : "border-border text-muted-foreground hover:border-primary/40"
-        }`}
+        } ${isLocked ? "cursor-default" : ""}`}
         aria-pressed={active}
+        aria-disabled={isLocked}
+        title={isLocked ? "This use case needs this annotation type." : undefined}
         onclick={() => toggle(slot)}
       >
-        {slot}
+        {slot}{#if isLocked}<span class="ml-1 opacity-60">•</span>{/if}
       </button>
     {/each}
   </div>

--- a/ui/apps/pixano/src/components/library/import-wizard/AttrsEditor.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/AttrsEditor.svelte
@@ -7,13 +7,16 @@ License: CECILL-C
 <script lang="ts">
   import { Plus, Trash } from "phosphor-svelte";
 
-  import { ENTITY_ATTR_TYPES, type EntityAttrRow } from "./rawSchema";
+  import { ATTR_TYPES, type AttrRow } from "./rawSchema";
 
   interface Props {
-    rows: EntityAttrRow[];
+    rows: AttrRow[];
+    hint: string;
+    /** Record attrs forbid `required`: media-only imports create records with no attr values. */
+    allowRequired?: boolean;
   }
 
-  let { rows = $bindable() }: Props = $props();
+  let { rows = $bindable(), hint, allowRequired = true }: Props = $props();
 
   function addRow() {
     rows = [...rows, { name: "", type: "str", list: false, required: false, defaultValue: "" }];
@@ -23,16 +26,20 @@ License: CECILL-C
     rows = rows.filter((_, i) => i !== index);
   }
 
+  const ZERO_DEFAULTS: Record<string, string> = {
+    str: '""',
+    int: "0",
+    float: "0.0",
+    bool: "false",
+  };
+
   const inputClass =
     "rounded-lg border border-border bg-card px-2 py-1.5 text-xs text-foreground " +
     "placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 </script>
 
 <div class="space-y-2">
-  <p class="text-xs text-muted-foreground">
-    Attributes each annotated object carries (e.g. <span class="font-mono">category: str</span>
-    ).
-  </p>
+  <p class="text-xs text-muted-foreground">{hint}</p>
 
   {#each rows as row, index (index)}
     <div class="flex flex-wrap items-center gap-2">
@@ -44,7 +51,7 @@ License: CECILL-C
         aria-label="Attribute name"
       />
       <select class={inputClass} bind:value={row.type} aria-label="Attribute type">
-        {#each ENTITY_ATTR_TYPES as type (type)}
+        {#each ATTR_TYPES as type (type)}
           <option value={type}>{type}</option>
         {/each}
       </select>
@@ -52,18 +59,25 @@ License: CECILL-C
         <input type="checkbox" bind:checked={row.list} />
         list
       </label>
-      <label class="flex items-center gap-1 text-xs text-muted-foreground">
-        <input type="checkbox" bind:checked={row.required} />
-        required
-      </label>
+      {#if allowRequired}
+        <label class="flex items-center gap-1 text-xs text-muted-foreground">
+          <input type="checkbox" bind:checked={row.required} />
+          required
+        </label>
+      {/if}
       {#if !row.required}
         <input
           type="text"
-          class="{inputClass} w-24 font-mono"
-          placeholder="default"
+          class="{inputClass} w-28 font-mono"
+          placeholder={row.list ? "a, b, c" : "default"}
           bind:value={row.defaultValue}
           aria-label="Default value"
         />
+        {#if !row.defaultValue.trim()}
+          <span class="text-[10px] text-muted-foreground/70">
+            defaults to {row.list ? "[]" : ZERO_DEFAULTS[row.type]}
+          </span>
+        {/if}
       {/if}
       <button
         type="button"

--- a/ui/apps/pixano/src/components/library/import-wizard/ImportWizard.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/ImportWizard.svelte
@@ -11,7 +11,10 @@ License: CECILL-C
 
   import DoneStep from "./DoneStep.svelte";
   import IntentStep from "./IntentStep.svelte";
+  import type { RawUseCase } from "./layoutPreflight";
   import ProgressStep from "./ProgressStep.svelte";
+  import { DEFAULT_ANNOTATIONS } from "./rawSchema";
+  import RawUseCaseStep from "./RawUseCaseStep.svelte";
   import ReviewStep from "./ReviewStep.svelte";
   import SourceStep from "./SourceStep.svelte";
   import WizardStepIndicator from "./WizardStepIndicator.svelte";
@@ -47,16 +50,7 @@ License: CECILL-C
 
   let { onClose }: Props = $props();
 
-  type Step = "intent" | "source" | "review" | "progress" | "done";
-
-  const STEP_LABELS = ["Type", "Source", "Review", "Import"];
-  const STEP_INDEX: Record<Step, number> = {
-    intent: 0,
-    source: 1,
-    review: 2,
-    progress: 3,
-    done: 3,
-  };
+  type Step = "intent" | "usecase" | "source" | "review" | "progress" | "done";
 
   let open = $state(true);
   let step = $state<Step>("intent");
@@ -83,11 +77,38 @@ License: CECILL-C
 
   const hasErrors = $derived(plan ? groupFindings(plan).errors.length > 0 : false);
   const canGoAnalyze = $derived(canAnalyze(fields, advancedJson));
+  const isRaw = $derived(fields.intent === "raw");
+  const referenceMode = $derived(
+    isRaw && fields.raw.useCase === "video" && fields.raw.framesMode === "reference",
+  );
+
+  // The raw flow adds a "Use case" step between Type and Source.
+  const stepLabels = $derived(
+    isRaw
+      ? ["Type", "Use case", "Source", "Review", "Import"]
+      : ["Type", "Source", "Review", "Import"],
+  );
+  const stepIndex = $derived.by(() => {
+    const offset = isRaw ? 1 : 0;
+    const index: Record<Step, number> = {
+      intent: 0,
+      usecase: 1,
+      source: 1 + offset,
+      review: 2 + offset,
+      progress: 3 + offset,
+      done: 3 + offset,
+    };
+    return index[step];
+  });
 
   const STEP_META: Record<Step, { title: string; description: string }> = {
     intent: {
       title: "Import Dataset",
       description: "What are you importing?",
+    },
+    usecase: {
+      title: "Import raw media",
+      description: "What are you building? This sets the views, workspace, and annotation types.",
     },
     source: {
       title: "Import Dataset",
@@ -126,6 +147,14 @@ License: CECILL-C
 
   function handleIntentSelect(intent: ImportIntent) {
     fields.intent = intent;
+    step = intent === "raw" ? "usecase" : "source";
+  }
+
+  function handleUseCaseSelect(useCase: RawUseCase) {
+    if (fields.raw.useCase !== useCase) {
+      fields.raw.useCase = useCase;
+      fields.raw.annotations = [...DEFAULT_ANNOTATIONS[useCase]];
+    }
     step = "source";
   }
 
@@ -231,14 +260,16 @@ License: CECILL-C
             {/if}
           </div>
 
-          <WizardStepIndicator steps={STEP_LABELS} current={STEP_INDEX[step]} />
+          <WizardStepIndicator steps={stepLabels} current={stepIndex} />
 
           {#if step === "intent"}
             <IntentStep {formats} onSelect={handleIntentSelect} />
+          {:else if step === "usecase"}
+            <RawUseCaseStep onSelect={handleUseCaseSelect} />
           {:else if step === "source"}
             <SourceStep bind:fields bind:advancedJson />
           {:else if step === "review"}
-            <ReviewStep {analyzing} {analyzeError} {plan} />
+            <ReviewStep {analyzing} {analyzeError} {plan} {referenceMode} />
           {:else if step === "progress"}
             <ProgressStep {job} {cancelRequested} />
           {:else if step === "done"}
@@ -246,7 +277,7 @@ License: CECILL-C
           {/if}
 
           <div class={BLOCKING_ALERT_ACTIONS_CLASS}>
-            {#if step === "intent" || step === "source" || step === "review"}
+            {#if step === "intent" || step === "usecase" || step === "source" || step === "review"}
               <button
                 type="button"
                 class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
@@ -256,11 +287,21 @@ License: CECILL-C
               </button>
             {/if}
 
-            {#if step === "source"}
+            {#if step === "usecase"}
               <button
                 type="button"
                 class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
                 onclick={() => (step = "intent")}
+              >
+                Back
+              </button>
+            {/if}
+
+            {#if step === "source"}
+              <button
+                type="button"
+                class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
+                onclick={() => (step = isRaw ? "usecase" : "intent")}
               >
                 Back
               </button>

--- a/ui/apps/pixano/src/components/library/import-wizard/LayoutPreviewPanel.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/LayoutPreviewPanel.svelte
@@ -1,0 +1,68 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { Warning, WarningCircle } from "phosphor-svelte";
+
+  import type { LayoutPreflight } from "./layoutPreflight";
+
+  interface Props {
+    layout: LayoutPreflight;
+  }
+
+  let { layout }: Props = $props();
+
+  const errors = $derived(layout.findings.filter((finding) => finding.severity === "error"));
+  const warnings = $derived(layout.findings.filter((finding) => finding.severity === "warning"));
+</script>
+
+<div class="space-y-2 rounded-xl border border-border bg-card p-4">
+  <p class="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+    Detected layout
+  </p>
+
+  {#if layout.ok}
+    <div class="flex flex-wrap items-center gap-1.5 text-xs">
+      <span class="font-medium text-foreground">
+        {layout.totalRecords} record{layout.totalRecords === 1 ? "" : "s"}
+      </span>
+      {#each layout.views as view (view.name)}
+        <span
+          class="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] text-muted-foreground"
+        >
+          {view.name} · {view.kind} · {view.fileCount} file{view.fileCount === 1 ? "" : "s"}
+        </span>
+      {/each}
+      {#if layout.splits.length > 1}
+        {#each layout.splits as split (split.name)}
+          <span
+            class="rounded-full border border-primary/30 px-2 py-0.5 text-[10px] text-muted-foreground"
+          >
+            {split.name}: {split.recordCount}
+          </span>
+        {/each}
+      {/if}
+      {#if layout.ignoredFiles > 0}
+        <span class="text-[10px] text-muted-foreground/70">
+          ({layout.ignoredFiles} non-matching file{layout.ignoredFiles === 1 ? "" : "s"} skipped)
+        </span>
+      {/if}
+    </div>
+  {/if}
+
+  {#each errors as finding (finding.code + finding.message)}
+    <p class="flex items-start gap-1.5 text-xs text-destructive">
+      <WarningCircle weight="fill" class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      {finding.message}
+    </p>
+  {/each}
+  {#each warnings as finding (finding.code + finding.message)}
+    <p class="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+      <Warning weight="fill" class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      {finding.message}
+    </p>
+  {/each}
+</div>

--- a/ui/apps/pixano/src/components/library/import-wizard/RawSchemaBuilder.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/RawSchemaBuilder.svelte
@@ -6,13 +6,12 @@ License: CECILL-C
 
 <script lang="ts">
   import AnnotationSlotsPicker from "./AnnotationSlotsPicker.svelte";
-  import EntityAttrsEditor from "./EntityAttrsEditor.svelte";
+  import AttrsEditor from "./AttrsEditor.svelte";
   import {
     ANNOTATION_CHOICES,
-    DEFAULT_ANNOTATIONS,
+    LOCKED_ANNOTATIONS,
     validateRawFields,
     type RawFields,
-    type RawMediaKind,
   } from "./rawSchema";
 
   interface Props {
@@ -21,18 +20,7 @@ License: CECILL-C
 
   let { raw = $bindable() }: Props = $props();
 
-  const KINDS: { kind: RawMediaKind; label: string }[] = [
-    { kind: "images", label: "Images" },
-    { kind: "videos", label: "Videos" },
-    { kind: "texts", label: "Text" },
-  ];
-
   const validationError = $derived(validateRawFields(raw));
-
-  function setKind(kind: RawMediaKind) {
-    raw.kind = kind;
-    raw.annotations = [...DEFAULT_ANNOTATIONS[kind]];
-  }
 
   const labelClass = "text-xs font-semibold uppercase tracking-widest text-muted-foreground";
   const inputClass =
@@ -47,65 +35,7 @@ License: CECILL-C
 </script>
 
 <div class="space-y-4 rounded-xl border border-border p-4">
-  <div class="space-y-1.5">
-    <p class={labelClass}>Media type</p>
-    <div class="flex gap-1.5" role="radiogroup" aria-label="Media type">
-      {#each KINDS as entry (entry.kind)}
-        <button
-          type="button"
-          class={segmentClass(raw.kind === entry.kind)}
-          role="radio"
-          aria-checked={raw.kind === entry.kind}
-          onclick={() => setKind(entry.kind)}
-        >
-          {entry.label}
-        </button>
-      {/each}
-    </div>
-  </div>
-
-  {#if raw.kind === "images"}
-    <div class="space-y-1.5">
-      <p class={labelClass}>Views</p>
-      <div class="flex gap-1.5">
-        <button
-          type="button"
-          class={segmentClass(raw.viewsMode === "auto")}
-          onclick={() => (raw.viewsMode = "auto")}
-        >
-          Auto from folders
-        </button>
-        <button
-          type="button"
-          class={segmentClass(raw.viewsMode === "named")}
-          onclick={() => (raw.viewsMode = "named")}
-        >
-          Name them
-        </button>
-      </div>
-      {#if raw.viewsMode === "auto"}
-        <p class="text-xs text-muted-foreground">
-          Subfolders become views (e.g. <span class="font-mono">left/</span>
-          ,
-          <span class="font-mono">right/</span>
-          , matched by file name); a flat folder becomes one view.
-        </p>
-      {:else}
-        <input
-          type="text"
-          class="{inputClass} font-mono"
-          placeholder="left, right"
-          bind:value={raw.viewNames}
-          aria-label="View names"
-        />
-        <p class="text-xs text-muted-foreground">
-          Comma-separated snake_case names; each needs a matching folder in the source.
-        </p>
-      {/if}
-    </div>
-  {/if}
-
-  {#if raw.kind === "videos"}
+  {#if raw.useCase === "video"}
     <div class="space-y-1.5">
       <p class={labelClass}>Video handling</p>
       <div class="flex gap-1.5">
@@ -121,7 +51,7 @@ License: CECILL-C
           class={segmentClass(raw.framesMode === "reference")}
           onclick={() => (raw.framesMode = "reference")}
         >
-          Reference clips (browse)
+          Reference clips (metadata only)
         </button>
       </div>
       {#if raw.framesMode === "extract"}
@@ -140,20 +70,37 @@ License: CECILL-C
         </div>
       {:else}
         <p class="text-xs text-muted-foreground">
-          Clips play in the explorer but cannot be annotated frame by frame in this release.
+          Clips import as references (metadata + file). In-app playback is not available in this
+          release — choose Extract frames to annotate or browse them.
         </p>
       {/if}
     </div>
   {/if}
 
   <div class="space-y-1.5">
-    <p class={labelClass}>Entity attributes</p>
-    <EntityAttrsEditor bind:rows={raw.entityAttrs} />
+    <p class={labelClass}>Record attributes</p>
+    <AttrsEditor
+      bind:rows={raw.recordAttrs}
+      hint="One value per item (e.g. weather: str, captured_at: str). Values are filled in Pixano after import."
+      allowRequired={false}
+    />
+  </div>
+
+  <div class="space-y-1.5">
+    <p class={labelClass}>Object attributes</p>
+    <AttrsEditor
+      bind:rows={raw.entityAttrs}
+      hint="Attributes each annotated object carries (e.g. category: str)."
+    />
   </div>
 
   <div class="space-y-1.5">
     <p class={labelClass}>Annotations</p>
-    <AnnotationSlotsPicker choices={ANNOTATION_CHOICES[raw.kind]} bind:selected={raw.annotations} />
+    <AnnotationSlotsPicker
+      choices={ANNOTATION_CHOICES[raw.useCase]}
+      locked={LOCKED_ANNOTATIONS[raw.useCase]}
+      bind:selected={raw.annotations}
+    />
   </div>
 
   {#if validationError}

--- a/ui/apps/pixano/src/components/library/import-wizard/RawUseCaseStep.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/RawUseCaseStep.svelte
@@ -1,0 +1,51 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { ChatsCircle, Images, LinkSimple, VideoCamera } from "phosphor-svelte";
+
+  import type { RawUseCase } from "./layoutPreflight";
+  import { USE_CASE_CARDS } from "./rawSchema";
+
+  interface Props {
+    onSelect: (useCase: RawUseCase) => void;
+  }
+
+  let { onSelect }: Props = $props();
+
+  const ICONS: Record<RawUseCase, typeof Images> = {
+    image: Images,
+    video: VideoCamera,
+    image_vqa: ChatsCircle,
+    image_text_entity_linking: LinkSimple,
+  };
+</script>
+
+<div class="px-6 sm:px-7 pb-2 space-y-3">
+  <div class="grid gap-2 sm:grid-cols-2">
+    {#each USE_CASE_CARDS as card (card.useCase)}
+      {@const Icon = ICONS[card.useCase]}
+      <button
+        type="button"
+        class="rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-primary/50"
+        onclick={() => onSelect(card.useCase)}
+      >
+        <span class="flex items-center gap-2 text-sm font-medium text-foreground">
+          <Icon weight="regular" class="h-5 w-5 shrink-0 text-primary" />
+          {card.title}
+        </span>
+        <span class="mt-1.5 block text-xs leading-relaxed text-muted-foreground">{card.blurb}</span>
+        <pre
+          class="mt-2 overflow-x-auto rounded-lg bg-surface-2 px-2.5 py-2 font-mono text-[10px] leading-relaxed text-muted-foreground">{card.layoutHint}</pre>
+      </button>
+    {/each}
+  </div>
+  <p class="text-xs text-muted-foreground">
+    Optional <span class="font-mono">train/ val/ test/</span>
+    folders can wrap either shape. Other data (e.g. plain text corpora) imports via the Advanced spec
+    or the CLI.
+  </p>
+</div>

--- a/ui/apps/pixano/src/components/library/import-wizard/ReviewStep.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/ReviewStep.svelte
@@ -15,9 +15,11 @@ License: CECILL-C
     analyzing: boolean;
     analyzeError: string;
     plan: ImportPlanResponse | null;
+    /** Raw video "reference clips" mode: imports succeed but clips don't play in-app yet. */
+    referenceMode?: boolean;
   }
 
-  let { analyzing, analyzeError, plan }: Props = $props();
+  let { analyzing, analyzeError, plan, referenceMode = false }: Props = $props();
 
   const grouped = $derived(plan ? groupFindings(plan) : { errors: [], warnings: [] });
   const splitEntries = $derived(Object.entries(plan?.splits ?? {}));
@@ -76,6 +78,19 @@ License: CECILL-C
 
     {#if plan.inferred_schema}
       <SchemaPanel schema={plan.inferred_schema} />
+    {/if}
+
+    {#if referenceMode}
+      <div class="rounded-xl border border-amber-500/40 bg-amber-500/5 p-3">
+        <p class="flex items-center gap-2 text-xs font-semibold text-amber-600 dark:text-amber-400">
+          <Warning weight="fill" class="h-4 w-4 shrink-0" />
+          Reference clips will not play in the explorer in this release
+        </p>
+        <p class="mt-1 text-xs text-foreground/80">
+          The videos import as metadata + file references. To annotate or browse frames, go back and
+          choose “Extract frames” instead.
+        </p>
+      </div>
     {/if}
 
     {#each grouped.errors as finding (finding.code)}

--- a/ui/apps/pixano/src/components/library/import-wizard/SourceStep.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/SourceStep.svelte
@@ -7,7 +7,9 @@ License: CECILL-C
 <script lang="ts">
   import { CaretDown, CaretRight, CheckCircle, FolderOpen, UploadSimple } from "phosphor-svelte";
 
-  import { matchesMediaKind } from "./rawSchema";
+  import { matchesUseCase, preflightLayout } from "./layoutPreflight";
+  import LayoutPreviewPanel from "./LayoutPreviewPanel.svelte";
+  import { USE_CASE_CARDS } from "./rawSchema";
   import RawSchemaBuilder from "./RawSchemaBuilder.svelte";
   import {
     formatBytes,
@@ -42,11 +44,16 @@ License: CECILL-C
   let fileInput = $state<HTMLInputElement | null>(null);
   let abortController: AbortController | null = null;
   let uploadId = "";
-  let uploadedKind = $state(fields.raw.kind);
+  let uploadedUseCase = $state(fields.raw.useCase);
 
   const advancedError = $derived(parseAdvancedSpec(advancedJson).error);
   const showLerobot = $derived(showsLerobotFields(fields));
   const offersHub = $derived(fields.intent === "lerobot" || fields.intent === "auto");
+  const layoutHint = $derived(
+    fields.intent === "raw"
+      ? (USE_CASE_CARDS.find((card) => card.useCase === fields.raw.useCase)?.layoutHint ?? "")
+      : "",
+  );
   const progressPercent = $derived(
     progress && progress.totalBytes > 0
       ? Math.min(100, Math.round((progress.uploadedBytes / progress.totalBytes) * 100))
@@ -58,10 +65,14 @@ License: CECILL-C
   });
 
   $effect(() => {
-    // Raw uploads are filtered by media kind; if the user changes the kind
-    // after uploading, the staged files no longer match — drop them so the
+    // Raw uploads are filtered by use case; if the user changes the use case
+    // after picking, the staged files no longer match — drop them so the
     // next pick re-filters. (Guarded so the reset can't re-trigger itself.)
-    if (fields.intent === "raw" && uploadState !== "idle" && fields.raw.kind !== uploadedKind) {
+    if (
+      fields.intent === "raw" &&
+      (uploadState !== "idle" || fields.raw.layout !== null) &&
+      fields.raw.useCase !== uploadedUseCase
+    ) {
       discardStagedUpload();
     }
   });
@@ -71,6 +82,7 @@ License: CECILL-C
       void deleteUploadSession(uploadId).catch(() => undefined);
       uploadId = "";
     }
+    fields.raw.layout = null;
     if (uploadState !== "idle") {
       fields.source = "";
       fields.sourceLabel = "";
@@ -100,19 +112,20 @@ License: CECILL-C
     discardStagedUpload();
     let picked = splitFolderSelection(files);
     if (fields.intent === "raw") {
-      // Upload only the media of the chosen kind: a stray metadata.jsonl,
+      // Preflight the layout on the client BEFORE uploading anything: a bad
+      // folder structure must not cost a multi-gigabyte upload to discover.
+      const layout = preflightLayout(picked.entries, fields.raw.useCase);
+      fields.raw.layout = layout;
+      uploadedUseCase = fields.raw.useCase;
+      if (!layout.ok) {
+        uploadState = "idle";
+        uploadError = "";
+        return; // the layout panel shows what to fix; pick the folder again
+      }
+      // Upload only the use case's media kinds: a stray metadata.jsonl,
       // .DS_Store, or README must not be staged (a metadata.jsonl would flip
       // the source out of media-only mode and import nothing).
-      const kind = fields.raw.kind;
-      const before = picked.entries.length;
-      picked = filterSelection(picked, (name) => matchesMediaKind(name, kind));
-      if (!picked.entries.length) {
-        uploadState = "error";
-        uploadError = `The selected folder has no ${kind} files (found ${before} other file${
-          before === 1 ? "" : "s"
-        }).`;
-        return;
-      }
+      picked = filterSelection(picked, (name) => matchesUseCase(name, fields.raw.useCase));
     }
     if (!picked.entries.length) {
       uploadState = "error";
@@ -120,7 +133,7 @@ License: CECILL-C
       return;
     }
     selection = picked;
-    uploadedKind = fields.raw.kind;
+    uploadedUseCase = fields.raw.useCase;
     uploadState = "uploading";
     uploadError = "";
     progress = {
@@ -220,13 +233,17 @@ License: CECILL-C
           onclick={() => fileInput?.click()}
         >
           <UploadSimple weight="regular" class="h-5 w-5 shrink-0 text-primary" />
-          <span>
+          <span class="min-w-0 flex-1">
             <span class="block text-sm font-medium text-foreground">
               Choose a folder on your computer…
             </span>
             <span class="mt-0.5 block text-xs text-muted-foreground">
               The folder uploads to Pixano and imports from there — nothing else to configure.
             </span>
+            {#if layoutHint}
+              <pre
+                class="mt-2 overflow-x-auto rounded-lg bg-surface-2 px-2.5 py-2 font-mono text-[10px] leading-relaxed text-muted-foreground">{layoutHint}</pre>
+            {/if}
           </span>
         </button>
         {#if uploadError}
@@ -282,6 +299,10 @@ License: CECILL-C
           </button>
         </div>
       {/if}
+    {/if}
+
+    {#if fields.intent === "raw" && fields.raw.layout}
+      <LayoutPreviewPanel layout={fields.raw.layout} />
     {/if}
   </div>
 

--- a/ui/apps/pixano/src/components/library/import-wizard/__tests__/layoutPreflight.test.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/__tests__/layoutPreflight.test.ts
@@ -1,0 +1,210 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyMediaName,
+  matchesUseCase,
+  preflightLayout,
+  toSnakeCase,
+  type LayoutPreflight,
+} from "../layoutPreflight";
+
+const entries = (...paths: string[]) => paths.map((relPath) => ({ relPath }));
+
+const codes = (layout: LayoutPreflight) => layout.findings.map((finding) => finding.code);
+
+describe("classifyMediaName / matchesUseCase", () => {
+  it("classifies by extension, case-insensitively", () => {
+    expect(classifyMediaName("a.JPG")).toBe("image");
+    expect(classifyMediaName("v.mp4")).toBe("video");
+    expect(classifyMediaName("t.md")).toBe("text");
+    expect(classifyMediaName("metadata.jsonl")).toBeNull();
+    expect(classifyMediaName(".DS_Store")).toBeNull();
+  });
+
+  it("MEL keeps both images and texts; image keeps only images", () => {
+    expect(matchesUseCase("a.jpg", "image_text_entity_linking")).toBe(true);
+    expect(matchesUseCase("a.txt", "image_text_entity_linking")).toBe(true);
+    expect(matchesUseCase("a.mp4", "image_text_entity_linking")).toBe(false);
+    expect(matchesUseCase("a.txt", "image")).toBe(false);
+  });
+});
+
+describe("toSnakeCase (mirrors the backend)", () => {
+  it("lowercases and collapses non-alphanumerics", () => {
+    expect(toSnakeCase("My-Left")).toBe("my_left");
+    expect(toSnakeCase("Left Cam")).toBe("left_cam");
+    expect(toSnakeCase("  left__cam  ")).toBe("left_cam");
+  });
+});
+
+describe("preflightLayout — happy paths", () => {
+  it("flat images: one view named after the kind", () => {
+    const layout = preflightLayout(entries("a.jpg", "b.png", "notes.csv"), "image");
+    expect(layout.ok).toBe(true);
+    expect(layout.views).toEqual([{ name: "image", kind: "image", fileCount: 2 }]);
+    expect(layout.splits).toEqual([{ name: "default", recordCount: 2 }]);
+    expect(layout.totalRecords).toBe(2);
+    expect(layout.ignoredFiles).toBe(1);
+  });
+
+  it("per-view folders stem-match into records, missing stems warn", () => {
+    const layout = preflightLayout(
+      entries("left/a.jpg", "left/b.jpg", "right/a.jpg", "right/b.jpg", "right/c.jpg"),
+      "image",
+    );
+    expect(layout.ok).toBe(true);
+    expect(layout.views).toEqual([
+      { name: "left", kind: "image", fileCount: 2 },
+      { name: "right", kind: "image", fileCount: 3 },
+    ]);
+    expect(layout.totalRecords).toBe(3);
+    const warning = layout.findings.find((finding) => finding.code === "missing_view_file");
+    expect(warning?.severity).toBe("warning");
+  });
+
+  it("split folders wrap either shape", () => {
+    const layout = preflightLayout(
+      entries("train/left/a.jpg", "train/right/a.jpg", "val/left/b.jpg", "val/right/b.jpg"),
+      "image",
+    );
+    expect(layout.ok).toBe(true);
+    expect(layout.splits).toEqual([
+      { name: "train", recordCount: 1 },
+      { name: "val", recordCount: 1 },
+    ]);
+    expect(layout.views.map((view) => view.name).sort()).toEqual(["left", "right"]);
+  });
+
+  it("MEL image/ + text/ folders pair up", () => {
+    const layout = preflightLayout(
+      entries("image/a.jpg", "image/b.jpg", "text/a.txt", "text/b.txt"),
+      "image_text_entity_linking",
+    );
+    expect(layout.ok).toBe(true);
+    expect(layout.views).toEqual([
+      { name: "image", kind: "image", fileCount: 2 },
+      { name: "text", kind: "text", fileCount: 2 },
+    ]);
+    expect(layout.totalRecords).toBe(2);
+  });
+
+  it("nested paths inside a view participate in the stem key", () => {
+    const layout = preflightLayout(entries("left/sub/a.jpg", "right/sub/a.jpg"), "image");
+    expect(layout.ok).toBe(true);
+    expect(layout.totalRecords).toBe(1);
+  });
+});
+
+describe("preflightLayout — blocking errors (mirror media_only.py)", () => {
+  it("mixed media kinds in one folder", () => {
+    const layout = preflightLayout(
+      entries("pair1/a.jpg", "pair1/a.txt"),
+      "image_text_entity_linking",
+    );
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("mixed_media_kinds");
+    // the MEL restructure hint rides on the message
+    const finding = layout.findings.find((item) => item.code === "mixed_media_kinds");
+    expect(finding?.message).toContain("separate view folders");
+  });
+
+  it("per-record MEL folders are detected and blocked", () => {
+    const layout = preflightLayout(
+      entries("rec1/a.jpg", "rec1/a.txt", "rec2/b.jpg", "rec2/b.txt"),
+      "image_text_entity_linking",
+    );
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("mixed_media_kinds");
+  });
+
+  it("split names mixed with view folders", () => {
+    const layout = preflightLayout(entries("train/a.jpg", "extra/b.jpg"), "image");
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("ambiguous_media_layout");
+  });
+
+  it("media directly in the folder AND inside subfolders", () => {
+    const layout = preflightLayout(entries("root.jpg", "left/a.jpg"), "image");
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("ambiguous_media_layout");
+  });
+
+  it("snake_case view-folder collision", () => {
+    const layout = preflightLayout(entries("Left Cam/a.jpg", "left_cam/a.jpg"), "image");
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("view_name_collision");
+  });
+
+  it("view folder named like a split", () => {
+    const layout = preflightLayout(
+      entries("train/test/a.jpg", "train/left/a.jpg", "val/test/a.jpg", "val/left/a.jpg"),
+      "image",
+    );
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("view_name_reserved");
+  });
+
+  it("inconsistent views across splits", () => {
+    const layout = preflightLayout(
+      entries("train/left/a.jpg", "train/right/a.jpg", "val/left/b.jpg"),
+      "image",
+    );
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("inconsistent_split_views");
+  });
+
+  it("duplicate stems inside one view", () => {
+    const flat = preflightLayout(entries("a.jpg", "a.png"), "image");
+    expect(flat.ok).toBe(false);
+    expect(codes(flat)).toContain("duplicate_view_stem");
+    const inView = preflightLayout(entries("left/a.jpg", "left/a.png", "right/a.jpg"), "image");
+    expect(inView.ok).toBe(false);
+    expect(codes(inView)).toContain("duplicate_view_stem");
+  });
+
+  it("MEL without a text folder", () => {
+    const layout = preflightLayout(
+      entries("image/a.jpg", "image/b.jpg"),
+      "image_text_entity_linking",
+    );
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("mel_needs_image_and_text");
+  });
+
+  it("nothing importable for the use case", () => {
+    const layout = preflightLayout(entries("a.mp4", "notes.csv"), "image");
+    expect(layout.ok).toBe(false);
+    expect(codes(layout)).toContain("no_media_found");
+  });
+});
+
+describe("preflightLayout — warnings", () => {
+  it("wrong-kind media becomes an ignored_files warning", () => {
+    const layout = preflightLayout(entries("a.jpg", "b.jpg", "clip.mp4"), "image_vqa");
+    expect(layout.ok).toBe(true);
+    const warning = layout.findings.find((finding) => finding.code === "ignored_files");
+    expect(warning?.severity).toBe("warning");
+    expect(warning?.message).toContain("1 video file");
+    expect(layout.ignoredFiles).toBe(1);
+  });
+
+  it("root files beside split folders warn", () => {
+    const layout = preflightLayout(entries("stray.jpg", "train/a.jpg"), "image");
+    expect(layout.ok).toBe(true);
+    expect(codes(layout)).toContain("files_outside_splits");
+    expect(layout.totalRecords).toBe(1);
+  });
+
+  it("hidden segments are skipped like the backend's dot-dir rule", () => {
+    const layout = preflightLayout(entries("a.jpg", ".cache/b.jpg", ".DS_Store"), "image");
+    expect(layout.ok).toBe(true);
+    expect(layout.totalRecords).toBe(1);
+    expect(layout.ignoredFiles).toBe(2);
+  });
+});

--- a/ui/apps/pixano/src/components/library/import-wizard/__tests__/rawSchema.test.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/__tests__/rawSchema.test.ts
@@ -6,15 +6,16 @@ License: CECILL-C
 
 import { describe, expect, it } from "vitest";
 
+import { preflightLayout } from "../layoutPreflight";
 import {
   buildRawSchemaSpec,
   DEFAULT_ANNOTATIONS,
   DEFAULT_RAW_FIELDS,
+  parseTypedListValue,
   parseTypedValue,
-  parseViewNames,
-  validateEntityAttrs,
+  validateAttrRows,
   validateRawFields,
-  type EntityAttrRow,
+  type AttrRow,
   type RawFields,
 } from "../rawSchema";
 
@@ -23,7 +24,7 @@ const raw = (overrides: Partial<RawFields>): RawFields => ({
   ...overrides,
 });
 
-const attr = (overrides: Partial<EntityAttrRow>): EntityAttrRow => ({
+const attr = (overrides: Partial<AttrRow>): AttrRow => ({
   name: "category",
   type: "str",
   list: false,
@@ -32,15 +33,7 @@ const attr = (overrides: Partial<EntityAttrRow>): EntityAttrRow => ({
   ...overrides,
 });
 
-describe("parseViewNames", () => {
-  it("splits, trims, and validates snake_case names", () => {
-    expect(parseViewNames("left, right")).toEqual({ names: ["left", "right"], error: "" });
-    expect(parseViewNames("")).toEqual({ names: [], error: "" });
-    expect(parseViewNames("Left").error).toContain("snake_case");
-    expect(parseViewNames("a b").error).toContain("snake_case");
-    expect(parseViewNames("left, left").error).toContain("unique");
-  });
-});
+const entries = (...paths: string[]) => paths.map((relPath) => ({ relPath }));
 
 describe("parseTypedValue", () => {
   it("parses per type and rejects mismatches", () => {
@@ -54,65 +47,153 @@ describe("parseTypedValue", () => {
   });
 });
 
-describe("validateEntityAttrs", () => {
+describe("parseTypedListValue", () => {
+  it("parses comma-separated lists per element type", () => {
+    expect(parseTypedListValue("str", "a, b")).toEqual(["a", "b"]);
+    expect(parseTypedListValue("int", "1, 2, 3")).toEqual([1, 2, 3]);
+    expect(parseTypedListValue("int", "1, oops")).toBeUndefined();
+    expect(parseTypedListValue("str", "")).toEqual([]);
+  });
+});
+
+describe("validateAttrRows", () => {
   it("rejects bad names, duplicates, and untyped defaults", () => {
-    expect(validateEntityAttrs([attr({})])).toBe("");
-    expect(validateEntityAttrs([attr({ name: "Bad Name" })])).toContain("snake_case");
-    expect(validateEntityAttrs([attr({}), attr({})])).toContain("twice");
-    expect(validateEntityAttrs([attr({ type: "int", defaultValue: "x" })])).toContain(
-      "not a valid int",
+    expect(validateAttrRows([attr({})])).toBe("");
+    expect(validateAttrRows([attr({ name: "Bad Name" })])).toContain("snake_case");
+    expect(validateAttrRows([attr({}), attr({})])).toContain("twice");
+    expect(validateAttrRows([attr({ type: "int", defaultValue: "x" })])).toContain("not a valid");
+  });
+
+  it("validates list defaults as comma-separated lists", () => {
+    expect(validateAttrRows([attr({ list: true, defaultValue: "a, b" })])).toBe("");
+    expect(validateAttrRows([attr({ type: "int", list: true, defaultValue: "1, x" })])).toContain(
+      "comma-separated int list",
+    );
+  });
+
+  it("prefixes messages with the given label", () => {
+    expect(validateAttrRows([attr({ name: "Bad" })], "Record attribute")).toContain(
+      "Record attribute",
     );
   });
 });
 
 describe("validateRawFields", () => {
-  it("requires named views to be present and max frames numeric", () => {
-    expect(validateRawFields(raw({}))).toBe("");
-    expect(validateRawFields(raw({ viewsMode: "named", viewNames: "" }))).toContain("at least one");
-    expect(validateRawFields(raw({ kind: "videos", maxFrames: "abc" }))).toContain("whole number");
-    expect(validateRawFields(raw({ kind: "videos", maxFrames: "100" }))).toBe("");
+  it("requires a whole number for max frames on video", () => {
+    expect(validateRawFields(raw({ useCase: "video", maxFrames: "12.5" }))).toContain(
+      "whole number",
+    );
+    expect(validateRawFields(raw({ useCase: "video", maxFrames: "100" }))).toBe("");
+  });
+
+  it("requires at least one annotation type", () => {
+    expect(validateRawFields(raw({ annotations: [] }))).toContain("at least one annotation");
+  });
+
+  it("validates record and entity attrs separately", () => {
+    expect(validateRawFields(raw({ recordAttrs: [attr({ name: "Bad" })] }))).toContain(
+      "Record attribute",
+    );
+    expect(validateRawFields(raw({ entityAttrs: [attr({ name: "Bad" })] }))).toContain(
+      "Object attribute",
+    );
   });
 });
 
 describe("buildRawSchemaSpec", () => {
-  it("omits views in auto mode and declares them in named mode", () => {
-    expect(buildRawSchemaSpec(raw({})).schema.views).toBeUndefined();
-    const named = buildRawSchemaSpec(raw({ viewsMode: "named", viewNames: "left,right" }));
-    expect(named.schema.views).toEqual({ left: "image", right: "image" });
+  it("always emits the use case as the workspace", () => {
+    expect(buildRawSchemaSpec(raw({ useCase: "image" })).workspace).toBe("image");
+    expect(buildRawSchemaSpec(raw({ useCase: "video" })).workspace).toBe("video");
+    expect(buildRawSchemaSpec(raw({ useCase: "image_vqa" })).workspace).toBe("image_vqa");
+    expect(buildRawSchemaSpec(raw({ useCase: "image_text_entity_linking" })).workspace).toBe(
+      "image_text_entity_linking",
+    );
   });
 
-  it("types defaults and honours list/required flags", () => {
-    const built = buildRawSchemaSpec(
+  it("omits views for single-view layouts (backend inference applies)", () => {
+    const layout = preflightLayout(entries("a.jpg", "b.jpg"), "image");
+    expect(buildRawSchemaSpec(raw({ layout })).schema.views).toBeUndefined();
+  });
+
+  it("declares views from the preflight for multi-view layouts", () => {
+    const layout = preflightLayout(entries("left/a.jpg", "right/a.jpg"), "image");
+    expect(buildRawSchemaSpec(raw({ layout })).schema.views).toEqual({
+      left: { kind: "image" },
+      right: { kind: "image" },
+    });
+  });
+
+  it("maps video views to sequence_frames or video by frames mode", () => {
+    const layout = preflightLayout(entries("front/v.mp4", "side/v.mp4"), "video");
+    const extract = buildRawSchemaSpec(raw({ useCase: "video", layout }));
+    expect(extract.schema.views).toEqual({
+      front: { kind: "sequence_frames" },
+      side: { kind: "sequence_frames" },
+    });
+    const reference = buildRawSchemaSpec(
+      raw({ useCase: "video", layout, framesMode: "reference" }),
+    );
+    expect(reference.schema.views).toEqual({ front: { kind: "video" }, side: { kind: "video" } });
+    expect(reference.options).toEqual({ frames: "reference" });
+  });
+
+  it("declares MEL views with their kinds", () => {
+    const layout = preflightLayout(
+      entries("image/a.jpg", "text/a.txt"),
+      "image_text_entity_linking",
+    );
+    const spec = buildRawSchemaSpec(
       raw({
+        useCase: "image_text_entity_linking",
+        layout,
+        annotations: [...DEFAULT_ANNOTATIONS.image_text_entity_linking],
+      }),
+    );
+    expect(spec.workspace).toBe("image_text_entity_linking");
+    expect(spec.schema.views).toEqual({ image: { kind: "image" }, text: { kind: "text" } });
+    expect(spec.schema.annotations).toEqual(["text_span", "bbox", "mask"]);
+  });
+
+  it("always re-adds locked slots (a non-empty list replaces the preset backend-side)", () => {
+    const spec = buildRawSchemaSpec(raw({ useCase: "image_vqa", annotations: ["bbox"] }));
+    expect(spec.schema.annotations).toEqual(["message", "bbox"]);
+  });
+
+  it("emits record and entity attrs, with list defaults as arrays", () => {
+    const spec = buildRawSchemaSpec(
+      raw({
+        recordAttrs: [attr({ name: "weather" })],
         entityAttrs: [
-          attr({ name: "count", type: "int", defaultValue: "3" }),
-          attr({ name: "label", required: true }),
-          attr({ name: "tags", list: true }),
+          attr({ name: "category", required: true }),
+          attr({ name: "tags", list: true, defaultValue: "a, b" }),
         ],
       }),
     );
-    expect(built.schema.entity).toEqual({
+    expect(spec.schema.record).toEqual({ attrs: { weather: { type: "str" } } });
+    expect(spec.schema.entity).toEqual({
       attrs: {
-        count: { type: "int", default: 3 },
-        label: { type: "str", required: true },
-        tags: { type: "str", collection: true },
+        category: { type: "str", required: true },
+        tags: { type: "str", collection: true, default: ["a", "b"] },
       },
     });
   });
 
-  it("maps media kinds to workspaces and video options", () => {
-    expect(buildRawSchemaSpec(raw({})).workspace).toBe("image");
-    const videos = buildRawSchemaSpec(raw({ kind: "videos", maxFrames: "50" }));
-    expect(videos.workspace).toBe("video");
-    expect(videos.options).toEqual({ max_frames_per_video: 50 });
-    const reference = buildRawSchemaSpec(raw({ kind: "videos", framesMode: "reference" }));
-    expect(reference.options).toEqual({ frames: "reference" });
-    expect(buildRawSchemaSpec(raw({ kind: "texts" })).workspace).toBeUndefined();
+  it("passes the max-frames cap through for extract mode", () => {
+    expect(buildRawSchemaSpec(raw({ useCase: "video", maxFrames: "200" })).options).toEqual({
+      max_frames_per_video: 200,
+    });
   });
 
-  it("keeps per-kind annotation defaults distinct", () => {
-    expect(DEFAULT_ANNOTATIONS.images).toContain("bbox");
-    expect(DEFAULT_ANNOTATIONS.videos).toContain("tracklet");
-    expect(DEFAULT_ANNOTATIONS.texts).toContain("text_span");
+  it("emits no views from a failed preflight", () => {
+    const layout = preflightLayout(entries("Left Cam/a.jpg", "left_cam/a.jpg"), "image");
+    expect(layout.ok).toBe(false);
+    expect(buildRawSchemaSpec(raw({ layout })).schema.views).toBeUndefined();
+  });
+
+  it("keeps per-use-case annotation defaults distinct", () => {
+    expect(DEFAULT_ANNOTATIONS.image).toContain("bbox");
+    expect(DEFAULT_ANNOTATIONS.video).toContain("tracklet");
+    expect(DEFAULT_ANNOTATIONS.image_vqa).toContain("message");
+    expect(DEFAULT_ANNOTATIONS.image_text_entity_linking).toContain("text_span");
   });
 });

--- a/ui/apps/pixano/src/components/library/import-wizard/__tests__/wizardUtils.test.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/__tests__/wizardUtils.test.ts
@@ -6,6 +6,7 @@ License: CECILL-C
 
 import { describe, expect, it } from "vitest";
 
+import { preflightLayout } from "../layoutPreflight";
 import {
   canAnalyze,
   DEFAULT_FIELDS,
@@ -82,10 +83,15 @@ describe("mergeSpec", () => {
     expect(mergeSpec(fields({}), "")).toEqual({});
   });
 
-  it("builds the raw-images spec with entity attrs and annotations", () => {
+  it("builds the raw multi-view image spec: preflight views + record/entity attrs", () => {
     const base = fields({ intent: "raw" });
-    base.raw.viewsMode = "named";
-    base.raw.viewNames = "left, right";
+    base.raw.layout = preflightLayout(
+      ["left/a.jpg", "right/a.jpg"].map((relPath) => ({ relPath })),
+      "image",
+    );
+    base.raw.recordAttrs = [
+      { name: "weather", type: "str", list: false, required: false, defaultValue: "" },
+    ];
     base.raw.entityAttrs = [
       { name: "category", type: "str", list: false, required: false, defaultValue: "" },
       { name: "tags", type: "str", list: true, required: false, defaultValue: "" },
@@ -95,7 +101,8 @@ describe("mergeSpec", () => {
       format: "pixano_jsonl",
       dataset: { workspace: "image" },
       schema: {
-        views: { left: "image", right: "image" },
+        views: { left: { kind: "image" }, right: { kind: "image" } },
+        record: { attrs: { weather: { type: "str" } } },
         entity: { attrs: { category: { type: "str" }, tags: { type: "str", collection: true } } },
         annotations: ["bbox", "classification"],
       },
@@ -104,7 +111,7 @@ describe("mergeSpec", () => {
 
   it("builds the raw-videos spec: extract default with cap, reference opt-in", () => {
     const extract = fields({ intent: "raw" });
-    extract.raw.kind = "videos";
+    extract.raw.useCase = "video";
     extract.raw.maxFrames = "200";
     extract.raw.annotations = ["bbox", "tracklet"];
     expect(mergeSpec(extract, "")).toEqual({
@@ -115,7 +122,7 @@ describe("mergeSpec", () => {
     });
 
     const reference = fields({ intent: "raw" });
-    reference.raw.kind = "videos";
+    reference.raw.useCase = "video";
     reference.raw.framesMode = "reference";
     reference.raw.annotations = ["bbox"];
     expect(mergeSpec(reference, "")).toEqual({
@@ -126,13 +133,30 @@ describe("mergeSpec", () => {
     });
   });
 
-  it("builds the raw-text spec without a workspace", () => {
-    const base = fields({ intent: "raw" });
-    base.raw.kind = "texts";
-    base.raw.annotations = ["text_span", "classification"];
-    expect(mergeSpec(base, "")).toEqual({
+  it("builds the VQA and MEL specs with their workspaces and locked slots", () => {
+    const vqa = fields({ intent: "raw" });
+    vqa.raw.useCase = "image_vqa";
+    vqa.raw.annotations = ["message"];
+    expect(mergeSpec(vqa, "")).toEqual({
       format: "pixano_jsonl",
-      schema: { annotations: ["text_span", "classification"] },
+      dataset: { workspace: "image_vqa" },
+      schema: { annotations: ["message"] },
+    });
+
+    const mel = fields({ intent: "raw" });
+    mel.raw.useCase = "image_text_entity_linking";
+    mel.raw.annotations = ["text_span", "bbox", "mask"];
+    mel.raw.layout = preflightLayout(
+      ["image/a.jpg", "text/a.txt"].map((relPath) => ({ relPath })),
+      "image_text_entity_linking",
+    );
+    expect(mergeSpec(mel, "")).toEqual({
+      format: "pixano_jsonl",
+      dataset: { workspace: "image_text_entity_linking" },
+      schema: {
+        views: { image: { kind: "image" }, text: { kind: "text" } },
+        annotations: ["text_span", "bbox", "mask"],
+      },
     });
   });
 
@@ -250,6 +274,16 @@ describe("canAnalyze", () => {
       { name: "category", type: "str", list: false, required: false, defaultValue: "" },
     ];
     expect(canAnalyze(good, "")).toBe(true);
+  });
+
+  it("gates on a failed layout preflight", () => {
+    const blocked = fields({ intent: "raw", source: "/data" });
+    blocked.raw.layout = preflightLayout(
+      ["Left Cam/a.jpg", "left_cam/a.jpg"].map((relPath) => ({ relPath })),
+      "image",
+    );
+    expect(blocked.raw.layout.ok).toBe(false);
+    expect(canAnalyze(blocked, "")).toBe(false);
   });
 });
 

--- a/ui/apps/pixano/src/components/library/import-wizard/layoutPreflight.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/layoutPreflight.ts
@@ -1,0 +1,419 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+/**
+ * Client-side folder-layout preflight for raw-media imports.
+ *
+ * Mirrors the backend's media-only discovery (`media_only.py`) over the picked
+ * FileList so layout problems surface BEFORE gigabytes upload, not after. The
+ * rules must stay in lockstep with the backend: split vocabulary, one media
+ * kind per folder, per-view subfolders matched by stem, snake_case view names.
+ */
+
+/** What the user is building — maps 1:1 onto the backend workspace values. */
+export type RawUseCase = "image" | "video" | "image_vqa" | "image_text_entity_linking";
+
+/** On-disk media kinds the media-only importer scans. */
+export type MediaFileKind = "image" | "video" | "text";
+
+/** File extensions per media kind (mirrors `media_only.py` suffix sets). */
+export const FILE_KIND_EXTENSIONS: Record<MediaFileKind, string[]> = {
+  image: [".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".webp"],
+  video: [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".vob"],
+  text: [".txt", ".md"],
+};
+
+/** The media kinds each use case imports (MEL pairs images with texts). */
+export const USE_CASE_FILE_KINDS: Record<RawUseCase, MediaFileKind[]> = {
+  image: ["image"],
+  video: ["video"],
+  image_vqa: ["image"],
+  image_text_entity_linking: ["image", "text"],
+};
+
+/** Split folder vocabulary (mirrors `_SPLIT_DIR_NAMES`). */
+const SPLIT_DIR_NAMES = new Set([
+  "train",
+  "training",
+  "val",
+  "valid",
+  "validation",
+  "test",
+  "testing",
+]);
+
+/** Classify a file name by extension (case-insensitive); null = not media. */
+export function classifyMediaName(name: string): MediaFileKind | null {
+  const lower = name.toLowerCase();
+  for (const [kind, extensions] of Object.entries(FILE_KIND_EXTENSIONS)) {
+    if (extensions.some((ext) => lower.endsWith(ext))) return kind as MediaFileKind;
+  }
+  return null;
+}
+
+/** True when a file belongs to the use case's upload (drives the upload filter). */
+export function matchesUseCase(name: string, useCase: RawUseCase): boolean {
+  const kind = classifyMediaName(name);
+  return kind !== null && USE_CASE_FILE_KINDS[useCase].includes(kind);
+}
+
+/** Mirror of the backend's `to_snake_case` (folder → view name). */
+export function toSnakeCase(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export interface LayoutFinding {
+  code: string;
+  severity: "error" | "warning";
+  message: string;
+}
+
+export interface LayoutView {
+  name: string;
+  kind: MediaFileKind;
+  fileCount: number;
+}
+
+export interface LayoutSplit {
+  name: string;
+  recordCount: number;
+}
+
+/** What the preflight derived from the picked folder. */
+export interface LayoutPreflight {
+  views: LayoutView[];
+  splits: LayoutSplit[];
+  totalRecords: number;
+  keptFiles: number;
+  ignoredFiles: number;
+  findings: LayoutFinding[];
+  ok: boolean;
+}
+
+interface KeptFile {
+  segments: string[]; // path segments inside the picked folder
+  kind: MediaFileKind;
+}
+
+/**
+ * Derive the layout the backend will discover from the picked selection.
+ *
+ * `entries` are the files' paths inside the picked folder (the folder's own
+ * name already stripped, as `splitFolderSelection` does). Only files matching
+ * the use case's media kinds are laid out — everything else is counted as
+ * ignored, exactly like the upload filter drops it.
+ */
+export function preflightLayout(
+  entries: readonly { relPath: string }[],
+  useCase: RawUseCase,
+): LayoutPreflight {
+  const findings: LayoutFinding[] = [];
+  const allowed = USE_CASE_FILE_KINDS[useCase];
+  const kept: KeptFile[] = [];
+  let ignoredFiles = 0;
+  const wrongKindCounts = new Map<MediaFileKind, number>();
+
+  for (const entry of entries) {
+    const segments = entry.relPath.split("/").filter(Boolean);
+    if (!segments.length || segments.some((segment) => segment.startsWith("."))) {
+      ignoredFiles += 1; // hidden segments mirror the backend's dot-dir skip
+      continue;
+    }
+    const kind = classifyMediaName(segments[segments.length - 1]);
+    if (kind === null) {
+      ignoredFiles += 1;
+      continue;
+    }
+    if (!allowed.includes(kind)) {
+      ignoredFiles += 1;
+      wrongKindCounts.set(kind, (wrongKindCounts.get(kind) ?? 0) + 1);
+      continue;
+    }
+    kept.push({ segments, kind });
+  }
+
+  for (const [kind, count] of wrongKindCounts) {
+    findings.push({
+      code: "ignored_files",
+      severity: "warning",
+      message: `${count} ${kind} file${count === 1 ? "" : "s"} will not be uploaded for this use case.`,
+    });
+  }
+
+  if (!kept.length) {
+    findings.push({
+      code: "no_media_found",
+      severity: "error",
+      message: "The selected folder has no importable media files for this use case.",
+    });
+    return result([], [], 0, kept.length, ignoredFiles, findings);
+  }
+
+  // Split detection at the root (all-or-none, like the backend).
+  const rootDirs = new Map<string, KeptFile[]>();
+  const rootFiles: KeptFile[] = [];
+  for (const file of kept) {
+    if (file.segments.length === 1) rootFiles.push(file);
+    else {
+      const dir = file.segments[0];
+      rootDirs.set(dir, [...(rootDirs.get(dir) ?? []), file]);
+    }
+  }
+  const splitLike = [...rootDirs.keys()].filter((dir) => SPLIT_DIR_NAMES.has(dir.toLowerCase()));
+  if (splitLike.length && splitLike.length !== rootDirs.size) {
+    findings.push({
+      code: "ambiguous_media_layout",
+      severity: "error",
+      message:
+        "Folders mix split names (train/val/test) with other media folders; " +
+        "use only split folders, or only view folders.",
+    });
+    return result([], [], 0, kept.length, ignoredFiles, findings);
+  }
+  const usesSplits = splitLike.length > 0;
+  if (usesSplits && rootFiles.length) {
+    findings.push({
+      code: "files_outside_splits",
+      severity: "warning",
+      message:
+        `${rootFiles.length} file${rootFiles.length === 1 ? "" : "s"} at the folder root ` +
+        "are ignored because the folder has split subfolders.",
+    });
+  }
+
+  const splitInputs: { name: string; files: KeptFile[] }[] = usesSplits
+    ? [...rootDirs.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, files]) => ({
+          name,
+          files: files.map((file) => ({ ...file, segments: file.segments.slice(1) })),
+        }))
+    : [{ name: "default", files: kept }];
+
+  const splits: LayoutSplit[] = [];
+  let referenceViews: Map<string, { kind: MediaFileKind; fileCount: number }> | null = null;
+  const viewTotals = new Map<string, { kind: MediaFileKind; fileCount: number }>();
+
+  for (const split of splitInputs) {
+    const splitViews = splitLayout(split.name, split.files, useCase, findings);
+    if (splitViews === null) {
+      return result([], [], 0, kept.length, ignoredFiles, findings);
+    }
+    if (referenceViews === null) {
+      referenceViews = splitViews.views;
+    } else if (!sameViewSets(referenceViews, splitViews.views)) {
+      findings.push({
+        code: "inconsistent_split_views",
+        severity: "error",
+        message:
+          `Split '${split.name}' implies different views than the other splits; ` +
+          "make every split's folders identical.",
+      });
+      return result([], [], 0, kept.length, ignoredFiles, findings);
+    }
+    for (const [name, view] of splitViews.views) {
+      const total = viewTotals.get(name) ?? { kind: view.kind, fileCount: 0 };
+      total.fileCount += view.fileCount;
+      viewTotals.set(name, total);
+    }
+    splits.push({ name: split.name, recordCount: splitViews.recordCount });
+  }
+
+  const views: LayoutView[] = [...viewTotals.entries()].map(([name, view]) => ({
+    name,
+    kind: view.kind,
+    fileCount: view.fileCount,
+  }));
+
+  if (useCase === "image_text_entity_linking") {
+    const textViews = views.filter((view) => view.kind === "text").length;
+    const imageViews = views.filter((view) => view.kind === "image").length;
+    if (textViews !== 1 || imageViews < 1) {
+      findings.push({
+        code: "mel_needs_image_and_text",
+        severity: "error",
+        message:
+          "Image–text linking needs one text folder and at least one image folder " +
+          "(e.g. image/ + text/), with files matched by name.",
+      });
+    }
+  }
+
+  const totalRecords = splits.reduce((sum, split) => sum + split.recordCount, 0);
+  return result(views, splits, totalRecords, kept.length, ignoredFiles, findings);
+}
+
+/** One split's views + record count, or null on a blocking ambiguity. */
+function splitLayout(
+  splitName: string,
+  files: KeptFile[],
+  useCase: RawUseCase,
+  findings: LayoutFinding[],
+): { views: Map<string, { kind: MediaFileKind; fileCount: number }>; recordCount: number } | null {
+  const where = splitName === "default" ? "the folder" : `'${splitName}/'`;
+  const direct = files.filter((file) => file.segments.length === 1);
+  const inDirs = files.filter((file) => file.segments.length > 1);
+
+  if (direct.length && inDirs.length) {
+    findings.push({
+      code: "ambiguous_media_layout",
+      severity: "error",
+      message:
+        `Media files sit both directly in ${where} and inside subfolders; ` +
+        "move them all into view folders, or all at one level.",
+    });
+    return null;
+  }
+
+  if (!inDirs.length) {
+    // Flat folder: one view named after the sole media kind.
+    const kind = soleKind(direct, where, useCase, findings);
+    if (kind === null) return null;
+    if (
+      !uniqueStems(
+        direct.map((file) => stemOf(file.segments)),
+        where,
+        findings,
+      )
+    )
+      return null;
+    return {
+      views: new Map([[kind, { kind, fileCount: direct.length }]]),
+      recordCount: direct.length,
+    };
+  }
+
+  // Per-view subfolders, stem-matched into records.
+  const byDir = new Map<string, KeptFile[]>();
+  for (const file of inDirs) {
+    byDir.set(file.segments[0], [...(byDir.get(file.segments[0]) ?? []), file]);
+  }
+  const views = new Map<string, { kind: MediaFileKind; fileCount: number }>();
+  const keysByView = new Map<string, Set<string>>();
+  const namedDirs = new Map<string, string>();
+  for (const [dir, dirFiles] of [...byDir.entries()].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const kind = soleKind(dirFiles, `'${dir}/'`, useCase, findings);
+    if (kind === null) return null;
+    const name = toSnakeCase(dir);
+    if (views.has(name)) {
+      findings.push({
+        code: "view_name_collision",
+        severity: "error",
+        message: `Folders '${namedDirs.get(name)}' and '${dir}' both map to view '${name}'; rename one.`,
+      });
+      return null;
+    }
+    if (SPLIT_DIR_NAMES.has(name)) {
+      findings.push({
+        code: "view_name_reserved",
+        severity: "error",
+        message: `View folder '${dir}' collides with the split names (train/val/test…); rename it.`,
+      });
+      return null;
+    }
+    const keys = dirFiles.map((file) => stemOf(file.segments.slice(1)));
+    if (!uniqueStems(keys, `'${dir}/'`, findings)) return null;
+    views.set(name, { kind, fileCount: dirFiles.length });
+    keysByView.set(name, new Set(keys));
+    namedDirs.set(name, dir);
+  }
+
+  const allKeys = new Set<string>();
+  for (const keys of keysByView.values()) for (const key of keys) allKeys.add(key);
+  let missing = 0;
+  for (const keys of keysByView.values()) missing += allKeys.size - keys.size;
+  if (missing > 0) {
+    findings.push({
+      code: "missing_view_file",
+      severity: "warning",
+      message:
+        `${missing} record${missing === 1 ? " is" : "s are"} missing a file in one of the views ` +
+        "(matched by file name); those views are omitted for those records.",
+    });
+  }
+  return { views, recordCount: allKeys.size };
+}
+
+function soleKind(
+  files: KeptFile[],
+  where: string,
+  useCase: RawUseCase,
+  findings: LayoutFinding[],
+): MediaFileKind | null {
+  const kinds = [...new Set(files.map((file) => file.kind))].sort();
+  if (kinds.length === 1) return kinds[0];
+  const hint =
+    useCase === "image_text_entity_linking"
+      ? " For image–text linking, put images and texts in separate view folders (image/ + text/)."
+      : "";
+  findings.push({
+    code: "mixed_media_kinds",
+    severity: "error",
+    message: `${where} mixes ${kinds.join(" and ")} files; keep one media kind per folder.${hint}`,
+  });
+  return null;
+}
+
+function uniqueStems(keys: string[], where: string, findings: LayoutFinding[]): boolean {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) duplicates.add(key);
+    seen.add(key);
+  }
+  if (!duplicates.size) return true;
+  const sample = [...duplicates][0];
+  findings.push({
+    code: "duplicate_view_stem",
+    severity: "error",
+    message: `'${sample}' appears with several extensions under ${where}; file names must be unique per view.`,
+  });
+  return false;
+}
+
+/** The stem-match key: the path inside the view folder, without the extension. */
+function stemOf(segments: string[]): string {
+  const path = segments.join("/");
+  const dot = path.lastIndexOf(".");
+  return dot > path.lastIndexOf("/") ? path.slice(0, dot) : path;
+}
+
+function sameViewSets(
+  left: Map<string, { kind: MediaFileKind }>,
+  right: Map<string, { kind: MediaFileKind }>,
+): boolean {
+  if (left.size !== right.size) return false;
+  for (const [name, view] of left) {
+    if (right.get(name)?.kind !== view.kind) return false;
+  }
+  return true;
+}
+
+function result(
+  views: LayoutView[],
+  splits: LayoutSplit[],
+  totalRecords: number,
+  keptFiles: number,
+  ignoredFiles: number,
+  findings: LayoutFinding[],
+): LayoutPreflight {
+  return {
+    views,
+    splits,
+    totalRecords,
+    keptFiles,
+    ignoredFiles,
+    findings,
+    ok: !findings.some((finding) => finding.severity === "error"),
+  };
+}

--- a/ui/apps/pixano/src/components/library/import-wizard/rawSchema.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/rawSchema.ts
@@ -6,105 +6,108 @@ License: CECILL-C
 
 /** The raw-media schema builder: pure helpers turning wizard fields into a spec `schema`. */
 
-export type RawMediaKind = "images" | "videos" | "texts";
-export type RawViewsMode = "auto" | "named";
-export type RawFramesMode = "extract" | "reference";
-export type EntityAttrType = "str" | "int" | "float" | "bool";
+import type { LayoutPreflight, RawUseCase } from "./layoutPreflight";
 
-export interface EntityAttrRow {
+export type RawFramesMode = "extract" | "reference";
+export type AttrType = "str" | "int" | "float" | "bool";
+
+export interface AttrRow {
   name: string;
-  type: EntityAttrType;
+  type: AttrType;
   list: boolean;
   required: boolean;
   defaultValue: string;
 }
 
 export interface RawFields {
-  kind: RawMediaKind;
-  viewsMode: RawViewsMode;
-  viewNames: string; // comma-separated, used when viewsMode === "named"
-  framesMode: RawFramesMode; // videos only
-  maxFrames: string; // videos, extract mode
-  entityAttrs: EntityAttrRow[];
+  useCase: RawUseCase;
+  framesMode: RawFramesMode; // video only
+  maxFrames: string; // video, extract mode
+  recordAttrs: AttrRow[];
+  entityAttrs: AttrRow[];
   annotations: string[];
+  layout: LayoutPreflight | null; // derived from the picked folder before upload
 }
 
-/** Annotation slots pre-selected per media kind (what most users annotate). */
-export const DEFAULT_ANNOTATIONS: Record<RawMediaKind, string[]> = {
-  images: ["bbox", "mask", "keypoint", "classification"],
-  videos: ["bbox", "mask", "keypoint", "tracklet"],
-  texts: ["text_span", "classification"],
+/** The use-case cards: labels + the folder layout each one expects. */
+export const USE_CASE_CARDS: {
+  useCase: RawUseCase;
+  title: string;
+  blurb: string;
+  layoutHint: string;
+}[] = [
+  {
+    useCase: "image",
+    title: "Image annotation",
+    blurb: "Detect, segment, classify objects on images — one or several views per record.",
+    layoutHint:
+      "photos/\n├─ a.jpg  b.jpg …      (single view)\n└─ or left/ right/ …   (views, same file names pair up)",
+  },
+  {
+    useCase: "video",
+    title: "Video annotation",
+    blurb: "Track objects across frames — videos import as annotatable frame sequences.",
+    layoutHint:
+      "clips/\n├─ v1.mp4  v2.mp4 …    (single view)\n└─ or front/ side/ …   (views, same file names pair up)",
+  },
+  {
+    useCase: "image_vqa",
+    title: "Visual Q&A",
+    blurb: "Ask and answer questions about images — conversations attach to each record.",
+    layoutHint: "photos/\n└─ a.jpg  b.jpg …      (questions are added in Pixano)",
+  },
+  {
+    useCase: "image_text_entity_linking",
+    title: "Image–text linking",
+    blurb: "Link mentions in a text to regions in an image (multimodal entity linking).",
+    layoutHint: "pairs/\n├─ image/  a.jpg  b.jpg\n└─ text/   a.txt  b.txt  (same names pair up)",
+  },
+];
+
+/** Annotation slots pre-selected per use case (what most users annotate). */
+export const DEFAULT_ANNOTATIONS: Record<RawUseCase, string[]> = {
+  image: ["bbox", "mask", "keypoint", "classification"],
+  video: ["bbox", "mask", "keypoint", "tracklet"],
+  image_vqa: ["message"],
+  image_text_entity_linking: ["text_span", "bbox", "mask"],
 };
 
-/** Annotation slots offered per media kind (the declarative-dialect subset that fits each). */
-export const ANNOTATION_CHOICES: Record<RawMediaKind, string[]> = {
-  images: ["bbox", "mask", "keypoint", "multi_path", "classification", "relation", "message"],
-  videos: ["bbox", "mask", "keypoint", "multi_path", "classification", "tracklet", "relation"],
-  texts: ["text_span", "classification", "message", "relation"],
+/** Annotation slots offered per use case (the declarative-dialect subset that fits each). */
+export const ANNOTATION_CHOICES: Record<RawUseCase, string[]> = {
+  image: ["bbox", "mask", "keypoint", "multi_path", "classification", "relation"],
+  video: ["bbox", "mask", "keypoint", "multi_path", "classification", "tracklet", "relation"],
+  image_vqa: ["message", "bbox", "mask", "classification"],
+  image_text_entity_linking: ["text_span", "bbox", "mask", "classification"],
 };
 
-/** File extensions the backend imports per media kind (mirrors media_only.py). */
-export const MEDIA_KIND_EXTENSIONS: Record<RawMediaKind, string[]> = {
-  images: [".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".webp"],
-  videos: [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".vob"],
-  texts: [".txt", ".md"],
+/**
+ * Slots the use case cannot work without (non-removable chips). A non-empty
+ * `schema.annotations` REPLACES the workspace preset's slots backend-side, so
+ * the wizard must always re-list these.
+ */
+export const LOCKED_ANNOTATIONS: Record<RawUseCase, string[]> = {
+  image: [],
+  video: [],
+  image_vqa: ["message"],
+  image_text_entity_linking: ["text_span"],
 };
 
-/** True when a file name carries one of the media kind's extensions (case-insensitive). */
-export function matchesMediaKind(name: string, kind: RawMediaKind): boolean {
-  const lower = name.toLowerCase();
-  return MEDIA_KIND_EXTENSIONS[kind].some((ext) => lower.endsWith(ext));
-}
-
-export const ENTITY_ATTR_TYPES: EntityAttrType[] = ["str", "int", "float", "bool"];
+export const ATTR_TYPES: AttrType[] = ["str", "int", "float", "bool"];
 
 export const DEFAULT_RAW_FIELDS: RawFields = {
-  kind: "images",
-  viewsMode: "auto",
-  viewNames: "",
+  useCase: "image",
   framesMode: "extract",
   maxFrames: "",
+  recordAttrs: [],
   entityAttrs: [],
-  annotations: [...DEFAULT_ANNOTATIONS.images],
+  annotations: [...DEFAULT_ANNOTATIONS.image],
+  layout: null,
 };
 
 const NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
 
-/** Parse the comma-separated view names input; names must be snake_case and unique. */
-export function parseViewNames(input: string): { names: string[]; error: string } {
-  const names = input
-    .split(",")
-    .map((name) => name.trim())
-    .filter((name) => name.length > 0);
-  for (const name of names) {
-    if (!NAME_PATTERN.test(name)) {
-      return { names: [], error: `View '${name}': use snake_case names (letters, digits, _).` };
-    }
-  }
-  if (new Set(names).size !== names.length) {
-    return { names: [], error: "View names must be unique." };
-  }
-  return { names, error: "" };
-}
-
-/** Validate the entity-attribute rows; returns "" when they compile cleanly. */
-export function validateEntityAttrs(rows: EntityAttrRow[]): string {
-  const seen = new Set<string>();
-  for (const row of rows) {
-    if (!NAME_PATTERN.test(row.name)) {
-      return `Attribute '${row.name || "(empty)"}': use snake_case names (letters, digits, _).`;
-    }
-    if (seen.has(row.name)) return `Attribute '${row.name}' is declared twice.`;
-    seen.add(row.name);
-    if (row.defaultValue.trim() && parseTypedValue(row.type, row.defaultValue) === undefined) {
-      return `Attribute '${row.name}': default '${row.defaultValue}' is not a valid ${row.type}.`;
-    }
-  }
-  return "";
-}
-
 /** Parse a default-value string as the attribute type; undefined when invalid. */
-export function parseTypedValue(type: EntityAttrType, value: string): unknown {
+export function parseTypedValue(type: AttrType, value: string): unknown {
   const text = value.trim();
   if (type === "str") return text;
   if (type === "bool") {
@@ -116,64 +119,111 @@ export function parseTypedValue(type: EntityAttrType, value: string): unknown {
   return /^-?(\d+\.?\d*|\.\d+)$/.test(text) ? Number(text) : undefined;
 }
 
+/** Parse a comma-separated list default (`a, b`); undefined when any element is invalid. */
+export function parseTypedListValue(type: AttrType, value: string): unknown[] | undefined {
+  const parts = value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  const parsed = parts.map((part) => parseTypedValue(type, part));
+  return parsed.some((item) => item === undefined) ? undefined : parsed;
+}
+
+/** Validate one attrs editor's rows; returns "" when they compile cleanly. */
+export function validateAttrRows(rows: AttrRow[], label = "Attribute"): string {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (!NAME_PATTERN.test(row.name)) {
+      return `${label} '${row.name || "(empty)"}': use snake_case names (letters, digits, _).`;
+    }
+    if (seen.has(row.name)) return `${label} '${row.name}' is declared twice.`;
+    seen.add(row.name);
+    if (row.defaultValue.trim()) {
+      const parsed = row.list
+        ? parseTypedListValue(row.type, row.defaultValue)
+        : parseTypedValue(row.type, row.defaultValue);
+      if (parsed === undefined) {
+        const shape = row.list ? `comma-separated ${row.type} list` : row.type;
+        return `${label} '${row.name}': default '${row.defaultValue}' is not a valid ${shape}.`;
+      }
+    }
+  }
+  return "";
+}
+
 /** One validation message for the whole raw form; "" when analyzable. */
 export function validateRawFields(raw: RawFields): string {
-  if (raw.kind === "images" && raw.viewsMode === "named") {
-    const { names, error } = parseViewNames(raw.viewNames);
-    if (error) return error;
-    if (!names.length) return "Name at least one view, or switch back to automatic views.";
-  }
-  if (raw.kind === "videos" && raw.maxFrames.trim() && !/^\d+$/.test(raw.maxFrames.trim())) {
+  if (raw.useCase === "video" && raw.maxFrames.trim() && !/^\d+$/.test(raw.maxFrames.trim())) {
     return "Max frames per video must be a whole number.";
   }
-  return validateEntityAttrs(raw.entityAttrs);
+  if (!raw.annotations.length) {
+    return "Select at least one annotation type.";
+  }
+  const recordError = validateAttrRows(raw.recordAttrs, "Record attribute");
+  if (recordError) return recordError;
+  return validateAttrRows(raw.entityAttrs, "Object attribute");
+}
+
+function attrsPayload(rows: AttrRow[]): Record<string, unknown> {
+  const attrs: Record<string, unknown> = {};
+  for (const row of rows) {
+    const attr: Record<string, unknown> = { type: row.type };
+    if (row.list) attr.collection = true;
+    if (row.required) attr.required = true;
+    else if (row.defaultValue.trim()) {
+      attr.default = row.list
+        ? parseTypedListValue(row.type, row.defaultValue)
+        : parseTypedValue(row.type, row.defaultValue);
+    }
+    attrs[row.name] = attr;
+  }
+  return attrs;
 }
 
 /**
  * Compile the raw form into spec fragments.
  *
- * Views are declared only when the user names them — otherwise the backend
- * infers them from the folder layout (and the confirmed schema is shown on
- * the review step). Note: an empty annotations selection keeps the workspace
- * preset's slots (the backend treats [] as "no override").
+ * The workspace is always the use case — that is what routes the dataset to
+ * the right annotation UI. Views are declared only when the preflight found
+ * several (per-view folders); single-view sources rely on backend inference.
+ * Annotations are always sent: a non-empty list replaces the preset's slots,
+ * so the chips are the single source of truth for what gets created.
  */
 export function buildRawSchemaSpec(raw: RawFields): {
   schema: Record<string, unknown>;
-  workspace?: string;
+  workspace: string;
   options?: Record<string, unknown>;
 } {
   const schema: Record<string, unknown> = {};
 
-  if (raw.kind === "images" && raw.viewsMode === "named") {
-    const { names } = parseViewNames(raw.viewNames);
-    if (names.length) {
-      schema.views = Object.fromEntries(names.map((name) => [name, "image"]));
-    }
+  const layoutViews = raw.layout?.ok ? raw.layout.views : [];
+  if (layoutViews.length >= 2) {
+    const videoKind = raw.framesMode === "reference" ? "video" : "sequence_frames";
+    schema.views = Object.fromEntries(
+      layoutViews.map((view) => [
+        view.name,
+        { kind: view.kind === "video" ? videoKind : view.kind },
+      ]),
+    );
   }
 
-  if (raw.entityAttrs.length) {
-    const attrs: Record<string, unknown> = {};
-    for (const row of raw.entityAttrs) {
-      const attr: Record<string, unknown> = { type: row.type };
-      if (row.list) attr.collection = true;
-      if (row.required) attr.required = true;
-      else if (row.defaultValue.trim()) attr.default = parseTypedValue(row.type, row.defaultValue);
-      attrs[row.name] = attr;
-    }
-    schema.entity = { attrs };
-  }
-
-  if (raw.annotations.length) schema.annotations = [...raw.annotations];
+  if (raw.recordAttrs.length) schema.record = { attrs: attrsPayload(raw.recordAttrs) };
+  if (raw.entityAttrs.length) schema.entity = { attrs: attrsPayload(raw.entityAttrs) };
+  const annotations = [
+    ...LOCKED_ANNOTATIONS[raw.useCase].filter((slot) => !raw.annotations.includes(slot)),
+    ...raw.annotations,
+  ];
+  if (annotations.length) schema.annotations = annotations;
 
   const options: Record<string, unknown> = {};
-  if (raw.kind === "videos") {
+  if (raw.useCase === "video") {
     if (raw.framesMode === "reference") options.frames = "reference";
     else if (raw.maxFrames.trim()) options.max_frames_per_video = Number(raw.maxFrames.trim());
   }
 
   return {
     schema,
-    workspace: raw.kind === "images" ? "image" : raw.kind === "videos" ? "video" : undefined,
+    workspace: raw.useCase,
     options: Object.keys(options).length ? options : undefined,
   };
 }

--- a/ui/apps/pixano/src/components/library/import-wizard/wizardUtils.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/wizardUtils.ts
@@ -158,10 +158,12 @@ export function sampleLocation(sample: { file?: string | null; line?: number | n
   return sample.line ? `${file}:${sample.line}` : file;
 }
 
-/** Source step gating: a source, valid Advanced JSON, and a clean raw form. */
+/** Source step gating: a source, valid Advanced JSON, a clean raw form, and a sound layout. */
 export function canAnalyze(fields: WizardFields, advancedJson: string): boolean {
   if (!fields.source.trim() || parseAdvancedSpec(advancedJson).error) return false;
-  return fields.intent !== "raw" || validateRawFields(fields.raw) === "";
+  if (fields.intent !== "raw") return true;
+  if (fields.raw.layout !== null && !fields.raw.layout.ok) return false;
+  return validateRawFields(fields.raw) === "";
 }
 
 /** One attribute chip of a schema entry. */

--- a/ui/apps/pixano/src/lib/api/__tests__/uploadClient.test.ts
+++ b/ui/apps/pixano/src/lib/api/__tests__/uploadClient.test.ts
@@ -4,7 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { matchesMediaKind } from "$components/library/import-wizard/rawSchema";
+import { matchesUseCase } from "$components/library/import-wizard/layoutPreflight";
 import { describe, expect, it } from "vitest";
 
 import { filterSelection, splitFolderSelection } from "../uploadClient";
@@ -41,29 +41,38 @@ describe("splitFolderSelection", () => {
   });
 });
 
-describe("filterSelection with matchesMediaKind", () => {
+describe("filterSelection with matchesUseCase", () => {
   const selection = splitFolderSelection([
     fakeFile("set/left/a.jpg", 100),
     fakeFile("set/right/a.JPG", 100),
     fakeFile("set/metadata.jsonl", 20),
     fakeFile("set/.DS_Store", 5),
     fakeFile("set/notes.txt", 10),
+    fakeFile("set/clip.mp4", 50),
   ]);
 
-  it("drops the stray metadata.jsonl and junk for an images import", () => {
-    const filtered = filterSelection(selection, (name) => matchesMediaKind(name, "images"));
+  it("drops the stray metadata.jsonl and junk for an image import", () => {
+    const filtered = filterSelection(selection, (name) => matchesUseCase(name, "image"));
     expect(filtered.entries.map((e) => e.relPath)).toEqual(["left/a.jpg", "right/a.JPG"]);
     expect(filtered.totalBytes).toBe(200); // metadata.jsonl / .DS_Store / notes.txt excluded
     expect(filtered.folderName).toBe("set");
   });
 
-  it("keeps only text files for a text import", () => {
-    const filtered = filterSelection(selection, (name) => matchesMediaKind(name, "texts"));
-    expect(filtered.entries.map((e) => e.relPath)).toEqual(["notes.txt"]);
+  it("keeps BOTH images and texts for a MEL import, dropping the rest", () => {
+    const filtered = filterSelection(selection, (name) =>
+      matchesUseCase(name, "image_text_entity_linking"),
+    );
+    expect(filtered.entries.map((e) => e.relPath)).toEqual([
+      "left/a.jpg",
+      "right/a.JPG",
+      "notes.txt",
+    ]);
+    expect(filtered.totalBytes).toBe(210);
   });
 
   it("yields an empty selection when nothing matches (caller shows an error)", () => {
-    const filtered = filterSelection(selection, (name) => matchesMediaKind(name, "videos"));
+    const noVideos = splitFolderSelection([fakeFile("set/a.jpg", 1)]);
+    const filtered = filterSelection(noVideos, (name) => matchesUseCase(name, "video"));
     expect(filtered.entries).toEqual([]);
   });
 });


### PR DESCRIPTION
## Issue

Completes the raw-media import improvements for the 5 GUI use cases (single/multi-view images, videos, VQA, MEL). Frontend counterpart of #700 (independent — no code dependency, but best tested together).

## Description

The raw flow now leads with **what the user is building** instead of a media-kind radio:

```
Type → Use case (NEW) → Source (+ layout preflight) → Review → Import
```

**Use-case step** — four cards (Image annotation / Video annotation / Visual Q&A / Image–text linking), each with a folder-layout diagram. The choice drives the workspace, upload filter, view kinds, and preset annotation slots. `image_vqa` and `image_text_entity_linking` datasets are now importable from the GUI (previously only via the Advanced-JSON escape hatch); the workspace is always emitted, so datasets open in the right annotation UI.

**Client-side layout preflight** (`layoutPreflight.ts`, pure + fully unit-tested) — mirrors the backend's media-only discovery over the picked FileList *before anything uploads*: per-view folders, stem matching, split vocabulary, mixed-kind detection, snake_case collisions, reserved names, duplicate stems, missing-stem warnings. A bad layout blocks with actionable messages instead of costing a multi-gigabyte upload and a failed analyze; a "Detected layout" panel shows views, splits, and record count.

**Upload filter by use case** — MEL keeps images **and** `.txt/.md` files. Previously choosing "Images" silently dropped every text file, making MEL impossible and invisible.

**Schema builder** — record-level attributes get their own editor (backend `schema.record.attrs` was unreachable from the form); `AttrsEditor` generalizes `EntityAttrsEditor` (record attrs disallow `required` — media-only ingest creates records without attr values); list defaults parse as comma-separated arrays; optional attrs show their backend zero-value. Annotation chips are per-use-case with locked slots (`message` for VQA, `text_span` for MEL) — locked because a non-empty `annotations` list replaces the workspace preset's slots backend-side.

**Honest video copy** — "Reference clips" no longer claims clips play in the explorer (there is no `/videos` route in this release); the review step warns explicitly. Raw text-only import moved out of the cards (its `undefined` workspace renders the wrong explorer) — still available via Advanced JSON / CLI.

## Tests

- New `layoutPreflight.test.ts`: 17 tests, one per mirrored backend rule (happy paths, all blocking errors, warnings).
- `rawSchema.test.ts` rewritten: workspace per use case, preflight-driven views, video kind mapping, locked slots, record attrs, list defaults.
- `wizardUtils.test.ts`: exact merged spec payloads for multi-view image / video / VQA / MEL; preflight gating of Analyze.
- `uploadClient.test.ts`: MEL keeps txt+jpg, drops mp4/`.DS_Store`.
- 154 vitest tests green (22 files), `tsc`+eslint clean, prettier clean, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)