### PR TITLE
chore: remove the deprecated File menu from the app header

### DIFF
--- a/ui/apps/pixano/src/components/library/import-wizard/ImportJobsTray.svelte
+++ b/ui/apps/pixano/src/components/library/import-wizard/ImportJobsTray.svelte
@@ -14,16 +14,10 @@ License: CECILL-C
     requestImportJobCancel,
   } from "$lib/stores/importJobsStore.svelte";
 
-  interface Props {
-    hidden?: boolean;
-  }
-
-  let { hidden = false }: Props = $props();
-
   const entries = $derived(visibleJobEntries(importJobsStore.value));
 </script>
 
-{#if !hidden && entries.length}
+{#if entries.length}
   <div class="fixed bottom-4 right-4 z-40 flex w-80 flex-col gap-2">
     {#each entries as entry (entry.jobId)}
       {@const terminal = isTerminalJob(entry.job.status)}

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -5,14 +5,12 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { DropdownMenu, Tooltip } from "bits-ui";
-  import { CaretDown, FolderOpen } from "phosphor-svelte";
+  import { Tooltip } from "bits-ui";
   import { fade } from "svelte/transition";
 
   import pixanoFavicon from "../assets/favicon.ico";
   import DatasetHeader from "../components/layout/DatasetHeader.svelte";
   import ImportJobsTray from "../components/library/import-wizard/ImportJobsTray.svelte";
-  import ImportWizard from "../components/library/import-wizard/ImportWizard.svelte";
   import type { LayoutProps } from "./$types";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
@@ -63,8 +61,6 @@ License: CECILL-C
     return () => window.removeEventListener("error", handleEffectDepthExceeded);
   });
 
-  let showImportModal = $state(false);
-
   async function navigateToHome() {
     await goto("/");
   }
@@ -100,39 +96,6 @@ License: CECILL-C
       </div>
 
       <div class="flex items-center gap-2 shrink-0">
-        <!-- File menu -->
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger
-            class="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg border border-border/60
-              bg-background/60 text-sm font-semibold text-foreground hover:bg-accent
-              hover:border-border transition-all duration-150 focus-visible:outline-none
-              focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            File
-            <CaretDown weight="bold" class="h-3 w-3 text-muted-foreground" />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              class="z-[300] min-w-[200px] rounded-xl border border-border bg-background/95
-                backdrop-blur-sm shadow-lg py-1.5 text-sm"
-              sideOffset={6}
-              align="end"
-            >
-              <DropdownMenu.Item
-                class="flex items-center gap-2.5 px-3 py-2 cursor-pointer rounded-lg mx-1
-                  text-foreground hover:bg-accent focus-visible:bg-accent
-                  focus-visible:outline-none transition-colors"
-                onSelect={() => {
-                  showImportModal = true;
-                }}
-              >
-                <FolderOpen weight="regular" class="h-4 w-4 text-muted-foreground" />
-                Import dataset…
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-
         <ThemeToggle mode={themeMode.value} onToggle={toggleTheme} />
       </div>
     </header>
@@ -144,13 +107,5 @@ License: CECILL-C
     </main>
   </div>
 
-  <ImportJobsTray hidden={showImportModal} />
-
-  {#if showImportModal}
-    <ImportWizard
-      onClose={() => {
-        showImportModal = false;
-      }}
-    />
-  {/if}
+  <ImportJobsTray />
 </Tooltip.Provider>


### PR DESCRIPTION
## Issue

The app header's "File" dropdown is deprecated — dataset import is now driven by the library page's Import button.

## Description

Removes the File menu from the global header (`routes/+layout.svelte`). Its single item, "Import dataset…", duplicated the library page's Import button, and it drove a second mounted `ImportWizard` instance in the layout. Along with the menu, the now-dead wiring goes too:

- the `showImportModal` flag and the layout's `ImportWizard` block + import,
- the `DropdownMenu` (bits-ui) and `CaretDown`/`FolderOpen` (phosphor) imports,
- `ImportJobsTray`'s `hidden` prop (its only binding was `hidden={showImportModal}`; the tray now simply renders whenever it has entries, matching the existing behavior of the library-page wizard path).

Net: 2 files, +3/−54. Behavior note: the File menu was the only import entry point on non-library routes; imports now start from the library page — the intended single entry point.

## Tests

- 154 vitest tests pass (no test referenced the menu); `tsc --noEmit` + eslint clean; prettier clean; production build succeeds.
- Grep-verified: no `DropdownMenu`, `showImportModal`, `CaretDown`, `FolderOpen`, or `ImportWizard` references remain in `+layout.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)