### PR TITLE
chore(ui): upgrade eslint-plugin-svelte to 3.x + widget error boundary

### DIFF
--- a/ui/apps/pixano/src/components/dataset/FilterTable.svelte
+++ b/ui/apps/pixano/src/components/dataset/FilterTable.svelte
@@ -51,6 +51,7 @@ License: CECILL-C
   // cosmetic: use a ghost span to measure width and adjust select width accordingly
   function updateWidth() {
     if (!ghostEl || !selectEl) return;
+    // eslint-disable-next-line svelte/no-dom-manipulating -- measurement-only ghost span, never rendered from reactive state
     ghostEl.textContent = selectedCol;
     const width = ghostEl.getBoundingClientRect().width + 10; // +padding
     selectWidth = Math.max(width, 50); // min width
@@ -90,7 +91,7 @@ License: CECILL-C
     class="h-10 pl-10 pr-4 rounded-lg border font-normal text-foreground placeholder-muted-foreground bg-background border-border shadow-sm"
     onchange={handleFilterText}
   />
-  <IconButton onclick={handleClearFilter} tooltipContent={"Clear filter"}>
+  <IconButton onclick={handleClearFilter} tooltipContent="Clear filter">
     <Prohibit weight="regular" />
   </IconButton>
 </div>

--- a/ui/apps/pixano/src/components/ui/autoresize-textarea/autoresize-textarea.svelte
+++ b/ui/apps/pixano/src/components/ui/autoresize-textarea/autoresize-textarea.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import { tick } from "svelte";
   import type { HTMLTextareaAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/card/card-content.svelte
+++ b/ui/apps/pixano/src/components/ui/card/card-content.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import type { Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/card/card-description.svelte
+++ b/ui/apps/pixano/src/components/ui/card/card-description.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import type { Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/card/card-footer.svelte
+++ b/ui/apps/pixano/src/components/ui/card/card-footer.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import type { Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/card/card-header.svelte
+++ b/ui/apps/pixano/src/components/ui/card/card-header.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import type { Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/card/card-title.svelte
+++ b/ui/apps/pixano/src/components/ui/card/card-title.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import type { Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/card/card.svelte
+++ b/ui/apps/pixano/src/components/ui/card/card.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   import type { Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/ui/input/input.svelte
+++ b/ui/apps/pixano/src/components/ui/input/input.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   // Imports
   import type { Snippet } from "svelte";
   import type { HTMLInputAttributes } from "svelte/elements";

--- a/ui/apps/pixano/src/components/ui/skeleton/skeleton.svelte
+++ b/ui/apps/pixano/src/components/ui/skeleton/skeleton.svelte
@@ -5,7 +5,6 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  /* eslint-disable svelte/valid-compile */
   // Imports
   import type { HTMLAttributes } from "svelte/elements";
 

--- a/ui/apps/pixano/src/components/workspace/Toolbar/FusionTool.svelte
+++ b/ui/apps/pixano/src/components/workspace/Toolbar/FusionTool.svelte
@@ -122,14 +122,14 @@ License: CECILL-C
       class="flex items-center gap-0.5 animate-in fade-in slide-in-from-left-1 duration-500 bg-background/60 backdrop-blur-sm rounded-lg p-0.5 border border-border/40 shadow-sm ml-0.5"
     >
       <IconButton
-        tooltipContent={"Validate association (S / Enter)"}
+        tooltipContent="Validate association (S / Enter)"
         onclick={onValidate}
         class="h-8 w-8 text-success/80 hover:bg-success/5"
       >
         <Check class="h-4.5 w-4.5" />
       </IconButton>
       <IconButton
-        tooltipContent={"Abort association (Escape)"}
+        tooltipContent="Abort association (Escape)"
         onclick={onAbort}
         class="h-8 w-8 text-destructive/80 hover:bg-destructive/5"
       >

--- a/ui/apps/web/src/lib/components/grid/WidgetFrame.svelte
+++ b/ui/apps/web/src/lib/components/grid/WidgetFrame.svelte
@@ -18,6 +18,14 @@ License: CECILL-C
   let { widget, config, onRemove }: Props = $props();
 
   let WidgetComponent = $derived(config.component);
+
+  function reportWidgetError(error: unknown) {
+    console.error(`Widget "${widget.title}" crashed:`, error);
+  }
+
+  function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
 </script>
 
 <div
@@ -38,7 +46,26 @@ License: CECILL-C
 
   <div class="flex-1 overflow-hidden">
     {#if WidgetComponent}
-      <WidgetComponent widgetId={widget.id} options={widget.options} data={widget.data} />
+      <!-- Contain widget crashes: without a boundary, one throwing widget can
+           silently break the reactivity of the surrounding workspace. -->
+      <svelte:boundary onerror={reportWidgetError}>
+        <WidgetComponent widgetId={widget.id} options={widget.options} data={widget.data} />
+
+        {#snippet failed(error, reset)}
+          <div
+            class="flex h-full flex-col items-center justify-center gap-2 overflow-auto p-4 text-center"
+          >
+            <p class="text-sm font-medium text-destructive">This widget crashed.</p>
+            <p class="text-xs text-muted-foreground">{errorMessage(error)}</p>
+            <button
+              onclick={reset}
+              class="cursor-pointer rounded border border-border px-2 py-1 text-xs text-card-foreground hover:bg-muted"
+            >
+              Reload widget
+            </button>
+          </div>
+        {/snippet}
+      </svelte:boundary>
     {/if}
   </div>
 </div>

--- a/ui/apps/web/src/lib/components/grid/__tests__/ThrowingWidget.svelte
+++ b/ui/apps/web/src/lib/components/grid/__tests__/ThrowingWidget.svelte
@@ -1,0 +1,28 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  interface Props {
+    widgetId: string;
+    // The test passes a mutable flag through options so a boundary reset() can
+    // re-create the component against a new value.
+    options: { crash: { value: boolean } };
+    data?: Record<string, unknown>;
+  }
+
+  let { options }: Props = $props();
+
+  // Called from the template so the throw happens during render, where a
+  // <svelte:boundary> can catch it; a reset() re-renders and re-reads the flag.
+  function assertAlive(): string {
+    if (options.crash.value) {
+      throw new Error("widget exploded");
+    }
+    return "alive";
+  }
+</script>
+
+<span data-testid="widget-alive">{assertAlive()}</span>

--- a/ui/apps/web/src/lib/components/grid/__tests__/WidgetFrame.svelte.test.ts
+++ b/ui/apps/web/src/lib/components/grid/__tests__/WidgetFrame.svelte.test.ts
@@ -1,0 +1,65 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { cleanup, render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import WidgetFrame from "../WidgetFrame.svelte";
+import ThrowingWidget from "./ThrowingWidget.svelte";
+import type { WidgetExtensionConfig, WidgetInstance } from "$lib/extensions/types.js";
+
+afterEach(() => cleanup());
+
+describe("WidgetFrame — error boundary", () => {
+  it("shows a fallback on widget crash and recovers through reset", async () => {
+    const crash = { value: true };
+    const widget: WidgetInstance = {
+      id: "w1",
+      extensionName: "throwing",
+      title: "Flaky widget",
+      layout: { x: 0, y: 0, w: 6, h: 6 },
+      options: { crash },
+    };
+    const config = {
+      name: "throwing",
+      label: "Throwing",
+      icon: "square",
+      defaultLayout: { x: 0, y: 0, w: 6, h: 6 },
+      component: ThrowingWidget,
+    } as unknown as WidgetExtensionConfig;
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { container, getByText } = render(WidgetFrame, {
+        props: { widget, config, onRemove: () => {} },
+      });
+      await tick();
+
+      // The crash is contained: fallback + error message shown, frame (title
+      // bar) still alive, and the error was reported with the widget's name.
+      expect(container.querySelectorAll("[data-testid='widget-alive']")).toHaveLength(0);
+      expect(getByText("This widget crashed.")).toBeTruthy();
+      expect(getByText("widget exploded")).toBeTruthy();
+      expect(getByText("Flaky widget")).toBeTruthy();
+      expect(
+        consoleError.mock.calls.some((args) =>
+          String(args[0]).includes('Widget "Flaky widget" crashed'),
+        ),
+      ).toBe(true);
+
+      // reset() re-creates the widget content; with the crash flag cleared the
+      // widget renders normally again.
+      crash.value = false;
+      getByText("Reload widget").click();
+      await tick();
+      expect(container.querySelectorAll("[data-testid='widget-alive']")).toHaveLength(1);
+      expect(container.querySelectorAll("button").length).toBeGreaterThan(0); // frame close button still there
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -5,6 +5,7 @@ import js from "@eslint/js";
 import eslint from "@eslint/js";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
+import svelte from "eslint-plugin-svelte";
 import globals from "globals";
 import svelteParser from "svelte-eslint-parser";
 import tseslint from "typescript-eslint";
@@ -26,16 +27,26 @@ export default [
       "**/tailwind.config.cjs",
       "**/postcss.config.cjs",
       "**/vite.config.ts",
-      ".svelte-kit/**/*",
+      "**/vitest.config.ts",
+      "**/vitest.setup.ts",
+      "**/pixano-aliases.js",
+      // Generated output (eslint-plugin-svelte 2.x happened to skip these; with
+      // 3.x they must be ignored explicitly, and the old root-relative
+      // ".svelte-kit/**/*" pattern never covered the per-app directories).
+      "**/.svelte-kit/**",
+      "**/coverage/**",
+      "apps/*/build/**",
       "**/mask_utils.ts",
     ],
   },
   ...compat.extends(
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended-type-checked",
-    "plugin:svelte/recommended",
     "prettier",
   ),
+  // eslint-plugin-svelte 3.x ships native flat configs; the legacy eslintrc
+  // "plugin:svelte/recommended" shareable config no longer exists.
+  ...svelte.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
@@ -88,6 +99,16 @@ export default [
         },
       ],
       "svelte/no-inner-declarations": "off",
+      // Rules newly enabled by eslint-plugin-svelte 3.x "recommended" that
+      // require real refactors of existing (mostly apps/pixano) code. Disabled
+      // during the 2.x → 3.x upgrade to keep it behavior-neutral; re-enable
+      // rule by rule as the offending code gets cleaned up.
+      "svelte/require-each-key": "off",
+      "svelte/prefer-svelte-reactivity": "off",
+      "svelte/no-navigation-without-resolve": "off",
+      "svelte/prefer-writable-derived": "off",
+      "svelte/no-useless-children-snippet": "off",
+      "svelte/no-unused-props": "off",
     },
   },
   {

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,11 +19,11 @@
     "@typescript-eslint/parser": "^8.24.1",
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-svelte": "^2.46.1",
+    "eslint-plugin-svelte": "^3.22.0",
     "globals": "^16.0.0",
     "prettier": "^3.2.5",
     "prettier-plugin-svelte": "^3.3.2",
-    "svelte-eslint-parser": "^0.43.0",
+    "svelte-eslint-parser": "^1.8.0",
     "turbo": "^2.8.20",
     "typescript-eslint": "^8.24.1"
   },

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.20.1(jiti@2.6.1))
       eslint-plugin-svelte:
-        specifier: ^2.46.1
-        version: 2.46.1(eslint@9.20.1(jiti@2.6.1))(svelte@5.51.2)
+        specifier: ^3.22.0
+        version: 3.22.0(eslint@9.20.1(jiti@2.6.1))(svelte@5.51.2)
       globals:
         specifier: ^16.0.0
         version: 16.0.0
@@ -42,8 +42,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.3(prettier@3.5.1)(svelte@5.51.2)
       svelte-eslint-parser:
-        specifier: ^0.43.0
-        version: 0.43.0(svelte@5.51.2)
+        specifier: ^1.8.0
+        version: 1.8.0(svelte@5.51.2)
       turbo:
         specifier: ^2.8.20
         version: 2.8.20
@@ -635,6 +635,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/eslint-utils@4.4.1':
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
@@ -2190,31 +2196,21 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-compat-utils@0.5.1:
-    resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      eslint: '>=6.0.0'
-
   eslint-config-prettier@9.1.0:
     resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-svelte@2.46.1:
-    resolution: {integrity: sha512-7xYr2o4NID/f9OEYMqxsEQsCsj4KaMy4q5sANaKkAb6/QeCjYFxRmDm2S3YC3A3pl1kyPZ/syOx/i7LcWYSbIw==}
-    engines: {node: ^14.17.0 || >=16.0.0}
+  eslint-plugin-svelte@3.22.0:
+    resolution: {integrity: sha512-O3qn0NePTWta+1o25dIThqeEP/hEQ3VxDK2LVO8SQ5wG9umLMvulK+m1yQ4JGOb2Pkl8IB0G1lpRV/HXDXSLTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0-0 || ^9.0.0-0
+      eslint: ^8.57.1 || ^9.0.0 || ^10.0.0
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
-
-  eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   eslint-scope@8.2.0:
     resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
@@ -2244,10 +2240,6 @@ packages:
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  espree@9.6.1:
-    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -2559,8 +2551,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  known-css-properties@0.35.0:
-    resolution: {integrity: sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==}
+  known-css-properties@0.37.0:
+    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
 
   konva@9.3.18:
     resolution: {integrity: sha512-ad5h0Y9phUrinBrKXyIISbURRHQO7Rx5cz7mAEEfdVCs45gDqRD8Y0I0nJRk8S6iqEbiRE87CEZu5GVSnU8oow==}
@@ -2977,11 +2969,11 @@ packages:
       ts-node:
         optional: true
 
-  postcss-safe-parser@6.0.0:
-    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
-    engines: {node: '>=12.0'}
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.3.3
+      postcss: ^8.4.31
 
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
@@ -2989,8 +2981,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.29
 
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+  postcss-selector-parser@7.1.4:
+    resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
 
   postcss@8.5.3:
@@ -3184,6 +3176,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
 
@@ -3268,9 +3265,9 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
-  svelte-eslint-parser@0.43.0:
-    resolution: {integrity: sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  svelte-eslint-parser@1.8.0:
+    resolution: {integrity: sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.34.1}
     peerDependencies:
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
@@ -3894,6 +3891,11 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.20.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.20.1(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.4.1(eslint@9.20.1(jiti@2.6.1))':
     dependencies:
       eslint: 9.20.1(jiti@2.6.1)
@@ -3990,13 +3992,13 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -4021,7 +4023,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@kurkle/color@0.3.4': {}
 
@@ -5543,38 +5545,27 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.20.1(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.20.1(jiti@2.6.1)
-      semver: 7.7.1
-
   eslint-config-prettier@9.1.0(eslint@9.20.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.20.1(jiti@2.6.1)
 
-  eslint-plugin-svelte@2.46.1(eslint@9.20.1(jiti@2.6.1))(svelte@5.51.2):
+  eslint-plugin-svelte@3.22.0(eslint@9.20.1(jiti@2.6.1))(svelte@5.51.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.20.1(jiti@2.6.1))
       '@jridgewell/sourcemap-codec': 1.5.0
       eslint: 9.20.1(jiti@2.6.1)
-      eslint-compat-utils: 0.5.1(eslint@9.20.1(jiti@2.6.1))
       esutils: 2.0.3
-      known-css-properties: 0.35.0
+      globals: 16.0.0
+      known-css-properties: 0.37.0
       postcss: 8.5.3
       postcss-load-config: 3.1.4(postcss@8.5.3)
-      postcss-safe-parser: 6.0.0(postcss@8.5.3)
-      postcss-selector-parser: 6.1.2
+      postcss-safe-parser: 7.0.1(postcss@8.5.3)
       semver: 7.7.1
-      svelte-eslint-parser: 0.43.0(svelte@5.51.2)
+      svelte-eslint-parser: 1.8.0(svelte@5.51.2)
     optionalDependencies:
       svelte: 5.51.2
     transitivePeerDependencies:
       - ts-node
-
-  eslint-scope@7.2.2:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
 
   eslint-scope@8.2.0:
     dependencies:
@@ -5634,19 +5625,13 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.0
 
-  espree@9.6.1:
-    dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint-visitor-keys: 3.4.3
-
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
 
   esrap@2.2.3:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -5934,7 +5919,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  known-css-properties@0.35.0: {}
+  known-css-properties@0.37.0: {}
 
   konva@9.3.18: {}
 
@@ -6046,7 +6031,7 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.21:
     dependencies:
@@ -6342,7 +6327,7 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.3
 
-  postcss-safe-parser@6.0.0(postcss@8.5.3):
+  postcss-safe-parser@7.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
@@ -6350,7 +6335,7 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
-  postcss-selector-parser@6.1.2:
+  postcss-selector-parser@7.1.4:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -6638,6 +6623,8 @@ snapshots:
 
   semver@7.7.1: {}
 
+  semver@7.8.5: {}
+
   set-cookie-parser@3.0.1: {}
 
   shebang-command@2.0.0:
@@ -6723,13 +6710,15 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.43.0(svelte@5.51.2):
+  svelte-eslint-parser@1.8.0(svelte@5.51.2):
     dependencies:
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
+      eslint-scope: 8.2.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
       postcss: 8.5.3
       postcss-scss: 4.0.9(postcss@8.5.3)
+      postcss-selector-parser: 7.1.4
+      semver: 7.8.5
     optionalDependencies:
       svelte: 5.51.2
 
@@ -6763,7 +6752,7 @@ snapshots:
   svelte@5.51.2:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
       '@types/estree': 1.0.6
       '@types/trusted-types': 2.0.7


### PR DESCRIPTION
Stacked on #708 (its commits appear here until it merges).

## Why

eslint-plugin-svelte 2.46.1 could not parse `<svelte:boundary>` ("Parsing error: Unknown type: SvelteBoundary"), which blocked the follow-up hardening from the 3D-widget freeze fix (#708).

## Changes

**chore(ui): upgrade eslint-plugin-svelte 2.x -> 3.x** — 3.22.0 + svelte-eslint-parser 1.8.0; config migrated to the plugin's native flat configs; generated output (`.svelte-kit`, `build`, `coverage`) and untypechecked config helpers explicitly ignored; six new 3.x recommended rules that would require real refactors of legacy code disabled with a TODO; trivial safe fixes applied (useless mustaches, obsolete `valid-compile` disable directives, one scoped `no-dom-manipulating` disable).

**feat(web): contain widget crashes with `<svelte:boundary>`** — a crashing widget now shows an error panel (message + "Reload widget" calling `reset()`) and logs the error with the widget's name, instead of silently breaking the surrounding workspace's reactivity. Covered by a dedicated WidgetFrame test.

## Verification

- Full-workspace lint diffed against a 2.x baseline: **zero new errors** (pre-existing count drops 294 → 146, the delta being generated-file noise now ignored).
- `turbo lint` (apps/pixano tsc + eslint) passes; svelte-check unchanged (41 pre-existing).
- 286/286 vitest tests; prettier + pre-commit clean.
- In-browser smoke on Nuscenes tri3d: all widgets mount, 3D toolbar reactive, orbit drag doesn't move the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)