### PR TITLE
refactor: rename the raw-import wizard 'use case' to 'task'

### DIFF
--- a/ui/apps/pixano/src/components/library/import-wizard/AnnotationSlotsPicker.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/AnnotationSlotsPicker.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   interface Props {
     choices: string[];
     selected: string[];
-    /** Slots the use case cannot work without — always selected, not toggleable. */
+    /** Slots the task cannot work without — always selected, not toggleable. */
     locked?: string[];
   }
 
@@ -35,7 +35,7 @@ License: CECILL-C
         } ${isLocked ? "cursor-default" : ""}`}
         aria-pressed={active}
         aria-disabled={isLocked}
-        title={isLocked ? "This use case needs this annotation type." : undefined}
+        title={isLocked ? "This task needs this annotation type." : undefined}
         onclick={() => toggle(slot)}
       >
         {slot}{#if isLocked}<span class="ml-1 opacity-60">•</span>{/if}

--- a/ui/apps/pixano/src/components/library/import-wizard/ImportWizard.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/ImportWizard.svelte
@@ -11,10 +11,10 @@ License: CECILL-C
 
   import DoneStep from "./DoneStep.svelte";
   import IntentStep from "./IntentStep.svelte";
-  import type { RawUseCase } from "./layoutPreflight";
+  import type { RawTask } from "./layoutPreflight";
   import ProgressStep from "./ProgressStep.svelte";
   import { DEFAULT_ANNOTATIONS } from "./rawSchema";
-  import RawUseCaseStep from "./RawUseCaseStep.svelte";
+  import RawTaskStep from "./RawTaskStep.svelte";
   import ReviewStep from "./ReviewStep.svelte";
   import SourceStep from "./SourceStep.svelte";
   import WizardStepIndicator from "./WizardStepIndicator.svelte";
@@ -50,7 +50,7 @@ License: CECILL-C
 
   let { onClose }: Props = $props();
 
-  type Step = "intent" | "usecase" | "source" | "review" | "progress" | "done";
+  type Step = "intent" | "task" | "source" | "review" | "progress" | "done";
 
   let open = $state(true);
   let step = $state<Step>("intent");
@@ -79,20 +79,18 @@ License: CECILL-C
   const canGoAnalyze = $derived(canAnalyze(fields, advancedJson));
   const isRaw = $derived(fields.intent === "raw");
   const referenceMode = $derived(
-    isRaw && fields.raw.useCase === "video" && fields.raw.framesMode === "reference",
+    isRaw && fields.raw.task === "video" && fields.raw.framesMode === "reference",
   );
 
-  // The raw flow adds a "Use case" step between Type and Source.
+  // The raw flow adds a "Task" step between Type and Source.
   const stepLabels = $derived(
-    isRaw
-      ? ["Type", "Use case", "Source", "Review", "Import"]
-      : ["Type", "Source", "Review", "Import"],
+    isRaw ? ["Type", "Task", "Source", "Review", "Import"] : ["Type", "Source", "Review", "Import"],
   );
   const stepIndex = $derived.by(() => {
     const offset = isRaw ? 1 : 0;
     const index: Record<Step, number> = {
       intent: 0,
-      usecase: 1,
+      task: 1,
       source: 1 + offset,
       review: 2 + offset,
       progress: 3 + offset,
@@ -106,7 +104,7 @@ License: CECILL-C
       title: "Import Dataset",
       description: "What are you importing?",
     },
-    usecase: {
+    task: {
       title: "Import raw media",
       description: "What are you building? This sets the views, workspace, and annotation types.",
     },
@@ -147,13 +145,13 @@ License: CECILL-C
 
   function handleIntentSelect(intent: ImportIntent) {
     fields.intent = intent;
-    step = intent === "raw" ? "usecase" : "source";
+    step = intent === "raw" ? "task" : "source";
   }
 
-  function handleUseCaseSelect(useCase: RawUseCase) {
-    if (fields.raw.useCase !== useCase) {
-      fields.raw.useCase = useCase;
-      fields.raw.annotations = [...DEFAULT_ANNOTATIONS[useCase]];
+  function handleTaskSelect(task: RawTask) {
+    if (fields.raw.task !== task) {
+      fields.raw.task = task;
+      fields.raw.annotations = [...DEFAULT_ANNOTATIONS[task]];
     }
     step = "source";
   }
@@ -264,8 +262,8 @@ License: CECILL-C
 
           {#if step === "intent"}
             <IntentStep {formats} onSelect={handleIntentSelect} />
-          {:else if step === "usecase"}
-            <RawUseCaseStep onSelect={handleUseCaseSelect} />
+          {:else if step === "task"}
+            <RawTaskStep onSelect={handleTaskSelect} />
           {:else if step === "source"}
             <SourceStep bind:fields bind:advancedJson />
           {:else if step === "review"}
@@ -277,7 +275,7 @@ License: CECILL-C
           {/if}
 
           <div class={BLOCKING_ALERT_ACTIONS_CLASS}>
-            {#if step === "intent" || step === "usecase" || step === "source" || step === "review"}
+            {#if step === "intent" || step === "task" || step === "source" || step === "review"}
               <button
                 type="button"
                 class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
@@ -287,7 +285,7 @@ License: CECILL-C
               </button>
             {/if}
 
-            {#if step === "usecase"}
+            {#if step === "task"}
               <button
                 type="button"
                 class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
@@ -301,7 +299,7 @@ License: CECILL-C
               <button
                 type="button"
                 class={BLOCKING_ALERT_SECONDARY_BUTTON_CLASS}
-                onclick={() => (step = isRaw ? "usecase" : "intent")}
+                onclick={() => (step = isRaw ? "task" : "intent")}
               >
                 Back
               </button>

--- a/ui/apps/pixano/src/components/library/import-wizard/RawSchemaBuilder.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/RawSchemaBuilder.svelte
@@ -35,7 +35,7 @@ License: CECILL-C
 </script>
 
 <div class="space-y-4 rounded-xl border border-border p-4">
-  {#if raw.useCase === "video"}
+  {#if raw.task === "video"}
     <div class="space-y-1.5">
       <p class={labelClass}>Video handling</p>
       <div class="flex gap-1.5">
@@ -97,8 +97,8 @@ License: CECILL-C
   <div class="space-y-1.5">
     <p class={labelClass}>Annotations</p>
     <AnnotationSlotsPicker
-      choices={ANNOTATION_CHOICES[raw.useCase]}
-      locked={LOCKED_ANNOTATIONS[raw.useCase]}
+      choices={ANNOTATION_CHOICES[raw.task]}
+      locked={LOCKED_ANNOTATIONS[raw.task]}
       bind:selected={raw.annotations}
     />
   </div>

--- a/ui/apps/pixano/src/components/library/import-wizard/RawTaskStep.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/RawTaskStep.svelte
@@ -7,16 +7,16 @@ License: CECILL-C
 <script lang="ts">
   import { ChatsCircle, Images, LinkSimple, VideoCamera } from "phosphor-svelte";
 
-  import type { RawUseCase } from "./layoutPreflight";
-  import { USE_CASE_CARDS } from "./rawSchema";
+  import type { RawTask } from "./layoutPreflight";
+  import { TASK_CARDS } from "./rawSchema";
 
   interface Props {
-    onSelect: (useCase: RawUseCase) => void;
+    onSelect: (task: RawTask) => void;
   }
 
   let { onSelect }: Props = $props();
 
-  const ICONS: Record<RawUseCase, typeof Images> = {
+  const ICONS: Record<RawTask, typeof Images> = {
     image: Images,
     video: VideoCamera,
     image_vqa: ChatsCircle,
@@ -26,12 +26,12 @@ License: CECILL-C
 
 <div class="px-6 sm:px-7 pb-2 space-y-3">
   <div class="grid gap-2 sm:grid-cols-2">
-    {#each USE_CASE_CARDS as card (card.useCase)}
-      {@const Icon = ICONS[card.useCase]}
+    {#each TASK_CARDS as card (card.task)}
+      {@const Icon = ICONS[card.task]}
       <button
         type="button"
         class="rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-primary/50"
-        onclick={() => onSelect(card.useCase)}
+        onclick={() => onSelect(card.task)}
       >
         <span class="flex items-center gap-2 text-sm font-medium text-foreground">
           <Icon weight="regular" class="h-5 w-5 shrink-0 text-primary" />

--- a/ui/apps/pixano/src/components/library/import-wizard/SourceStep.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/SourceStep.svelte
@@ -7,9 +7,9 @@ License: CECILL-C
 <script lang="ts">
   import { CaretDown, CaretRight, CheckCircle, FolderOpen, UploadSimple } from "phosphor-svelte";
 
-  import { matchesUseCase, preflightLayout } from "./layoutPreflight";
+  import { matchesTask, preflightLayout } from "./layoutPreflight";
   import LayoutPreviewPanel from "./LayoutPreviewPanel.svelte";
-  import { USE_CASE_CARDS } from "./rawSchema";
+  import { TASK_CARDS } from "./rawSchema";
   import RawSchemaBuilder from "./RawSchemaBuilder.svelte";
   import {
     formatBytes,
@@ -44,14 +44,14 @@ License: CECILL-C
   let fileInput = $state<HTMLInputElement | null>(null);
   let abortController: AbortController | null = null;
   let uploadId = "";
-  let uploadedUseCase = $state(fields.raw.useCase);
+  let uploadedTask = $state(fields.raw.task);
 
   const advancedError = $derived(parseAdvancedSpec(advancedJson).error);
   const showLerobot = $derived(showsLerobotFields(fields));
   const offersHub = $derived(fields.intent === "lerobot" || fields.intent === "auto");
   const layoutHint = $derived(
     fields.intent === "raw"
-      ? (USE_CASE_CARDS.find((card) => card.useCase === fields.raw.useCase)?.layoutHint ?? "")
+      ? (TASK_CARDS.find((card) => card.task === fields.raw.task)?.layoutHint ?? "")
       : "",
   );
   const progressPercent = $derived(
@@ -65,13 +65,13 @@ License: CECILL-C
   });
 
   $effect(() => {
-    // Raw uploads are filtered by use case; if the user changes the use case
+    // Raw uploads are filtered by task; if the user changes the task
     // after picking, the staged files no longer match — drop them so the
     // next pick re-filters. (Guarded so the reset can't re-trigger itself.)
     if (
       fields.intent === "raw" &&
       (uploadState !== "idle" || fields.raw.layout !== null) &&
-      fields.raw.useCase !== uploadedUseCase
+      fields.raw.task !== uploadedTask
     ) {
       discardStagedUpload();
     }
@@ -114,18 +114,18 @@ License: CECILL-C
     if (fields.intent === "raw") {
       // Preflight the layout on the client BEFORE uploading anything: a bad
       // folder structure must not cost a multi-gigabyte upload to discover.
-      const layout = preflightLayout(picked.entries, fields.raw.useCase);
+      const layout = preflightLayout(picked.entries, fields.raw.task);
       fields.raw.layout = layout;
-      uploadedUseCase = fields.raw.useCase;
+      uploadedTask = fields.raw.task;
       if (!layout.ok) {
         uploadState = "idle";
         uploadError = "";
         return; // the layout panel shows what to fix; pick the folder again
       }
-      // Upload only the use case's media kinds: a stray metadata.jsonl,
+      // Upload only the task's media kinds: a stray metadata.jsonl,
       // .DS_Store, or README must not be staged (a metadata.jsonl would flip
       // the source out of media-only mode and import nothing).
-      picked = filterSelection(picked, (name) => matchesUseCase(name, fields.raw.useCase));
+      picked = filterSelection(picked, (name) => matchesTask(name, fields.raw.task));
     }
     if (!picked.entries.length) {
       uploadState = "error";
@@ -133,7 +133,7 @@ License: CECILL-C
       return;
     }
     selection = picked;
-    uploadedUseCase = fields.raw.useCase;
+    uploadedTask = fields.raw.task;
     uploadState = "uploading";
     uploadError = "";
     progress = {

--- a/ui/apps/pixano/src/components/library/import-wizard/__tests__/layoutPreflight.test.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/__tests__/layoutPreflight.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   classifyMediaName,
-  matchesUseCase,
+  matchesTask,
   preflightLayout,
   toSnakeCase,
   type LayoutPreflight,
@@ -18,7 +18,7 @@ const entries = (...paths: string[]) => paths.map((relPath) => ({ relPath }));
 
 const codes = (layout: LayoutPreflight) => layout.findings.map((finding) => finding.code);
 
-describe("classifyMediaName / matchesUseCase", () => {
+describe("classifyMediaName / matchesTask", () => {
   it("classifies by extension, case-insensitively", () => {
     expect(classifyMediaName("a.JPG")).toBe("image");
     expect(classifyMediaName("v.mp4")).toBe("video");
@@ -28,10 +28,10 @@ describe("classifyMediaName / matchesUseCase", () => {
   });
 
   it("MEL keeps both images and texts; image keeps only images", () => {
-    expect(matchesUseCase("a.jpg", "image_text_entity_linking")).toBe(true);
-    expect(matchesUseCase("a.txt", "image_text_entity_linking")).toBe(true);
-    expect(matchesUseCase("a.mp4", "image_text_entity_linking")).toBe(false);
-    expect(matchesUseCase("a.txt", "image")).toBe(false);
+    expect(matchesTask("a.jpg", "image_text_entity_linking")).toBe(true);
+    expect(matchesTask("a.txt", "image_text_entity_linking")).toBe(true);
+    expect(matchesTask("a.mp4", "image_text_entity_linking")).toBe(false);
+    expect(matchesTask("a.txt", "image")).toBe(false);
   });
 });
 
@@ -177,7 +177,7 @@ describe("preflightLayout — blocking errors (mirror media_only.py)", () => {
     expect(codes(layout)).toContain("mel_needs_image_and_text");
   });
 
-  it("nothing importable for the use case", () => {
+  it("nothing importable for the task", () => {
     const layout = preflightLayout(entries("a.mp4", "notes.csv"), "image");
     expect(layout.ok).toBe(false);
     expect(codes(layout)).toContain("no_media_found");

--- a/ui/apps/pixano/src/components/library/import-wizard/__tests__/rawSchema.test.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/__tests__/rawSchema.test.ts
@@ -80,10 +80,8 @@ describe("validateAttrRows", () => {
 
 describe("validateRawFields", () => {
   it("requires a whole number for max frames on video", () => {
-    expect(validateRawFields(raw({ useCase: "video", maxFrames: "12.5" }))).toContain(
-      "whole number",
-    );
-    expect(validateRawFields(raw({ useCase: "video", maxFrames: "100" }))).toBe("");
+    expect(validateRawFields(raw({ task: "video", maxFrames: "12.5" }))).toContain("whole number");
+    expect(validateRawFields(raw({ task: "video", maxFrames: "100" }))).toBe("");
   });
 
   it("requires at least one annotation type", () => {
@@ -101,11 +99,11 @@ describe("validateRawFields", () => {
 });
 
 describe("buildRawSchemaSpec", () => {
-  it("always emits the use case as the workspace", () => {
-    expect(buildRawSchemaSpec(raw({ useCase: "image" })).workspace).toBe("image");
-    expect(buildRawSchemaSpec(raw({ useCase: "video" })).workspace).toBe("video");
-    expect(buildRawSchemaSpec(raw({ useCase: "image_vqa" })).workspace).toBe("image_vqa");
-    expect(buildRawSchemaSpec(raw({ useCase: "image_text_entity_linking" })).workspace).toBe(
+  it("always emits the task as the workspace", () => {
+    expect(buildRawSchemaSpec(raw({ task: "image" })).workspace).toBe("image");
+    expect(buildRawSchemaSpec(raw({ task: "video" })).workspace).toBe("video");
+    expect(buildRawSchemaSpec(raw({ task: "image_vqa" })).workspace).toBe("image_vqa");
+    expect(buildRawSchemaSpec(raw({ task: "image_text_entity_linking" })).workspace).toBe(
       "image_text_entity_linking",
     );
   });
@@ -125,14 +123,12 @@ describe("buildRawSchemaSpec", () => {
 
   it("maps video views to sequence_frames or video by frames mode", () => {
     const layout = preflightLayout(entries("front/v.mp4", "side/v.mp4"), "video");
-    const extract = buildRawSchemaSpec(raw({ useCase: "video", layout }));
+    const extract = buildRawSchemaSpec(raw({ task: "video", layout }));
     expect(extract.schema.views).toEqual({
       front: { kind: "sequence_frames" },
       side: { kind: "sequence_frames" },
     });
-    const reference = buildRawSchemaSpec(
-      raw({ useCase: "video", layout, framesMode: "reference" }),
-    );
+    const reference = buildRawSchemaSpec(raw({ task: "video", layout, framesMode: "reference" }));
     expect(reference.schema.views).toEqual({ front: { kind: "video" }, side: { kind: "video" } });
     expect(reference.options).toEqual({ frames: "reference" });
   });
@@ -144,7 +140,7 @@ describe("buildRawSchemaSpec", () => {
     );
     const spec = buildRawSchemaSpec(
       raw({
-        useCase: "image_text_entity_linking",
+        task: "image_text_entity_linking",
         layout,
         annotations: [...DEFAULT_ANNOTATIONS.image_text_entity_linking],
       }),
@@ -155,7 +151,7 @@ describe("buildRawSchemaSpec", () => {
   });
 
   it("always re-adds locked slots (a non-empty list replaces the preset backend-side)", () => {
-    const spec = buildRawSchemaSpec(raw({ useCase: "image_vqa", annotations: ["bbox"] }));
+    const spec = buildRawSchemaSpec(raw({ task: "image_vqa", annotations: ["bbox"] }));
     expect(spec.schema.annotations).toEqual(["message", "bbox"]);
   });
 
@@ -179,7 +175,7 @@ describe("buildRawSchemaSpec", () => {
   });
 
   it("passes the max-frames cap through for extract mode", () => {
-    expect(buildRawSchemaSpec(raw({ useCase: "video", maxFrames: "200" })).options).toEqual({
+    expect(buildRawSchemaSpec(raw({ task: "video", maxFrames: "200" })).options).toEqual({
       max_frames_per_video: 200,
     });
   });
@@ -190,7 +186,7 @@ describe("buildRawSchemaSpec", () => {
     expect(buildRawSchemaSpec(raw({ layout })).schema.views).toBeUndefined();
   });
 
-  it("keeps per-use-case annotation defaults distinct", () => {
+  it("keeps per-task annotation defaults distinct", () => {
     expect(DEFAULT_ANNOTATIONS.image).toContain("bbox");
     expect(DEFAULT_ANNOTATIONS.video).toContain("tracklet");
     expect(DEFAULT_ANNOTATIONS.image_vqa).toContain("message");

--- a/ui/apps/pixano/src/components/library/import-wizard/__tests__/wizardUtils.test.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/__tests__/wizardUtils.test.ts
@@ -111,7 +111,7 @@ describe("mergeSpec", () => {
 
   it("builds the raw-videos spec: extract default with cap, reference opt-in", () => {
     const extract = fields({ intent: "raw" });
-    extract.raw.useCase = "video";
+    extract.raw.task = "video";
     extract.raw.maxFrames = "200";
     extract.raw.annotations = ["bbox", "tracklet"];
     expect(mergeSpec(extract, "")).toEqual({
@@ -122,7 +122,7 @@ describe("mergeSpec", () => {
     });
 
     const reference = fields({ intent: "raw" });
-    reference.raw.useCase = "video";
+    reference.raw.task = "video";
     reference.raw.framesMode = "reference";
     reference.raw.annotations = ["bbox"];
     expect(mergeSpec(reference, "")).toEqual({
@@ -135,7 +135,7 @@ describe("mergeSpec", () => {
 
   it("builds the VQA and MEL specs with their workspaces and locked slots", () => {
     const vqa = fields({ intent: "raw" });
-    vqa.raw.useCase = "image_vqa";
+    vqa.raw.task = "image_vqa";
     vqa.raw.annotations = ["message"];
     expect(mergeSpec(vqa, "")).toEqual({
       format: "pixano_jsonl",
@@ -144,7 +144,7 @@ describe("mergeSpec", () => {
     });
 
     const mel = fields({ intent: "raw" });
-    mel.raw.useCase = "image_text_entity_linking";
+    mel.raw.task = "image_text_entity_linking";
     mel.raw.annotations = ["text_span", "bbox", "mask"];
     mel.raw.layout = preflightLayout(
       ["image/a.jpg", "text/a.txt"].map((relPath) => ({ relPath })),

--- a/ui/apps/pixano/src/components/library/import-wizard/layoutPreflight.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/layoutPreflight.ts
@@ -14,7 +14,7 @@ License: CECILL-C
  */
 
 /** What the user is building — maps 1:1 onto the backend workspace values. */
-export type RawUseCase = "image" | "video" | "image_vqa" | "image_text_entity_linking";
+export type RawTask = "image" | "video" | "image_vqa" | "image_text_entity_linking";
 
 /** On-disk media kinds the media-only importer scans. */
 export type MediaFileKind = "image" | "video" | "text";
@@ -26,8 +26,8 @@ export const FILE_KIND_EXTENSIONS: Record<MediaFileKind, string[]> = {
   text: [".txt", ".md"],
 };
 
-/** The media kinds each use case imports (MEL pairs images with texts). */
-export const USE_CASE_FILE_KINDS: Record<RawUseCase, MediaFileKind[]> = {
+/** The media kinds each task imports (MEL pairs images with texts). */
+export const TASK_FILE_KINDS: Record<RawTask, MediaFileKind[]> = {
   image: ["image"],
   video: ["video"],
   image_vqa: ["image"],
@@ -54,10 +54,10 @@ export function classifyMediaName(name: string): MediaFileKind | null {
   return null;
 }
 
-/** True when a file belongs to the use case's upload (drives the upload filter). */
-export function matchesUseCase(name: string, useCase: RawUseCase): boolean {
+/** True when a file belongs to the task's upload (drives the upload filter). */
+export function matchesTask(name: string, task: RawTask): boolean {
   const kind = classifyMediaName(name);
-  return kind !== null && USE_CASE_FILE_KINDS[useCase].includes(kind);
+  return kind !== null && TASK_FILE_KINDS[task].includes(kind);
 }
 
 /** Mirror of the backend's `to_snake_case` (folder → view name). */
@@ -108,15 +108,15 @@ interface KeptFile {
  *
  * `entries` are the files' paths inside the picked folder (the folder's own
  * name already stripped, as `splitFolderSelection` does). Only files matching
- * the use case's media kinds are laid out — everything else is counted as
+ * the task's media kinds are laid out — everything else is counted as
  * ignored, exactly like the upload filter drops it.
  */
 export function preflightLayout(
   entries: readonly { relPath: string }[],
-  useCase: RawUseCase,
+  task: RawTask,
 ): LayoutPreflight {
   const findings: LayoutFinding[] = [];
-  const allowed = USE_CASE_FILE_KINDS[useCase];
+  const allowed = TASK_FILE_KINDS[task];
   const kept: KeptFile[] = [];
   let ignoredFiles = 0;
   const wrongKindCounts = new Map<MediaFileKind, number>();
@@ -144,7 +144,7 @@ export function preflightLayout(
     findings.push({
       code: "ignored_files",
       severity: "warning",
-      message: `${count} ${kind} file${count === 1 ? "" : "s"} will not be uploaded for this use case.`,
+      message: `${count} ${kind} file${count === 1 ? "" : "s"} will not be uploaded for this task.`,
     });
   }
 
@@ -152,7 +152,7 @@ export function preflightLayout(
     findings.push({
       code: "no_media_found",
       severity: "error",
-      message: "The selected folder has no importable media files for this use case.",
+      message: "The selected folder has no importable media files for this task.",
     });
     return result([], [], 0, kept.length, ignoredFiles, findings);
   }
@@ -203,7 +203,7 @@ export function preflightLayout(
   const viewTotals = new Map<string, { kind: MediaFileKind; fileCount: number }>();
 
   for (const split of splitInputs) {
-    const splitViews = splitLayout(split.name, split.files, useCase, findings);
+    const splitViews = splitLayout(split.name, split.files, task, findings);
     if (splitViews === null) {
       return result([], [], 0, kept.length, ignoredFiles, findings);
     }
@@ -233,7 +233,7 @@ export function preflightLayout(
     fileCount: view.fileCount,
   }));
 
-  if (useCase === "image_text_entity_linking") {
+  if (task === "image_text_entity_linking") {
     const textViews = views.filter((view) => view.kind === "text").length;
     const imageViews = views.filter((view) => view.kind === "image").length;
     if (textViews !== 1 || imageViews < 1) {
@@ -255,7 +255,7 @@ export function preflightLayout(
 function splitLayout(
   splitName: string,
   files: KeptFile[],
-  useCase: RawUseCase,
+  task: RawTask,
   findings: LayoutFinding[],
 ): { views: Map<string, { kind: MediaFileKind; fileCount: number }>; recordCount: number } | null {
   const where = splitName === "default" ? "the folder" : `'${splitName}/'`;
@@ -275,7 +275,7 @@ function splitLayout(
 
   if (!inDirs.length) {
     // Flat folder: one view named after the sole media kind.
-    const kind = soleKind(direct, where, useCase, findings);
+    const kind = soleKind(direct, where, task, findings);
     if (kind === null) return null;
     if (
       !uniqueStems(
@@ -302,7 +302,7 @@ function splitLayout(
   for (const [dir, dirFiles] of [...byDir.entries()].sort(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    const kind = soleKind(dirFiles, `'${dir}/'`, useCase, findings);
+    const kind = soleKind(dirFiles, `'${dir}/'`, task, findings);
     if (kind === null) return null;
     const name = toSnakeCase(dir);
     if (views.has(name)) {
@@ -347,13 +347,13 @@ function splitLayout(
 function soleKind(
   files: KeptFile[],
   where: string,
-  useCase: RawUseCase,
+  task: RawTask,
   findings: LayoutFinding[],
 ): MediaFileKind | null {
   const kinds = [...new Set(files.map((file) => file.kind))].sort();
   if (kinds.length === 1) return kinds[0];
   const hint =
-    useCase === "image_text_entity_linking"
+    task === "image_text_entity_linking"
       ? " For image–text linking, put images and texts in separate view folders (image/ + text/)."
       : "";
   findings.push({

--- a/ui/apps/pixano/src/components/library/import-wizard/rawSchema.ts
+++ b/ui/apps/pixano/src/components/library/import-wizard/rawSchema.ts
@@ -6,7 +6,7 @@ License: CECILL-C
 
 /** The raw-media schema builder: pure helpers turning wizard fields into a spec `schema`. */
 
-import type { LayoutPreflight, RawUseCase } from "./layoutPreflight";
+import type { LayoutPreflight, RawTask } from "./layoutPreflight";
 
 export type RawFramesMode = "extract" | "reference";
 export type AttrType = "str" | "int" | "float" | "bool";
@@ -20,7 +20,7 @@ export interface AttrRow {
 }
 
 export interface RawFields {
-  useCase: RawUseCase;
+  task: RawTask;
   framesMode: RawFramesMode; // video only
   maxFrames: string; // video, extract mode
   recordAttrs: AttrRow[];
@@ -29,51 +29,51 @@ export interface RawFields {
   layout: LayoutPreflight | null; // derived from the picked folder before upload
 }
 
-/** The use-case cards: labels + the folder layout each one expects. */
-export const USE_CASE_CARDS: {
-  useCase: RawUseCase;
+/** The task cards: labels + the folder layout each one expects. */
+export const TASK_CARDS: {
+  task: RawTask;
   title: string;
   blurb: string;
   layoutHint: string;
 }[] = [
   {
-    useCase: "image",
+    task: "image",
     title: "Image annotation",
     blurb: "Detect, segment, classify objects on images — one or several views per record.",
     layoutHint:
       "photos/\n├─ a.jpg  b.jpg …      (single view)\n└─ or left/ right/ …   (views, same file names pair up)",
   },
   {
-    useCase: "video",
+    task: "video",
     title: "Video annotation",
     blurb: "Track objects across frames — videos import as annotatable frame sequences.",
     layoutHint:
       "clips/\n├─ v1.mp4  v2.mp4 …    (single view)\n└─ or front/ side/ …   (views, same file names pair up)",
   },
   {
-    useCase: "image_vqa",
+    task: "image_vqa",
     title: "Visual Q&A",
     blurb: "Ask and answer questions about images — conversations attach to each record.",
     layoutHint: "photos/\n└─ a.jpg  b.jpg …      (questions are added in Pixano)",
   },
   {
-    useCase: "image_text_entity_linking",
+    task: "image_text_entity_linking",
     title: "Image–text linking",
     blurb: "Link mentions in a text to regions in an image (multimodal entity linking).",
     layoutHint: "pairs/\n├─ image/  a.jpg  b.jpg\n└─ text/   a.txt  b.txt  (same names pair up)",
   },
 ];
 
-/** Annotation slots pre-selected per use case (what most users annotate). */
-export const DEFAULT_ANNOTATIONS: Record<RawUseCase, string[]> = {
+/** Annotation slots pre-selected per task (what most users annotate). */
+export const DEFAULT_ANNOTATIONS: Record<RawTask, string[]> = {
   image: ["bbox", "mask", "keypoint", "classification"],
   video: ["bbox", "mask", "keypoint", "tracklet"],
   image_vqa: ["message"],
   image_text_entity_linking: ["text_span", "bbox", "mask"],
 };
 
-/** Annotation slots offered per use case (the declarative-dialect subset that fits each). */
-export const ANNOTATION_CHOICES: Record<RawUseCase, string[]> = {
+/** Annotation slots offered per task (the declarative-dialect subset that fits each). */
+export const ANNOTATION_CHOICES: Record<RawTask, string[]> = {
   image: ["bbox", "mask", "keypoint", "multi_path", "classification", "relation"],
   video: ["bbox", "mask", "keypoint", "multi_path", "classification", "tracklet", "relation"],
   image_vqa: ["message", "bbox", "mask", "classification"],
@@ -81,11 +81,11 @@ export const ANNOTATION_CHOICES: Record<RawUseCase, string[]> = {
 };
 
 /**
- * Slots the use case cannot work without (non-removable chips). A non-empty
+ * Slots the task cannot work without (non-removable chips). A non-empty
  * `schema.annotations` REPLACES the workspace preset's slots backend-side, so
  * the wizard must always re-list these.
  */
-export const LOCKED_ANNOTATIONS: Record<RawUseCase, string[]> = {
+export const LOCKED_ANNOTATIONS: Record<RawTask, string[]> = {
   image: [],
   video: [],
   image_vqa: ["message"],
@@ -95,7 +95,7 @@ export const LOCKED_ANNOTATIONS: Record<RawUseCase, string[]> = {
 export const ATTR_TYPES: AttrType[] = ["str", "int", "float", "bool"];
 
 export const DEFAULT_RAW_FIELDS: RawFields = {
-  useCase: "image",
+  task: "image",
   framesMode: "extract",
   maxFrames: "",
   recordAttrs: [],
@@ -153,7 +153,7 @@ export function validateAttrRows(rows: AttrRow[], label = "Attribute"): string {
 
 /** One validation message for the whole raw form; "" when analyzable. */
 export function validateRawFields(raw: RawFields): string {
-  if (raw.useCase === "video" && raw.maxFrames.trim() && !/^\d+$/.test(raw.maxFrames.trim())) {
+  if (raw.task === "video" && raw.maxFrames.trim() && !/^\d+$/.test(raw.maxFrames.trim())) {
     return "Max frames per video must be a whole number.";
   }
   if (!raw.annotations.length) {
@@ -183,7 +183,7 @@ function attrsPayload(rows: AttrRow[]): Record<string, unknown> {
 /**
  * Compile the raw form into spec fragments.
  *
- * The workspace is always the use case — that is what routes the dataset to
+ * The workspace is always the task — that is what routes the dataset to
  * the right annotation UI. Views are declared only when the preflight found
  * several (per-view folders); single-view sources rely on backend inference.
  * Annotations are always sent: a non-empty list replaces the preset's slots,
@@ -210,20 +210,20 @@ export function buildRawSchemaSpec(raw: RawFields): {
   if (raw.recordAttrs.length) schema.record = { attrs: attrsPayload(raw.recordAttrs) };
   if (raw.entityAttrs.length) schema.entity = { attrs: attrsPayload(raw.entityAttrs) };
   const annotations = [
-    ...LOCKED_ANNOTATIONS[raw.useCase].filter((slot) => !raw.annotations.includes(slot)),
+    ...LOCKED_ANNOTATIONS[raw.task].filter((slot) => !raw.annotations.includes(slot)),
     ...raw.annotations,
   ];
   if (annotations.length) schema.annotations = annotations;
 
   const options: Record<string, unknown> = {};
-  if (raw.useCase === "video") {
+  if (raw.task === "video") {
     if (raw.framesMode === "reference") options.frames = "reference";
     else if (raw.maxFrames.trim()) options.max_frames_per_video = Number(raw.maxFrames.trim());
   }
 
   return {
     schema,
-    workspace: raw.useCase,
+    workspace: raw.task,
     options: Object.keys(options).length ? options : undefined,
   };
 }

--- a/ui/apps/pixano/src/lib/api/__tests__/uploadClient.test.ts
+++ b/ui/apps/pixano/src/lib/api/__tests__/uploadClient.test.ts
@@ -4,7 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { matchesUseCase } from "$components/library/import-wizard/layoutPreflight";
+import { matchesTask } from "$components/library/import-wizard/layoutPreflight";
 import { describe, expect, it } from "vitest";
 
 import { filterSelection, splitFolderSelection } from "../uploadClient";
@@ -41,7 +41,7 @@ describe("splitFolderSelection", () => {
   });
 });
 
-describe("filterSelection with matchesUseCase", () => {
+describe("filterSelection with matchesTask", () => {
   const selection = splitFolderSelection([
     fakeFile("set/left/a.jpg", 100),
     fakeFile("set/right/a.JPG", 100),
@@ -52,7 +52,7 @@ describe("filterSelection with matchesUseCase", () => {
   ]);
 
   it("drops the stray metadata.jsonl and junk for an image import", () => {
-    const filtered = filterSelection(selection, (name) => matchesUseCase(name, "image"));
+    const filtered = filterSelection(selection, (name) => matchesTask(name, "image"));
     expect(filtered.entries.map((e) => e.relPath)).toEqual(["left/a.jpg", "right/a.JPG"]);
     expect(filtered.totalBytes).toBe(200); // metadata.jsonl / .DS_Store / notes.txt excluded
     expect(filtered.folderName).toBe("set");
@@ -60,7 +60,7 @@ describe("filterSelection with matchesUseCase", () => {
 
   it("keeps BOTH images and texts for a MEL import, dropping the rest", () => {
     const filtered = filterSelection(selection, (name) =>
-      matchesUseCase(name, "image_text_entity_linking"),
+      matchesTask(name, "image_text_entity_linking"),
     );
     expect(filtered.entries.map((e) => e.relPath)).toEqual([
       "left/a.jpg",
@@ -72,7 +72,7 @@ describe("filterSelection with matchesUseCase", () => {
 
   it("yields an empty selection when nothing matches (caller shows an error)", () => {
     const noVideos = splitFolderSelection([fakeFile("set/a.jpg", 1)]);
-    const filtered = filterSelection(noVideos, (name) => matchesUseCase(name, "video"));
+    const filtered = filterSelection(noVideos, (name) => matchesTask(name, "video"));
     expect(filtered.entries).toEqual([]);
   });
 });


### PR DESCRIPTION
## Issue

The import wizard's step-2 label reads **"Use case"**; it should read **"Task"**.

## Description

This lands a rename that was written during PR #701 but missed the merge train: PR #701 was squash-merged into `arch/data-import` from the pre-rename commit, and the rename commit was pushed to the branch immediately afterward — so `arch/data-import` still shows "Use case" and ships `RawUseCaseStep.svelte`, while the fix sat stranded on the (now-closed) feature branch. This PR cherry-picks that commit onto current `arch/data-import`.

It is the full, consistent concept rename — the visible label **and** the code, so nothing drifts:

- Step label `"Use case"` → **"Task"** (renders `TASK` in the stepper, matching `TYPE`/`SOURCE`/…).
- `RawUseCase` → `RawTask`, `useCase` → `task`, `USE_CASE_*` → `TASK_*`, `matchesUseCase` → `matchesTask`, `Step` value `"usecase"` → `"task"`.
- Component `RawUseCaseStep.svelte` → `RawTaskStep.svelte` (git-tracked rename).

**No behaviour change:** the workspace values the task maps to (`image` / `video` / `image_vqa` / `image_text_entity_linking`) are unchanged. Frontend only; backend untouched.

## Tests

- 154 vitest tests pass; `tsc --noEmit` + eslint clean; prettier clean; production build succeeds.
- Verified the built bundle contains `"Task","Source"` and no `"Use case"`.

> Note: after merge, rebuild the UI (`dist/` is gitignored) and hard-refresh the browser to clear the cached JS bundle — a stale bundle is why the old label still showed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)