### PR TITLE
fix(web): 3D widget freeze after saving an annotation

### DIFF
--- a/ui/apps/web/src/lib/components/grid/GridWorkspace.svelte
+++ b/ui/apps/web/src/lib/components/grid/GridWorkspace.svelte
@@ -24,7 +24,9 @@ License: CECILL-C
   let { manager, registry }: Props = $props();
 
   let grid: GridStack;
-  let mountedWidgets: Map<string, Record<string, unknown>> = new Map();
+  // Value is the mounted Svelte component, or null while its deferred mount is
+  // still pending (see mountWidget).
+  let mountedWidgets: Map<string, Record<string, unknown> | null> = new Map();
   let lastManipulationEvent = 0;
 
   function mountWidget(widget: WidgetInstance) {
@@ -35,39 +37,68 @@ License: CECILL-C
     element.dataset.widgetId = widget.id;
     grid.el.appendChild(element);
 
-    const component = mount(WidgetFrame, {
-      target: element,
-      context: new Map<string, unknown>([["workspaceManager", manager]]),
-      props: {
-        widget,
-        config,
-        onRemove: () => manager.removeWidget(widget.id),
-      },
+    // Reserve the slot before the deferred mount so the reconciliation effect
+    // stays idempotent and unmountWidget can cancel a not-yet-run mount.
+    mountedWidgets.set(widget.id, null);
+
+    // Mount in a microtask, outside any reactive context. A component root
+    // created inside a re-running $effect is "detached" by Svelte on the next
+    // re-run while staying reachable from this component's effect tree; when
+    // such a half-detached root is later scheduled together with the app root
+    // in one flush, Svelte's scheduler permanently stops updating it (the
+    // widget freezes: toolbar, gizmos and resize go dead while the canvas
+    // keeps rendering). Deferring makes each widget an independent root from
+    // birth, which that scheduler conflict cannot reach.
+    queueMicrotask(() => {
+      // Unmounted (or workspace destroyed) before the mount could run. The
+      // element check covers an unmount + remount of the same id in between:
+      // only the latest attempt's element is still in the grid.
+      if (!mountedWidgets.has(widget.id) || !element.isConnected) return;
+
+      const component = mount(WidgetFrame, {
+        target: element,
+        context: new Map<string, unknown>([["workspaceManager", manager]]),
+        props: {
+          widget,
+          config,
+          onRemove: () => manager.removeWidget(widget.id),
+        },
+      });
+
+      mountedWidgets.set(widget.id, component);
+
+      // Honor the computed layout even when it is below the extension's default
+      // minW/minH; otherwise GridStack silently enlarges the widget and breaks
+      // the alignment of programmatically computed grids.
+      const minW = Math.min(widget.layout.w, config.defaultLayout.minW ?? 2);
+      const minH = Math.min(widget.layout.h, config.defaultLayout.minH ?? 2);
+
+      // Keep the stored spot when free, else drop into the next free spot (used
+      // when a re-shown widget's original slot was filled by a prior compaction).
+      // Registered only after the mount: GridStack resolves the drag handle
+      // (.grid-stack-handle, the frame's title bar) from the item's content when
+      // it wires dragging — registering an empty element would make the whole
+      // widget draggable from anywhere, including the 3D canvas.
+      placeWidget(grid, element, widget.id, widget.layout, minW, minH, manager);
     });
-
-    mountedWidgets.set(widget.id, component);
-
-    // Honor the computed layout even when it is below the extension's default
-    // minW/minH; otherwise GridStack silently enlarges the widget and breaks
-    // the alignment of programmatically computed grids.
-    const minW = Math.min(widget.layout.w, config.defaultLayout.minW ?? 2);
-    const minH = Math.min(widget.layout.h, config.defaultLayout.minH ?? 2);
-
-    // Keep the stored spot when free, else drop into the next free spot (used
-    // when a re-shown widget's original slot was filled by a prior compaction).
-    placeWidget(grid, element, widget.id, widget.layout, minW, minH, manager);
   }
 
   function unmountWidget(widgetId: string) {
-    const component = mountedWidgets.get(widgetId);
-    if (!component) return;
+    if (!mountedWidgets.has(widgetId)) return;
 
-    unmount(component);
+    // A null entry means the deferred mount hasn't run yet; deleting the entry
+    // cancels it (the microtask bails when the id is gone from the map).
+    const component = mountedWidgets.get(widgetId);
     mountedWidgets.delete(widgetId);
+    if (component) void unmount(component);
 
     const element = grid.getGridItems().find((i) => i.dataset.widgetId === widgetId);
     if (element) {
       grid.removeWidget(element, true);
+    } else {
+      // The deferred mount hadn't registered the element with GridStack yet;
+      // it is still a plain child of the grid container.
+      grid.el.querySelector(`[data-widget-id="${CSS.escape(widgetId)}"]`)?.remove();
     }
   }
 
@@ -185,7 +216,7 @@ License: CECILL-C
 
   onDestroy(() => {
     for (const component of mountedWidgets.values()) {
-      unmount(component);
+      if (component) void unmount(component);
     }
     mountedWidgets.clear();
 

--- a/ui/apps/web/src/lib/components/grid/__tests__/GridWorkspace.svelte.test.ts
+++ b/ui/apps/web/src/lib/components/grid/__tests__/GridWorkspace.svelte.test.ts
@@ -9,6 +9,7 @@ import { flushSync, tick } from "svelte";
 import { afterEach, describe, expect, it } from "vitest";
 
 import GridWorkspace from "../GridWorkspace.svelte";
+import StubReactiveWidget from "./StubReactiveWidget.svelte";
 import type { WidgetExtensionConfig } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 import type { DatasetGateway } from "$lib/workspace/datasetGateway.js";
@@ -66,6 +67,100 @@ describe("GridWorkspace — hide/show reflow", () => {
     flushSync();
     await tick();
     expect(mountedIds(container)).toEqual([top.id, bottom.id].sort());
+  });
+
+  it("keeps earlier-mounted widgets reactive after the mount effect re-runs", async () => {
+    // Guards the deferred-mount lifecycle (mount lands after a microtask, and
+    // widgets keep reacting across reconciliation re-runs + cross-root
+    // flushes). Context: mounting widget roots inside the reconciliation
+    // $effect let a later re-run detach them (Svelte nulls their parent while
+    // they stay reachable from this tree), after which a flush queueing both
+    // the app root and a detached widget root froze the widget for good, with
+    // no error thrown. That scheduler poisoning needs a tree topology jsdom
+    // doesn't reproduce, so this test can't fail for it — the freeze itself
+    // was verified fixed in the browser.
+    const reactiveConfig = {
+      ...stubConfig,
+      component: StubReactiveWidget,
+    } as WidgetExtensionConfig;
+    const reactiveRegistry = {
+      get: () => reactiveConfig,
+      getAll: () => [reactiveConfig],
+    } as unknown as WidgetRegistry;
+
+    const manager = new WorkspaceManager(reactiveRegistry, {} as DatasetGateway);
+
+    const { container } = render(GridWorkspace, {
+      props: { manager, registry: reactiveRegistry },
+    });
+    await tick();
+
+    // Widget added after initial render: mounted by the reconciliation
+    // $effect. A further re-run of that effect is what used to detach it.
+    manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } });
+    flushSync();
+    await tick();
+    await Promise.resolve(); // let the deferred widget mount run
+    await tick();
+    expect(container.querySelectorAll("[data-testid='preset-name']")).toHaveLength(1);
+
+    // Further batches: each add re-runs the $effect (used to detach the
+    // previously mounted widget roots while they stayed reachable from this
+    // tree).
+    for (let i = 1; i <= 3; i++) {
+      manager.addWidget("stub", { layout: { x: 0, y: 6 * i, w: 6, h: 6 } });
+      flushSync();
+      await tick();
+      await Promise.resolve();
+      await tick();
+    }
+
+    // One flush dirtying both the workspace tree (editMode) and the widget
+    // roots (presetName) — the poisoning pattern — followed by a second write:
+    // the widgets must still re-render it.
+    manager.editMode = false;
+    manager.presetName = "First";
+    await tick();
+    manager.presetName = "Second";
+    await tick();
+
+    const labels = [...container.querySelectorAll("[data-testid='preset-name']")];
+    expect(labels).toHaveLength(4);
+    for (const label of labels) {
+      expect(label.textContent).toBe("Second");
+    }
+  });
+
+  it("cancels a deferred mount when the widget is removed before it runs", async () => {
+    // Removal in the same synchronous batch as the add: the widget's Svelte
+    // component must never mount, and the placeholder element (not yet
+    // registered with GridStack at that point) must be removed from the DOM.
+    const reactiveConfig = {
+      ...stubConfig,
+      component: StubReactiveWidget,
+    } as WidgetExtensionConfig;
+    const reactiveRegistry = {
+      get: () => reactiveConfig,
+      getAll: () => [reactiveConfig],
+    } as unknown as WidgetRegistry;
+
+    const manager = new WorkspaceManager(reactiveRegistry, {} as DatasetGateway);
+    const { container } = render(GridWorkspace, {
+      props: { manager, registry: reactiveRegistry },
+    });
+    await tick();
+
+    const widget = manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } })!;
+    flushSync(); // reconciliation effect appends the element and defers the mount
+    manager.removeWidget(widget.id);
+    flushSync(); // unmount runs before the deferred mount's microtask
+
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    expect(container.querySelectorAll("[data-widget-id]")).toHaveLength(0);
+    expect(container.querySelectorAll("[data-testid='preset-name']")).toHaveLength(0);
   });
 
   it("does not compact when a widget is removed (not hidden)", async () => {

--- a/ui/apps/web/src/lib/components/grid/__tests__/StubReactiveWidget.svelte
+++ b/ui/apps/web/src/lib/components/grid/__tests__/StubReactiveWidget.svelte
@@ -1,0 +1,15 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { getContext } from "svelte";
+
+  import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
+
+  const manager = getContext<WorkspaceManager>("workspaceManager");
+</script>
+
+<span data-testid="preset-name">{manager.presetName}</span>


### PR DESCRIPTION
## Why

Saving an annotation (2D or 3D box, reliably when editing an existing one) partially froze the point-cloud widget: toolbar, orbit indicator, box picking and resize went dead while camera navigation kept working, with zero console output. Saving again temporarily healed it.

## Root cause

An upstream Svelte 5 scheduler bug (still present in 5.56.7): component roots `mount()`ed inside a re-running `$effect` (GridWorkspace's widget reconciliation) are detached on the next re-run while staying reachable from the workspace tree. A flush that queues both the app root and such a half-detached widget root traverses it twice, and the `CLEAN` XOR toggle leaves it permanently flagged as "already scheduled" — every later update under it silently bails.

## Fix

Defer each widget `mount()` to a microtask so widget roots are independent from birth, out of reach of that scheduler conflict. GridStack registration also moves after the mount so the drag handle resolves to the title bar (registering an empty element made the whole widget draggable from the 3D canvas). Includes lifecycle regression tests (reactivity across reconciliation re-runs, cancellation of a not-yet-run deferred mount).

Verified in-browser on Nuscenes tri3d: widget stays fully live after save/flush, resize re-fits the cloud, canvas drag orbits without moving the widget.

Note: this repo's `frontend/next-ui-init` is behind the fork's, so earlier fork-side commits (#2–#6 there) appear in this PR until the base catches up; the fix itself is the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)