### PR TITLE
feat: record-level semantic search (foundation)

### DIFF
--- a/src/pixano/api/embeddings.py
+++ b/src/pixano/api/embeddings.py
@@ -1,0 +1,164 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Record-embedding computation job.
+
+Computes one CLIP-style vector per record from its image view by calling the connected
+pixano-inference provider, writes the vectors to the dataset's record-embedding table, and builds
+the vector index. Runs in a background thread tracked in the shared `JobStore`, so progress is
+polled through the existing ``/io/jobs/{id}`` endpoint. Idempotent: records already embedded are
+skipped (resume-safe).
+"""
+
+import asyncio
+import logging
+import os
+import threading
+import traceback
+from pathlib import Path
+from typing import Any
+
+from pixano.datasets.dataset import Dataset
+from pixano.datasets.io.jobs import JobSink, JobStore
+from pixano.datasets.io.progress import ProgressEvent
+from pixano.inference.media import bytes_to_data_uri
+from pixano.inference.provider import InferenceProvider
+from pixano.inference.types import EmbeddingInput, EmbeddingResult
+
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_TABLE = "images"
+_EMBED_BATCH = 16
+
+
+def _resolve_image_ref(dataset: Dataset, image: Any) -> str | None:
+    """Resolve an image row to a value the embedding endpoint accepts (data-URI or URL).
+
+    ``raw_bytes`` is a blob column excluded from `get_data`'s default projection, so embedded
+    images are fetched via `get_view_binary`; datalake images pass their URI through.
+    """
+    uri = getattr(image, "uri", None)
+    if uri:
+        return uri
+    result = dataset.get_view_binary(_IMAGE_TABLE, image.id)
+    if result is not None:
+        blob, _ = result
+        if blob:
+            return bytes_to_data_uri(blob)
+    return None
+
+
+def _embed_images(provider: InferenceProvider, model: str, images: list[str]) -> list[list[float]]:
+    """Call the provider's (async) embedding task for a batch of images, on this thread."""
+
+    async def _call() -> EmbeddingResult:
+        return await provider.embedding(EmbeddingInput(model=model, image=images))
+
+    result = asyncio.run(_call())
+    dim = result.data.dim
+    values = result.data.embedding.values
+    return [values[i * dim : (i + 1) * dim] for i in range(len(images))]
+
+
+def _run_embedding_job(
+    store: JobStore,
+    job_id: str,
+    dataset_path: Path,
+    provider: InferenceProvider,
+    model: str,
+    batch_size: int,
+) -> None:
+    dataset = Dataset(dataset_path)
+    store.update_job(job_id, status="running", pid=os.getpid(), heartbeat=True)
+    sink = JobSink(store, job_id)
+    try:
+        record_ids: list[str] = dataset.get_all_ids("records")
+        already: set[str] = set()
+        if dataset.has_record_embeddings():
+            existing = dataset.get_data(dataset._RECORD_EMBEDDING_TABLE, limit=None)  # noqa: SLF001
+            already = {row.record_id for row in (existing or [])}
+        pending = [rid for rid in record_ids if rid not in already]
+        total = len(record_ids)
+        done = len(already)
+        sink.emit(ProgressEvent(phase="embed", done=done, total=total, unit="records"))
+
+        for start in range(0, len(pending), batch_size):
+            if store.cancel_requested(job_id):
+                store.update_job(job_id, status="cancelled")
+                return
+            batch_ids = pending[start : start + batch_size]
+            images = dataset.get_data(_IMAGE_TABLE, record_ids=batch_ids) or []
+            by_record: dict[str, Any] = {}
+            for image in images:
+                by_record.setdefault(image.record_id, image)
+
+            refs: list[str] = []
+            ordered_ids: list[str] = []
+            for rid in batch_ids:
+                image = by_record.get(rid)
+                ref = _resolve_image_ref(dataset, image) if image is not None else None
+                if ref is not None:
+                    refs.append(ref)
+                    ordered_ids.append(rid)
+
+            if refs:
+                vectors = _embed_images(provider, model, refs)
+                if not dataset.has_record_embeddings():
+                    dataset.create_record_embedding_table(dim=len(vectors[0]), model_id=model)
+                dataset.add_record_embeddings(
+                    [
+                        {"record_id": rid, "view_id": by_record[rid].id, "vector": vector}
+                        for rid, vector in zip(ordered_ids, vectors, strict=True)
+                    ]
+                )
+            done += len(batch_ids)
+            sink.emit(ProgressEvent(phase="embed", done=done, total=total, unit="records"))
+
+        if dataset.has_record_embeddings():
+            sink.emit(ProgressEvent(phase="finalize", done=total, total=total, message="Building index"))
+            dataset.build_record_embedding_index()
+
+        # Drop the API's cached Dataset so the newly written embeddings sidecar is picked up —
+        # before marking the job done, so a client that polls "done" then queries sees embeddings.
+        Dataset.invalidate_caches(dataset.info.id)
+        store.update_job(
+            job_id,
+            status="done",
+            progress=ProgressEvent(phase="embed", done=total, total=total, final=True).model_dump(),
+        )
+    except Exception as exc:  # noqa: BLE001 - surface as job error
+        logger.exception("Embedding job %s failed", job_id)
+        store.update_job(
+            job_id,
+            status="error",
+            error={"type": type(exc).__name__, "message": str(exc), "trace": traceback.format_exc()},
+        )
+    finally:
+        sink.close()
+
+
+def submit_embedding_job(
+    store: JobStore,
+    dataset_path: Path,
+    dataset_id: str,
+    provider: InferenceProvider,
+    model: str,
+    batch_size: int = _EMBED_BATCH,
+) -> str:
+    """Create an embedding job and start it in a background daemon thread.
+
+    Returns:
+        The job id (poll via ``GET /io/jobs/{id}``).
+    """
+    job = store.create_job(kind="embed", dataset=dataset_id, spec={"model": model})
+    thread = threading.Thread(
+        target=_run_embedding_job,
+        args=(store, job.id, dataset_path, provider, model, batch_size),
+        daemon=True,
+    )
+    thread.start()
+    return job.id

--- a/src/pixano/api/embeddings.py
+++ b/src/pixano/api/embeddings.py
@@ -13,7 +13,6 @@ polled through the existing ``/io/jobs/{id}`` endpoint. Idempotent: records alre
 skipped (resume-safe).
 """
 
-import asyncio
 import logging
 import os
 import threading
@@ -21,12 +20,13 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+from pixano_inference_client import EmbeddingRequest, SyncPixanoInferenceClient
+
 from pixano.datasets.dataset import Dataset
 from pixano.datasets.io.jobs import JobSink, JobStore
 from pixano.datasets.io.progress import ProgressEvent
 from pixano.inference.media import bytes_to_data_uri
 from pixano.inference.provider import InferenceProvider
-from pixano.inference.types import EmbeddingInput, EmbeddingResult
 
 
 logger = logging.getLogger(__name__)
@@ -52,27 +52,27 @@ def _resolve_image_ref(dataset: Dataset, image: Any) -> str | None:
     return None
 
 
-def _embed_images(provider: InferenceProvider, model: str, images: list[str]) -> list[list[float]]:
-    """Call the provider's (async) embedding task for a batch of images, on this thread."""
+def _embed_images(client: SyncPixanoInferenceClient, model: str, images: list[str]) -> list[list[float]]:
+    """Embed a batch of images via the SYNCHRONOUS client.
 
-    async def _call() -> EmbeddingResult:
-        return await provider.embedding(EmbeddingInput(model=model, image=images))
-
-    result = asyncio.run(_call())
-    dim = result.data.dim
-    values = result.data.embedding.values
-    return [values[i * dim : (i + 1) * dim] for i in range(len(images))]
+    The compute job runs in its own thread, so it must NOT reuse the connected provider's async
+    httpx client (bound to the server's event loop); a fresh sync client avoids the cross-loop hang.
+    """
+    response = client.embedding(EmbeddingRequest(model=model, image=images))
+    return response.data.embeddings.to_numpy().tolist()
 
 
 def _run_embedding_job(
     store: JobStore,
     job_id: str,
     dataset_path: Path,
-    provider: InferenceProvider,
+    url: str,
+    api_key: str | None,
     model: str,
     batch_size: int,
 ) -> None:
     dataset = Dataset(dataset_path)
+    client = SyncPixanoInferenceClient(url, api_key=api_key)
     store.update_job(job_id, status="running", pid=os.getpid(), heartbeat=True)
     sink = JobSink(store, job_id)
     try:
@@ -106,7 +106,7 @@ def _run_embedding_job(
                     ordered_ids.append(rid)
 
             if refs:
-                vectors = _embed_images(provider, model, refs)
+                vectors = _embed_images(client, model, refs)
                 if not dataset.has_record_embeddings():
                     dataset.create_record_embedding_table(dim=len(vectors[0]), model_id=model)
                 dataset.add_record_embeddings(
@@ -139,6 +139,7 @@ def _run_embedding_job(
         )
     finally:
         sink.close()
+        client.close()
 
 
 def submit_embedding_job(
@@ -151,13 +152,20 @@ def submit_embedding_job(
 ) -> str:
     """Create an embedding job and start it in a background daemon thread.
 
+    The connected provider supplies the server URL/key; the job then talks to it through a fresh
+    synchronous client on its own thread.
+
     Returns:
         The job id (poll via ``GET /io/jobs/{id}``).
     """
+    url = getattr(provider, "url", None)
+    if not url:
+        raise ValueError("The connected provider does not expose a server URL for embedding.")
+    api_key = getattr(provider, "_api_key", None)
     job = store.create_job(kind="embed", dataset=dataset_id, spec={"model": model})
     thread = threading.Thread(
         target=_run_embedding_job,
-        args=(store, job.id, dataset_path, provider, model, batch_size),
+        args=(store, job.id, dataset_path, url, api_key, model, batch_size),
         daemon=True,
     )
     thread.start()

--- a/src/pixano/api/routers/explorer.py
+++ b/src/pixano/api/routers/explorer.py
@@ -4,10 +4,14 @@
 # License: CECILL-C
 # =====================================
 
-"""Explorer router: filter capability document and item navigation."""
+"""Explorer router: filter capability document, item navigation, semantic search."""
+
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
+from pixano.api.embeddings import submit_embedding_job
 from pixano.api.models import (
     ColumnDescriptorResponse,
     FilterSchemaResponse,
@@ -21,10 +25,59 @@ from pixano.api.query import (
     validate_sort,
 )
 from pixano.api.routers._deps import get_dataset_dep
+from pixano.api.routers.data_io import _data_dir
+from pixano.api.routers.records import _resolve_view_previews
+from pixano.api.settings import Settings, get_settings
 from pixano.datasets import Dataset
+from pixano.datasets.io.jobs import JobStore
+from pixano.inference.provider import InferenceProvider
+from pixano.inference.types import EmbeddingInput
 
 
 router = APIRouter(prefix="/datasets/{dataset_id}", tags=["Explorer"])
+
+
+def _default_inference_provider(settings: Settings) -> InferenceProvider:
+    if not settings.inference_providers or not settings.default_inference_provider:
+        raise HTTPException(status_code=404, detail="No inference provider connected")
+    provider = settings.inference_providers.get(settings.default_inference_provider)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="No inference provider connected")
+    return provider
+
+
+class RecordSearchRequest(BaseModel):
+    """Semantic search over records by text or by similarity to a record."""
+
+    model: str | None = None
+    text: str | None = None
+    similar_to: str | None = None
+    k: int = 50
+    filter: list[str] | None = None
+    where: str | None = None
+
+
+class ComputeEmbeddingsRequest(BaseModel):
+    """Start a record-embedding computation job."""
+
+    model: str
+    provider_name: str | None = None
+
+
+class ComputeEmbeddingsResponse(BaseModel):
+    """The launched embedding job."""
+
+    job_id: str
+
+
+class RecordSearchResponse(BaseModel):
+    """Ranked semantic-search results."""
+
+    items: list[dict[str, Any]]
+    total: int
+    model: str
+    mode: str
+    k: int
 
 
 @router.get(
@@ -58,9 +111,19 @@ def get_filter_schema(
         )
         for column in catalogue
     ]
-    # `search.modes` is ["text"] today (lexical); semantic modes/models land in
-    # 0.9 and will populate these fields with no frontend change.
-    return FilterSchemaResponse(table="records", columns=columns, search=SearchCapabilities())
+    # Lexical text search is always available; semantic search + the model that produced the
+    # embeddings appear once a record-embedding table has been computed.
+    modes = ["text"]
+    models: list[str] = []
+    if dataset.has_record_embeddings():
+        modes.append("semantic")
+        space = dataset.record_embedding_space() or {}
+        model_id = space.get("model_id")
+        if model_id:
+            models.append(model_id)
+    return FilterSchemaResponse(
+        table="records", columns=columns, search=SearchCapabilities(modes=modes, models=models)
+    )
 
 
 @router.get(
@@ -106,3 +169,109 @@ def get_record_neighbors(
             raise HTTPException(status_code=400, detail=f"Invalid filter. {err}") from None
         raise
     return NeighborsResponse(**neighbors)
+
+
+def _stored_record_vector(dataset: Dataset, record_id: str) -> list[float] | None:
+    rows = dataset.get_data(dataset._RECORD_EMBEDDING_TABLE, where=f"record_id = '{record_id}'", limit=1)  # noqa: SLF001
+    if not rows:
+        return None
+    return list(rows[0].vector)
+
+
+def _prefilter_record_ids(dataset: Dataset, filters: list[str] | None, where: str | None) -> list[str] | None:
+    if not filters and not where:
+        return None
+    catalogue = build_column_catalogue(dataset, "records")
+    try:
+        compiled_where, _referenced, _servable = compile_filters(catalogue, filters or [])
+    except FilterCompileError as err:
+        raise HTTPException(status_code=400, detail=str(err)) from None
+    if where:
+        compiled_where = f"({where})" if compiled_where is None else f"{compiled_where} AND ({where})"
+    matches = dataset.get_data("records", where=compiled_where, limit=None)
+    return [record.id for record in (matches or [])]
+
+
+@router.post(
+    "/records/search",
+    response_model=RecordSearchResponse,
+    operation_id="search_records",
+    summary="Semantic record search",
+    description="Rank records by embedding similarity to a text query or to another record, "
+    "optionally restricted by the explorer's structured filters.",
+)
+async def search_records(
+    dataset_id: str,
+    body: RecordSearchRequest,
+    dataset: Dataset = Depends(get_dataset_dep),
+    settings: Annotated[Settings, Depends(get_settings)] = None,  # type: ignore[assignment]
+) -> RecordSearchResponse:
+    """Semantic search over records (text→records or find-similar)."""
+    if not dataset.has_record_embeddings():
+        raise HTTPException(status_code=400, detail="No record embeddings; compute them first.")
+    space = dataset.record_embedding_space() or {}
+    model = body.model or space.get("model_id", "")
+
+    mode: str
+    if body.similar_to:
+        query_vector = _stored_record_vector(dataset, body.similar_to)
+        if query_vector is None:
+            raise HTTPException(status_code=404, detail=f"Record '{body.similar_to}' has no embedding.")
+        mode = "similar"
+    elif body.text:
+        provider = _default_inference_provider(settings)
+        try:
+            result = await provider.embedding(EmbeddingInput(model=model, text=body.text))
+        except Exception as exc:  # noqa: BLE001 - provider/HTTP failure → 502
+            raise HTTPException(status_code=502, detail=f"Embedding failed: {exc}") from exc
+        query_vector = list(result.data.embedding.values)
+        mode = "text"
+    else:
+        raise HTTPException(status_code=400, detail="Provide either 'text' or 'similar_to'.")
+
+    record_id_filter = _prefilter_record_ids(dataset, body.filter, body.where)
+    try:
+        records, distances = dataset.search_records(query_vector, k=body.k, record_id_filter=record_id_filter)
+    except RuntimeError as err:
+        raise HTTPException(status_code=400, detail=f"Search failed. {err}") from None
+
+    record_ids = [record.id for record in records]
+    previews = _resolve_view_previews(dataset_id, dataset, record_ids) if record_ids else {}
+    items = [
+        {
+            **record.model_dump(),
+            "_distance": distance,
+            "view_previews": {name: preview.model_dump() for name, preview in (previews.get(record.id) or {}).items()}
+            or None,
+        }
+        for record, distance in zip(records, distances, strict=True)
+    ]
+    return RecordSearchResponse(items=items, total=len(items), model=model, mode=mode, k=body.k)
+
+
+@router.post(
+    "/embeddings/compute",
+    response_model=ComputeEmbeddingsResponse,
+    status_code=202,
+    operation_id="compute_record_embeddings",
+    summary="Compute record embeddings",
+    description="Launch a background job that embeds each record's image via the connected "
+    "inference provider and builds the vector index. Poll it via GET /io/jobs/{id}.",
+)
+def compute_record_embeddings(
+    dataset_id: str,
+    body: ComputeEmbeddingsRequest,
+    dataset: Dataset = Depends(get_dataset_dep),
+    settings: Annotated[Settings, Depends(get_settings)] = None,  # type: ignore[assignment]
+) -> ComputeEmbeddingsResponse:
+    """Start the record-embedding computation job."""
+    provider = (
+        _default_inference_provider(settings)
+        if body.provider_name is None
+        else settings.inference_providers.get(body.provider_name)
+    )
+    if provider is None:
+        raise HTTPException(status_code=404, detail=f"Unknown inference provider '{body.provider_name}'")
+    store = JobStore.for_data_dir(_data_dir(settings))
+    job_id = submit_embedding_job(store, dataset.path, dataset_id, provider, body.model)
+    return ComputeEmbeddingsResponse(job_id=job_id)

--- a/src/pixano/api/routers/inference.py
+++ b/src/pixano/api/routers/inference.py
@@ -33,6 +33,7 @@ from pixano.inference.providers.pixano_inference import PixanoInferenceProvider
 from pixano.inference.registry import get_provider
 from pixano.inference.types import (
     DetectionInput,
+    EmbeddingInput,
     ImageMaskGenerationInput,
     InferenceTask,
     NDArrayData,
@@ -126,6 +127,16 @@ class DetectionRequest(BaseModel):
     classes: list[str] | str
     box_threshold: float = 0.5
     text_threshold: float = 0.5
+
+
+class EmbeddingRequest(BaseModel):
+    """Request schema for embedding inference (exactly one of image/text)."""
+
+    model: str
+    provider_name: str | None = None
+    image: list[str] | str | None = None
+    text: list[str] | str | None = None
+    normalize: bool = True
 
 
 class NDArrayRequest(BaseModel):
@@ -724,6 +735,27 @@ async def detect(request: DetectionRequest, settings: Annotated[Settings, Depend
     except InferenceRequestError as exc:
         _raise_http_from_request_error(exc)
     return _serialize_detection_result(result)
+
+
+@router.post("/embedding", operation_id="embedding")
+async def embedding(request: EmbeddingRequest, settings: Annotated[Settings, Depends(get_settings)]) -> dict[str, Any]:
+    """Embed an image or text into a shared vector space (CLIP-style)."""
+    provider = _get_provider(settings, request.provider_name)
+    input_data = EmbeddingInput(
+        model=request.model, image=request.image, text=request.text, normalize=request.normalize
+    )
+    try:
+        result = await provider.embedding(input_data=input_data)
+    except InferenceRequestError as exc:
+        _raise_http_from_request_error(exc)
+    return {
+        "data": {"embedding": result.data.embedding.to_dict(), "dim": result.data.dim},
+        "timestamp": result.timestamp.isoformat(),
+        "processing_time": result.processing_time,
+        "metadata": result.metadata,
+        "id": result.id,
+        "status": result.status,
+    }
 
 
 @router.post("/image_mask_generation", operation_id="image_mask_generation")

--- a/src/pixano/datasets/dataset.py
+++ b/src/pixano/datasets/dataset.py
@@ -39,6 +39,7 @@ from pixano.schemas import (
     Record,
     SchemaGroup,
     ViewEmbedding,
+    build_record_embedding_schema,
     is_image,
     is_sequence_frame,
     is_video,
@@ -116,6 +117,8 @@ class Dataset:
     _PREVIEWS_PATH: str = "previews"
     _INFO_FILE: str = "info.json"
     _FEATURES_VALUES_FILE: str = "features_values.json"
+    _EMBEDDINGS_FILE: str = "embeddings.json"
+    _RECORD_EMBEDDING_TABLE: str = "embeddings"
     _STAT_FILE: str = "stats.json"
     _THUMB_FILE: str = "preview.png"
 
@@ -135,12 +138,18 @@ class Dataset:
         self._info_file = self.path / self._INFO_FILE
         self._table_handles: dict[str, LanceTable] = {}
         self._features_values_file = self.path / self._FEATURES_VALUES_FILE
+        self._embeddings_file = self.path / self._EMBEDDINGS_FILE
+        self._record_embedding_space: dict[str, Any] | None = None
         self._stat_file = self.path / self._STAT_FILE
         self._thumb_file = self.path / self._THUMB_FILE
         self._db_path = self.path / self._DB_PATH
 
         self.info = DatasetInfo.from_json(self._info_file)
         validate_canonical_table_map(self.info.tables)
+        # The record-embedding table is internal to the search engine (not part of the public
+        # dataset schema), so it is persisted in a sidecar and re-injected here after the
+        # canonical check — DatasetInfo does not round-trip it.
+        self._load_record_embedding_space()
         self.features_values = DatasetFeaturesValues.from_json(self._features_values_file)
         self.stats = DatasetStatistic.from_json(self._stat_file) if self._stat_file.is_file() else []
         self.thumbnail = self._thumb_file
@@ -1561,6 +1570,147 @@ class Dataset:
             if info.id == id:
                 return Dataset(json_fp.parent)
         raise FileNotFoundError(f"Dataset {id} not found in {directory}")
+
+    # ------------------------------------------------------------------
+    # Record-level embeddings & semantic search
+    # ------------------------------------------------------------------
+
+    def _load_record_embedding_space(self) -> None:
+        """Load the record-embedding sidecar and inject its schema into ``info.tables``."""
+        if not self._embeddings_file.is_file():
+            self._record_embedding_space = None
+            return
+        try:
+            space = json.loads(self._embeddings_file.read_text(encoding="utf-8"))
+            dim = int(space["dim"])
+        except (json.JSONDecodeError, KeyError, ValueError, OSError) as exc:
+            logger.warning("Dataset %s: ignoring unreadable %s: %s", self.path, self._EMBEDDINGS_FILE, exc)
+            self._record_embedding_space = None
+            return
+        self._record_embedding_space = space
+        self.info.tables[self._RECORD_EMBEDDING_TABLE] = build_record_embedding_schema(dim)
+
+    def has_record_embeddings(self) -> bool:
+        """Whether this dataset has a computed record-embedding table."""
+        return self._record_embedding_space is not None
+
+    def record_embedding_space(self) -> dict[str, Any] | None:
+        """Return the record-embedding space descriptor (model, dim, metric), or None."""
+        return dict(self._record_embedding_space) if self._record_embedding_space is not None else None
+
+    def create_record_embedding_table(
+        self,
+        dim: int,
+        model_id: str,
+        metric: str = "cosine",
+        source_view: str = "image",
+        index_type: str = "IVF_PQ",
+    ) -> None:
+        """Create (or replace) the record-embedding table and persist its sidecar descriptor.
+
+        Args:
+            dim: Embedding dimensionality.
+            model_id: Identifier of the model that produced the vectors.
+            metric: Distance metric (``cosine``/``l2``/``dot``).
+            source_view: Logical view the embeddings were computed from.
+            index_type: LanceDB vector index type to build once populated.
+        """
+        schema = build_record_embedding_schema(dim)
+        self.create_table(self._RECORD_EMBEDDING_TABLE, schema, mode="overwrite")
+        self._record_embedding_space = {
+            "table": self._RECORD_EMBEDDING_TABLE,
+            "model_id": model_id,
+            "dim": int(dim),
+            "metric": metric,
+            "source_view": source_view,
+            "index_type": index_type,
+        }
+        self.info.tables[self._RECORD_EMBEDDING_TABLE] = schema
+        self._embeddings_file.write_text(json.dumps(self._record_embedding_space, indent=4), encoding="utf-8")
+
+    def add_record_embeddings(self, rows: list[dict[str, Any]]) -> None:
+        """Append rows to the record-embedding table (plain float vectors, no model).
+
+        Args:
+            rows: Dicts with at least ``record_id`` and ``vector``; ``id``/``view_id`` optional.
+        """
+        if self._record_embedding_space is None:
+            raise DatasetAccessError("No record-embedding table; call create_record_embedding_table first.")
+        schema = self.info.tables[self._RECORD_EMBEDDING_TABLE]
+        instances = [
+            schema(
+                id=row.get("id") or shortuuid.uuid(),
+                record_id=row["record_id"],
+                view_id=row.get("view_id", ""),
+                frame_id=row.get("frame_id", ""),
+                vector=row["vector"],
+            )
+            for row in rows
+        ]
+        self.add_data(self._RECORD_EMBEDDING_TABLE, instances, raise_or_warn="none")
+
+    def build_record_embedding_index(self) -> None:
+        """Build the vector + record_id indexes on the record-embedding table.
+
+        The vector (ANN) index needs enough rows to train; when there are too few, it is skipped
+        and search falls back to an exact brute-force scan (still correct).
+        """
+        if self._record_embedding_space is None:
+            raise DatasetAccessError("No record-embedding table to index.")
+        table = self.open_table(self._RECORD_EMBEDDING_TABLE)
+        try:
+            table.create_scalar_index("record_id", index_type="BTREE")
+        except Exception:  # pragma: no cover - already indexed / lancedb quirk
+            logger.debug("record_id scalar index already present or unavailable", exc_info=True)
+        index_type = self._record_embedding_space.get("index_type", "IVF_PQ")
+        metric = self._record_embedding_space.get("metric", "cosine")
+        try:
+            table.create_index(metric=metric, index_type=index_type, vector_column_name="vector")
+        except Exception as exc:
+            # Typically "not enough rows to train IVF"; brute-force search remains exact.
+            logger.info("Skipping record-embedding vector index (%s): %s", index_type, exc)
+
+    def search_records(
+        self,
+        query_vector: Sequence[float],
+        k: int,
+        record_id_filter: list[str] | None = None,
+    ) -> tuple[list[LanceModel], list[float]]:
+        """Rank records by similarity of their embedding to ``query_vector``.
+
+        Args:
+            query_vector: The query embedding (same space/dim as the stored vectors).
+            k: Maximum number of records to return.
+            record_id_filter: Optional record-id allowlist applied as a vector-search prefilter.
+
+        Returns:
+            A tuple of ``(records, distances)`` ordered by increasing distance.
+        """
+        if self._record_embedding_space is None:
+            raise DatasetAccessError(f"Dataset {self.id} has no record embeddings.")
+        if not isinstance(k, int) or k < 1:
+            raise DatasetAccessError("k must be a strictly positive integer.")
+        if record_id_filter is not None and len(record_id_filter) == 0:
+            return [], []
+
+        table = self.open_table(self._RECORD_EMBEDDING_TABLE)
+        metric = self._record_embedding_space.get("metric", "cosine")
+        query = table.search(list(query_vector)).metric(metric).select(["record_id"])
+        if record_id_filter is not None:
+            query = query.where(f"record_id IN {to_sql_list(record_id_filter)}", prefilter=True)
+        # One vector per record, but group defensively so duplicates collapse to their best match.
+        results: pl.DataFrame = query.limit(max(k, 1)).to_polars()
+        if results.is_empty():
+            return [], []
+        ranked = results.group_by("record_id").agg(pl.min("_distance")).sort("_distance")
+        record_ids = ranked["record_id"].to_list()[:k]
+
+        records = self.get_data(SchemaGroup.RECORD.value, ids=record_ids)
+        records = sorted(records, key=lambda record: record_ids.index(record.id))
+        distances = [
+            ranked.row(by_predicate=(pl.col("record_id") == record.id), named=True)["_distance"] for record in records
+        ]
+        return records, distances
 
     def semantic_search(
         self, query: str, table_name: str, limit: int, skip: int = 0

--- a/src/pixano/datasets/io/progress.py
+++ b/src/pixano/datasets/io/progress.py
@@ -15,7 +15,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-Phase = Literal["analyze", "ingest", "finalize"]
+Phase = Literal["analyze", "ingest", "embed", "finalize"]
 
 
 class ProgressEvent(BaseModel):

--- a/src/pixano/schemas/__init__.py
+++ b/src/pixano/schemas/__init__.py
@@ -49,7 +49,14 @@ from .annotations import (
     is_text_span,
     is_tracklet,
 )
-from .embeddings import Embedding, ViewEmbedding, create_view_embedding_function, is_embedding, is_view_embedding
+from .embeddings import (
+    Embedding,
+    ViewEmbedding,
+    build_record_embedding_schema,
+    create_view_embedding_function,
+    is_embedding,
+    is_view_embedding,
+)
 from .entities import Entity, EntityDynamicState, is_entity, is_entity_dynamic_state
 from .records import Record, RecordComponent, is_record, is_record_component
 from .schema_group import CANONICAL_SCHEMA_MAP, SchemaGroup, group_to_str, schema_to_group
@@ -112,6 +119,7 @@ __all__ = [
     "Conversation",
     "EntityDynamicState",
     "Embedding",
+    "build_record_embedding_schema",
     "Entity",
     "Extrinsics",
     "Image",

--- a/src/pixano/schemas/embeddings/__init__.py
+++ b/src/pixano/schemas/embeddings/__init__.py
@@ -11,6 +11,7 @@ from .embedding import (
     is_embedding,
     is_view_embedding,
 )
+from .record_embedding import build_record_embedding_schema
 
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "is_embedding",
     "is_view_embedding",
     "create_view_embedding_function",
+    "build_record_embedding_schema",
 ]

--- a/src/pixano/schemas/embeddings/record_embedding.py
+++ b/src/pixano/schemas/embeddings/record_embedding.py
@@ -1,0 +1,37 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Record-level embedding schema for semantic search.
+
+A `RecordEmbedding` stores one plain float vector per record (computed from the record's image
+view). Unlike `ViewEmbedding`, it binds NO LanceDB embedding function, so opening the table never
+loads an ML model — vectors are supplied directly (the pixano-inference server computes them).
+"""
+
+from lancedb.pydantic import Vector
+from pydantic import create_model
+
+from .embedding import Embedding
+
+
+def build_record_embedding_schema(dim: int) -> type[Embedding]:
+    """Build a record-embedding schema with a fixed-size float32 vector column.
+
+    Args:
+        dim: Embedding vector dimensionality.
+
+    Returns:
+        A concrete `Embedding` subclass with ``vector: Vector(dim)`` (an Arrow
+        ``fixed_size_list<float32>[dim]`` column that a LanceDB vector index can cover). It is a
+        plain `Embedding` (NOT a `ViewEmbedding`), so no embedding function is registered.
+    """
+    if not isinstance(dim, int) or dim <= 0:
+        raise ValueError(f"Embedding dim must be a positive integer, got {dim!r}.")
+    return create_model(
+        "RecordEmbedding",
+        __base__=Embedding,
+        vector=(Vector(dim), ...),
+    )

--- a/tests/app/test_api_semantic_search.py
+++ b/tests/app/test_api_semantic_search.py
@@ -1,0 +1,188 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""End-to-end tests for semantic search: /filters capability, /records/search, compute job.
+
+The inference provider is a mock returning deterministic vectors, so no server or model is
+required. Record embeddings are seeded directly (bring-your-own vectors).
+"""
+
+import io
+import tempfile
+import time
+from functools import lru_cache
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from pixano.api.main import create_app
+from pixano.api.settings import Settings, get_settings
+from pixano.datasets.dataset import Dataset
+from pixano.datasets.dataset_info import DatasetInfo
+from pixano.features import Image, Record
+from pixano.inference.provider import InferenceProvider
+from pixano.inference.types import EmbeddingInput, EmbeddingOutput, EmbeddingResult, NDArrayData
+
+
+DATASET_ID = "semantic_dataset"
+DIM = 8
+
+
+def _bit_vector(i: int) -> list[float]:
+    return [float((i >> b) & 1) for b in range(DIM)]
+
+
+def _png_bytes(seed: int) -> bytes:
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (8, 8), color=(seed * 10 % 256, 0, 0)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _make_provider() -> MagicMock:
+    provider = MagicMock(spec=InferenceProvider)
+    provider.name = "mock-embed"
+    provider.url = "http://mock"
+
+    async def embedding(input_data: EmbeddingInput, timeout: float = 60.0) -> EmbeddingResult:
+        # Text "record N" embeds to record N's vector; image batches embed to zeros.
+        if input_data.text is not None:
+            texts = input_data.text if isinstance(input_data.text, list) else [input_data.text]
+            vectors = [_bit_vector(int(t.split()[-1])) for t in texts]
+        else:
+            images = input_data.image if isinstance(input_data.image, list) else [input_data.image]
+            vectors = [[0.0] * DIM for _ in images]
+        flat = [v for vec in vectors for v in vec]
+        from datetime import datetime
+
+        return EmbeddingResult(
+            data=EmbeddingOutput(embedding=NDArrayData(values=flat, shape=[len(vectors), DIM]), dim=DIM),
+            timestamp=datetime.now(),
+            processing_time=0.01,
+            metadata={},
+        )
+
+    provider.embedding = AsyncMock(side_effect=embedding)
+    return provider
+
+
+def _make_client(dataset: Dataset, provider: MagicMock | None = None) -> TestClient:
+    tmp = Path(tempfile.mkdtemp())
+    models_dir = tmp / "models"
+    models_dir.mkdir()
+    kwargs: dict = {"library_dir": str(dataset.path.parent), "models_dir": str(models_dir)}
+    if provider is not None:
+        kwargs["inference_providers"] = {"mock-embed": provider}
+        kwargs["default_inference_provider"] = "mock-embed"
+    settings = Settings(**kwargs)
+
+    @lru_cache
+    def get_settings_override():
+        return settings
+
+    app = create_app(settings)
+    app.dependency_overrides[get_settings] = get_settings_override
+    return TestClient(app)
+
+
+def _build_dataset(with_embeddings: bool) -> Dataset:
+    target = Path(tempfile.mkdtemp()) / "library" / DATASET_ID
+    dataset = Dataset.create(
+        target,
+        DatasetInfo(id=DATASET_ID, name=DATASET_ID, description="d", record=Record, views={"image": Image}),
+    )
+    records = [Record(id=f"r{i:02d}") for i in range(12)]
+    images = [
+        Image.from_bytes(record_id=f"r{i:02d}", logical_name="image", raw_bytes=_png_bytes(i), id=f"img{i:02d}")
+        for i in range(12)
+    ]
+    dataset.add_records({"records": records, "images": images})
+    if with_embeddings:
+        dataset.create_record_embedding_table(dim=DIM, model_id="mock-clip")
+        dataset.add_record_embeddings([{"record_id": f"r{i:02d}", "vector": _bit_vector(i)} for i in range(12)])
+        dataset.build_record_embedding_index()
+    return dataset
+
+
+BASE = f"/datasets/{DATASET_ID}"
+
+
+class TestSearchCapability:
+    def test_filters_advertise_no_semantic_without_embeddings(self):
+        client = _make_client(_build_dataset(with_embeddings=False))
+        search = client.get(f"{BASE}/filters").json()["search"]
+        assert search["modes"] == ["text"]
+        assert search["models"] == []
+
+    def test_filters_advertise_semantic_with_embeddings(self):
+        client = _make_client(_build_dataset(with_embeddings=True))
+        search = client.get(f"{BASE}/filters").json()["search"]
+        assert "semantic" in search["modes"]
+        assert search["models"] == ["mock-clip"]
+
+
+class TestRecordSearch:
+    def test_text_search_ranks_records(self):
+        provider = _make_provider()
+        client = _make_client(_build_dataset(with_embeddings=True), provider)
+        body = client.post(f"{BASE}/records/search", json={"text": "record 5", "k": 3}).json()
+        assert body["mode"] == "text"
+        assert body["items"][0]["id"] == "r05"
+        assert body["items"][0]["_distance"] == pytest.approx(0.0, abs=1e-6)
+        provider.embedding.assert_awaited()
+
+    def test_find_similar_uses_stored_vector_without_the_provider(self):
+        provider = _make_provider()
+        client = _make_client(_build_dataset(with_embeddings=True), provider)
+        body = client.post(f"{BASE}/records/search", json={"similar_to": "r07", "k": 2}).json()
+        assert body["mode"] == "similar"
+        assert body["items"][0]["id"] == "r07"
+        provider.embedding.assert_not_awaited()  # stored vector → no query encoding
+
+    def test_search_with_filter_prefilter(self):
+        provider = _make_provider()
+        client = _make_client(_build_dataset(with_embeddings=True), provider)
+        body = client.post(
+            f"{BASE}/records/search",
+            json={"text": "record 5", "k": 5, "filter": ["id:in:r01,r03,r05"]},
+        ).json()
+        assert {item["id"] for item in body["items"]} <= {"r01", "r03", "r05"}
+        assert body["items"][0]["id"] == "r05"
+
+    def test_search_without_embeddings_is_400(self):
+        client = _make_client(_build_dataset(with_embeddings=False), _make_provider())
+        resp = client.post(f"{BASE}/records/search", json={"text": "record 1"})
+        assert resp.status_code == 400
+
+    def test_search_requires_text_or_similar_to(self):
+        client = _make_client(_build_dataset(with_embeddings=True), _make_provider())
+        resp = client.post(f"{BASE}/records/search", json={"k": 3})
+        assert resp.status_code == 400
+
+
+class TestComputeJob:
+    def test_compute_embeddings_end_to_end(self):
+        provider = _make_provider()
+        client = _make_client(_build_dataset(with_embeddings=False), provider)
+        resp = client.post(f"{BASE}/embeddings/compute", json={"model": "mock-clip"})
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+
+        # Poll the shared job endpoint until the background thread finishes.
+        deadline = time.time() + 15
+        status = "pending"
+        while time.time() < deadline:
+            status = client.get(f"/io/jobs/{job_id}").json()["status"]
+            if status in {"done", "error", "cancelled"}:
+                break
+            time.sleep(0.1)
+        assert status == "done", client.get(f"/io/jobs/{job_id}").json()
+
+        # The dataset now advertises semantic search.
+        search = client.get(f"{BASE}/filters").json()["search"]
+        assert "semantic" in search["modes"]

--- a/tests/app/test_api_semantic_search.py
+++ b/tests/app/test_api_semantic_search.py
@@ -15,8 +15,9 @@ import tempfile
 import time
 from functools import lru_cache
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 from PIL import Image as PILImage
@@ -165,23 +166,49 @@ class TestRecordSearch:
         assert resp.status_code == 400
 
 
+def _fake_sync_client_factory():
+    """A stand-in for SyncPixanoInferenceClient: embeds each image batch to zero vectors."""
+
+    def make(url, api_key=None):  # noqa: ANN001, ARG001
+        instance = MagicMock()
+
+        def embedding(request):  # noqa: ANN001
+            images = request.image if isinstance(request.image, list) else [request.image]
+            arr = np.zeros((len(images), DIM), dtype=np.float32)
+            response = MagicMock()
+            response.data.embeddings.to_numpy.return_value = arr
+            response.data.dim = DIM
+            return response
+
+        instance.embedding.side_effect = embedding
+        instance.close.return_value = None
+        return instance
+
+    return make
+
+
 class TestComputeJob:
     def test_compute_embeddings_end_to_end(self):
         provider = _make_provider()
         client = _make_client(_build_dataset(with_embeddings=False), provider)
-        resp = client.post(f"{BASE}/embeddings/compute", json={"model": "mock-clip"})
-        assert resp.status_code == 202
-        job_id = resp.json()["job_id"]
+        # The background job uses a fresh SYNC client (not the async provider), so patch it.
+        with patch(
+            "pixano.api.embeddings.SyncPixanoInferenceClient",
+            side_effect=_fake_sync_client_factory(),
+        ):
+            resp = client.post(f"{BASE}/embeddings/compute", json={"model": "mock-clip"})
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
 
-        # Poll the shared job endpoint until the background thread finishes.
-        deadline = time.time() + 15
-        status = "pending"
-        while time.time() < deadline:
-            status = client.get(f"/io/jobs/{job_id}").json()["status"]
-            if status in {"done", "error", "cancelled"}:
-                break
-            time.sleep(0.1)
-        assert status == "done", client.get(f"/io/jobs/{job_id}").json()
+            # Poll the shared job endpoint until the background thread finishes.
+            deadline = time.time() + 15
+            status = "pending"
+            while time.time() < deadline:
+                status = client.get(f"/io/jobs/{job_id}").json()["status"]
+                if status in {"done", "error", "cancelled"}:
+                    break
+                time.sleep(0.1)
+            assert status == "done", client.get(f"/io/jobs/{job_id}").json()
 
         # The dataset now advertises semantic search.
         search = client.get(f"{BASE}/filters").json()["search"]

--- a/tests/datasets/test_record_embeddings.py
+++ b/tests/datasets/test_record_embeddings.py
@@ -1,0 +1,75 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Record-level embedding storage + vector search (no ML model involved)."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from pixano.datasets.dataset import Dataset
+from pixano.datasets.dataset_info import DatasetInfo
+from pixano.datasets.utils.errors import DatasetAccessError
+from pixano.features import Image, Record
+
+
+def _bit_vector(i: int, dim: int = 8) -> list[float]:
+    return [float((i >> b) & 1) for b in range(dim)]
+
+
+@pytest.fixture()
+def dataset_with_embeddings() -> Dataset:
+    tmp = Path(tempfile.mkdtemp()) / "ds"
+    dataset = Dataset.create(tmp, DatasetInfo(name="emb", description="d", record=Record, views={"image": Image}))
+    dataset.add_records({"records": [Record(id=f"r{i}") for i in range(20)]})
+    dataset.create_record_embedding_table(dim=8, model_id="test-clip", metric="cosine")
+    dataset.add_record_embeddings([{"record_id": f"r{i}", "vector": _bit_vector(i)} for i in range(20)])
+    dataset.build_record_embedding_index()
+    return dataset
+
+
+class TestRecordEmbeddingStorage:
+    def test_space_is_recorded(self, dataset_with_embeddings: Dataset):
+        assert dataset_with_embeddings.has_record_embeddings()
+        space = dataset_with_embeddings.record_embedding_space()
+        assert space["model_id"] == "test-clip"
+        assert space["dim"] == 8
+        assert space["metric"] == "cosine"
+
+    def test_embedding_table_opens_without_a_model(self, dataset_with_embeddings: Dataset):
+        # A plain Embedding table must open with no embedding-function registration.
+        table = dataset_with_embeddings.open_table("embeddings")
+        assert table.count_rows() == 20
+
+    def test_search_ranks_by_distance(self, dataset_with_embeddings: Dataset):
+        records, distances = dataset_with_embeddings.search_records(_bit_vector(5), k=3)
+        assert records[0].id == "r5"
+        assert distances[0] == pytest.approx(0.0, abs=1e-6)
+        assert distances == sorted(distances)
+
+    def test_search_respects_record_id_prefilter(self, dataset_with_embeddings: Dataset):
+        records, _ = dataset_with_embeddings.search_records(_bit_vector(5), k=5, record_id_filter=["r1", "r3", "r5"])
+        assert {r.id for r in records} <= {"r1", "r3", "r5"}
+        assert records[0].id == "r5"
+
+    def test_empty_prefilter_returns_nothing(self, dataset_with_embeddings: Dataset):
+        assert dataset_with_embeddings.search_records(_bit_vector(5), k=5, record_id_filter=[]) == ([], [])
+
+    def test_sidecar_persists_across_reopen(self, dataset_with_embeddings: Dataset):
+        reopened = Dataset(dataset_with_embeddings.path)
+        assert reopened.has_record_embeddings()
+        records, _ = reopened.search_records(_bit_vector(5), k=1)
+        assert records[0].id == "r5"
+
+    def test_search_without_embeddings_raises(self):
+        tmp = Path(tempfile.mkdtemp()) / "empty"
+        dataset = Dataset.create(
+            tmp, DatasetInfo(name="empty", description="d", record=Record, views={"image": Image})
+        )
+        assert not dataset.has_record_embeddings()
+        with pytest.raises(DatasetAccessError):
+            dataset.search_records(_bit_vector(0), k=1)

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -11,14 +11,18 @@ License: CECILL-C
   import DatasetPagination from "./DatasetPagination.svelte";
   import RecordFilterBar from "./RecordFilterBar.svelte";
   import { Table } from "./table";
+  import { invalidateAll } from "$app/navigation";
   import { navigating } from "$app/state";
+  import { computeEmbeddings, getIoJob, listInferenceModels } from "$lib/api";
   import type { FilterSchemaResponse } from "$lib/api/restTypes";
+  import { MultimodalImageNLPTask } from "$lib/types/inference";
   import type { DatasetBrowser } from "$lib/ui";
   import { EXPLORER_ROUTE_ID } from "$lib/utils/routes";
 
   interface Props {
     selectedDataset: DatasetBrowser;
     filterSchema: FilterSchemaResponse;
+    semanticActive?: boolean;
     onSelectItem?: (itemId: string) => void;
     onNavigate: (updates: Record<string, string | string[] | undefined>) => void;
     pagination: {
@@ -32,8 +36,17 @@ License: CECILL-C
     };
   }
 
-  let { selectedDataset, filterSchema, onSelectItem, onNavigate, pagination }: Props = $props();
+  let {
+    selectedDataset,
+    filterSchema,
+    semanticActive = false,
+    onSelectItem,
+    onNavigate,
+    pagination,
+  }: Props = $props();
   const isLoadingTableItems = $derived(navigating.to?.route?.id === EXPLORER_ROUTE_ID);
+
+  let computing = $state(false);
 
   // Remount the table when the dataset, its column set, or the active sort
   // changes: the table builds its column defs and initial sort state once at
@@ -51,9 +64,41 @@ License: CECILL-C
     onSelectItem?.(itemId);
   }
 
-  function handleApply(updates: { filter?: string[]; q?: string }) {
-    // Any filter/search change resets to the first page.
-    onNavigate({ page: "1", ...updates });
+  function handleApply(updates: { filter?: string[]; q?: string; semantic?: boolean }) {
+    // Any filter/search change resets to the first page. Semantic search is ranked, so it
+    // clears any column sort and the similar-to target.
+    const semantic = updates.semantic;
+    onNavigate({
+      page: "1",
+      filter: updates.filter,
+      q: updates.q,
+      semantic: semantic ? "1" : undefined,
+      similar_to: undefined, // a text search or filter change exits find-similar mode
+      ...(semantic ? { sort: undefined, order: undefined } : {}),
+    });
+  }
+
+  async function handleCompute() {
+    if (computing) return;
+    computing = true;
+    try {
+      const models = await listInferenceModels();
+      const embeddingModels = models.filter((m) => m.task === MultimodalImageNLPTask.EMBEDDING);
+      if (embeddingModels.length === 0) {
+        console.error("No embedding model available on the connected inference server");
+        return;
+      }
+      const jobId = await computeEmbeddings(selectedDataset.id, embeddingModels[0].name);
+      // Poll the shared job until it finishes, then reload so /filters advertises semantic search.
+      for (;;) {
+        const job = await getIoJob(jobId);
+        if (["done", "error", "cancelled"].includes(job.status)) break;
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
+      await invalidateAll();
+    } finally {
+      computing = false;
+    }
   }
 
   function handleColSort(colsorts: { id: string; order: string }[]) {
@@ -82,7 +127,10 @@ License: CECILL-C
           filters={pagination.filters}
           q={pagination.q}
           total={selectedDataset.pagination.total_size}
+          {semanticActive}
+          {computing}
           onApply={handleApply}
+          onCompute={handleCompute}
         />
       </div>
 

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -8,6 +8,7 @@ License: CECILL-C
   // Imports
   import { CircleNotch } from "phosphor-svelte";
 
+  import ConnectToServerModal from "../inference/ConnectToServerModal.svelte";
   import DatasetPagination from "./DatasetPagination.svelte";
   import RecordFilterBar from "./RecordFilterBar.svelte";
   import { Table } from "./table";
@@ -47,6 +48,22 @@ License: CECILL-C
   const isLoadingTableItems = $derived(navigating.to?.route?.id === EXPLORER_ROUTE_ID);
 
   let computing = $state(false);
+  let showConnectModal = $state(false);
+
+  async function runCompute(): Promise<boolean> {
+    // Returns false when no embedding model is reachable (caller prompts to connect).
+    const models = await listInferenceModels();
+    const embeddingModels = models.filter((m) => m.task === MultimodalImageNLPTask.EMBEDDING);
+    if (embeddingModels.length === 0) return false;
+    const jobId = await computeEmbeddings(selectedDataset.id, embeddingModels[0].name);
+    for (;;) {
+      const job = await getIoJob(jobId);
+      if (["done", "error", "cancelled"].includes(job.status)) break;
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+    await invalidateAll();
+    return true;
+  }
 
   // Remount the table when the dataset, its column set, or the active sort
   // changes: the table builds its column defs and initial sort state once at
@@ -82,20 +99,19 @@ License: CECILL-C
     if (computing) return;
     computing = true;
     try {
-      const models = await listInferenceModels();
-      const embeddingModels = models.filter((m) => m.task === MultimodalImageNLPTask.EMBEDDING);
-      if (embeddingModels.length === 0) {
-        console.error("No embedding model available on the connected inference server");
-        return;
-      }
-      const jobId = await computeEmbeddings(selectedDataset.id, embeddingModels[0].name);
-      // Poll the shared job until it finishes, then reload so /filters advertises semantic search.
-      for (;;) {
-        const job = await getIoJob(jobId);
-        if (["done", "error", "cancelled"].includes(job.status)) break;
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-      }
-      await invalidateAll();
+      // If no embedding model is reachable, the server isn't connected — prompt for it.
+      const ok = await runCompute();
+      if (!ok) showConnectModal = true;
+    } finally {
+      computing = false;
+    }
+  }
+
+  async function handleConnected() {
+    showConnectModal = false;
+    computing = true;
+    try {
+      await runCompute();
     } finally {
       computing = false;
     }
@@ -168,3 +184,7 @@ License: CECILL-C
     {/if}
   </div>
 </div>
+
+{#if showConnectModal}
+  <ConnectToServerModal onClose={() => (showConnectModal = false)} onConnected={handleConnected} />
+{/if}

--- a/ui/apps/pixano/src/components/dataset/RecordFilterBar.svelte
+++ b/ui/apps/pixano/src/components/dataset/RecordFilterBar.svelte
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { FunnelSimple, MagnifyingGlass, Plus, X } from "phosphor-svelte";
+  import { CircleNotch, FunnelSimple, MagnifyingGlass, Plus, Sparkle, X } from "phosphor-svelte";
 
   import FilterChipEditor from "./FilterChipEditor.svelte";
   import type { FilterSchemaResponse } from "$lib/api/restTypes";
@@ -22,13 +22,32 @@ License: CECILL-C
     filters: string[];
     q: string;
     total: number;
-    onApply: (updates: { filter?: string[]; q?: string }) => void;
+    semanticActive?: boolean;
+    computing?: boolean;
+    onApply: (updates: { filter?: string[]; q?: string; semantic?: boolean }) => void;
+    onCompute?: () => void;
   }
 
-  let { filterSchema, filters, q, total, onApply }: Props = $props();
+  let {
+    filterSchema,
+    filters,
+    q,
+    total,
+    semanticActive = false,
+    computing = false,
+    onApply,
+    onCompute,
+  }: Props = $props();
 
   const columns = $derived(filterSchema.columns);
   const hasSearchable = $derived(columns.some((c) => c.searchable));
+  const semanticAvailable = $derived((filterSchema.search?.modes ?? []).includes("semantic"));
+
+  // Semantic mode is a local toggle; it activates on submit and reflects the URL state.
+  let semanticMode = $state(false);
+  $effect(() => {
+    semanticMode = semanticActive;
+  });
 
   // Active filters, parsed from the URL-sourced tokens.
   const activeFilters = $derived(parseFilters(filters));
@@ -59,12 +78,20 @@ License: CECILL-C
   }
 
   function submitSearch() {
-    onApply({ q: searchInput.trim() || undefined });
+    const text = searchInput.trim();
+    onApply({ q: text || undefined, semantic: semanticMode && text !== "" });
   }
 
   function clearSearch() {
     searchInput = "";
-    onApply({ q: undefined });
+    onApply({ q: undefined, semantic: false });
+  }
+
+  function toggleSemantic() {
+    semanticMode = !semanticMode;
+    // Re-run the current query in the new mode when there is one.
+    if (searchInput.trim() !== "") submitSearch();
+    else if (semanticActive) onApply({ semantic: false });
   }
 
   function chipLabel(filter: RecordFilter): string {
@@ -76,18 +103,24 @@ License: CECILL-C
 
 <div class="flex flex-col gap-2 py-3">
   <div class="flex flex-wrap items-center gap-2">
-    {#if hasSearchable}
+    {#if hasSearchable || semanticAvailable}
       <div class="relative flex items-center">
-        <MagnifyingGlass
-          size={16}
-          class="absolute left-2.5 text-muted-foreground pointer-events-none"
-        />
+        {#if semanticMode}
+          <Sparkle size={16} class="absolute left-2.5 text-primary pointer-events-none" />
+        {:else}
+          <MagnifyingGlass
+            size={16}
+            class="absolute left-2.5 text-muted-foreground pointer-events-none"
+          />
+        {/if}
         <input
           type="text"
           bind:value={searchInput}
           onkeydown={(e) => e.key === "Enter" && submitSearch()}
-          placeholder="Search text…"
-          class="h-9 w-64 pl-8 pr-8 rounded-lg border border-border bg-background text-sm text-foreground placeholder-muted-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          placeholder={semanticMode ? "Search by meaning…" : "Search text…"}
+          class="h-9 w-72 pl-8 pr-8 rounded-lg border bg-background text-sm text-foreground placeholder-muted-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-ring {semanticMode
+            ? 'border-primary/50'
+            : 'border-border'}"
         />
         {#if searchInput !== ""}
           <button
@@ -100,6 +133,36 @@ License: CECILL-C
           </button>
         {/if}
       </div>
+
+      {#if semanticAvailable}
+        <button
+          type="button"
+          onclick={toggleSemantic}
+          title="Toggle semantic (meaning-based) search"
+          class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg border text-sm shadow-sm {semanticMode
+            ? 'border-primary bg-primary/10 text-primary'
+            : 'border-border bg-background text-foreground hover:bg-accent'}"
+        >
+          <Sparkle size={16} weight={semanticMode ? "fill" : "regular"} />
+          Semantic
+        </button>
+      {:else if onCompute}
+        <button
+          type="button"
+          onclick={onCompute}
+          disabled={computing}
+          title="Compute embeddings to enable semantic search"
+          class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg border border-dashed border-border bg-background text-sm text-muted-foreground hover:bg-accent shadow-sm disabled:opacity-60"
+        >
+          {#if computing}
+            <CircleNotch size={16} class="animate-spin" />
+            Computing…
+          {:else}
+            <Sparkle size={16} />
+            Enable semantic search
+          {/if}
+        </button>
+      {/if}
     {/if}
 
     <button
@@ -113,6 +176,9 @@ License: CECILL-C
     </button>
 
     <span class="ml-auto text-sm text-muted-foreground tabular-nums">
+      {#if semanticActive}
+        <span class="text-primary">Ranked by similarity ·</span>
+      {/if}
       {total.toLocaleString()}
       {total === 1 ? "record" : "records"}
     </span>

--- a/ui/apps/pixano/src/lib/api/__tests__/search.test.ts
+++ b/ui/apps/pixano/src/lib/api/__tests__/search.test.ts
@@ -1,0 +1,87 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { computeEmbeddings, searchRecords } from "../search";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+function requestBody(): Record<string, unknown> {
+  const init = fetchMock.mock.calls[0][1] as RequestInit;
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+describe("searchRecords", () => {
+  it("sends a text query with filters and adapts the ranked items to a browser view", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          { id: "r5", _distance: 0.0 },
+          { id: "r1", _distance: 0.3 },
+        ],
+        total: 2,
+        model: "clip",
+        mode: "text",
+        k: 50,
+      }),
+    );
+
+    const browser = await searchRecords("ds", {
+      text: "a red car",
+      k: 50,
+      filters: ["split:eq:train"],
+      model: "clip",
+    });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe("/datasets/ds/records/search");
+    const body = requestBody();
+    expect(body).toMatchObject({
+      text: "a red car",
+      k: 50,
+      filter: ["split:eq:train"],
+      model: "clip",
+    });
+    // Ranked order is preserved (no client re-sort).
+    expect(browser.table_data.rows.map((r) => r.id)).toEqual(["r5", "r1"]);
+    expect(browser.pagination.total_size).toBe(2);
+  });
+
+  it("sends similar_to for find-similar", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ items: [{ id: "r7" }], total: 1, model: "clip", mode: "similar", k: 20 }),
+    );
+    await searchRecords("ds", { similarTo: "r7", k: 20 });
+    expect(requestBody()).toMatchObject({ similar_to: "r7", k: 20 });
+  });
+});
+
+describe("computeEmbeddings", () => {
+  it("posts the model and returns the job id", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ job_id: "job-1" }));
+    const jobId = await computeEmbeddings("ds", "clip");
+    expect(jobId).toBe("job-1");
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe("/datasets/ds/embeddings/compute");
+    expect(requestBody()).toEqual({ model: "clip" });
+  });
+});

--- a/ui/apps/pixano/src/lib/api/index.ts
+++ b/ui/apps/pixano/src/lib/api/index.ts
@@ -7,6 +7,7 @@ License: CECILL-C
 export * from "./datasets";
 export * from "./filters";
 export * from "./records";
+export * from "./search";
 export * from "./workspace";
 export * from "./schemaApi";
 export * from "./inferenceApi";

--- a/ui/apps/pixano/src/lib/api/search.ts
+++ b/ui/apps/pixano/src/lib/api/search.ts
@@ -1,0 +1,69 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { toDatasetBrowser } from "./adapters";
+import { JSON_HEADERS, requestJson } from "./apiClient";
+import type { PaginatedResponse, RecordResponse } from "./restTypes";
+import type { DatasetBrowser } from "$lib/types/dataset";
+
+export interface RecordSearchOptions {
+  model?: string;
+  text?: string;
+  similarTo?: string;
+  k?: number;
+  filters?: string[];
+  where?: string;
+}
+
+interface RecordSearchResponse {
+  items: RecordResponse[];
+  total: number;
+  model: string;
+  mode: string;
+  k: number;
+}
+
+/** Semantic search over records (text→records or find-similar); returns a ranked browser view. */
+export async function searchRecords(
+  datasetId: string,
+  options: RecordSearchOptions,
+): Promise<DatasetBrowser> {
+  const k = options.k ?? 50;
+  const response = await requestJson<RecordSearchResponse>(
+    `/datasets/${datasetId}/records/search`,
+    {
+      headers: JSON_HEADERS,
+      method: "POST",
+      body: JSON.stringify({
+        model: options.model,
+        text: options.text,
+        similar_to: options.similarTo,
+        k,
+        filter: options.filters,
+        where: options.where,
+      }),
+    },
+    "searchRecords",
+  );
+  // The ranked items already carry `_distance` + `view_previews`; render them like a page.
+  const paginated: PaginatedResponse<RecordResponse> = {
+    items: response.items,
+    total: response.total,
+    limit: k,
+    offset: 0,
+  };
+  return toDatasetBrowser(datasetId, paginated);
+}
+
+/** Launch the record-embedding computation job; returns the job id (poll via getIoJob). */
+export async function computeEmbeddings(datasetId: string, model: string): Promise<string> {
+  const response = await requestJson<{ job_id: string }>(
+    `/datasets/${datasetId}/embeddings/compute`,
+    { headers: JSON_HEADERS, method: "POST", body: JSON.stringify({ model }) },
+    "computeEmbeddings",
+  );
+  return response.job_id;
+}

--- a/ui/apps/pixano/src/lib/types/inference.ts
+++ b/ui/apps/pixano/src/lib/types/inference.ts
@@ -16,7 +16,7 @@ export interface ConversationPromptContext {
 export enum MultimodalImageNLPTask {
   CAPTIONING = "image_captioning",
   VLM = "vlm",
-  EMBEDDING = "image_text_embedding",
+  EMBEDDING = "embedding",
   MATCHING = "image_text_matching",
   QUESTION_ANSWERING = "image_question_answering",
 }

--- a/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.svelte
@@ -61,6 +61,7 @@ License: CECILL-C
   <DatasetExplorer
     selectedDataset={data.browserData}
     filterSchema={data.filterSchema}
+    semanticActive={data.semantic?.active ?? false}
     onSelectItem={handleSelectItem}
     onNavigate={navigateTable}
     pagination={data.pagination}

--- a/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.ts
+++ b/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.ts
@@ -5,9 +5,11 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { PageLoad } from "./$types";
-import { listRecords } from "$lib/api";
+import { listRecords, searchRecords } from "$lib/api";
 import { DEFAULT_DATASET_TABLE_PAGE, DEFAULT_DATASET_TABLE_SIZE } from "$lib/constants";
 import { getRouteSearchParams } from "$lib/utils/routes";
+
+const SEMANTIC_LIMIT = 100;
 
 export const load: PageLoad = async ({ params, url }) => {
   const searchParams = getRouteSearchParams(url);
@@ -18,6 +20,27 @@ export const load: PageLoad = async ({ params, url }) => {
   const filters = searchParams.getAll("filter").filter((value) => value !== "");
   const q = searchParams.get("q") ?? "";
   const where = searchParams.get("where") ?? "";
+  const semantic = searchParams.get("semantic") === "1";
+  const similarTo = searchParams.get("similar_to") ?? "";
+  const model = searchParams.get("model") ?? "";
+
+  // Semantic search is a separate ranked endpoint (not paginated); a text query or a
+  // find-similar target activates it. Structured filter chips apply as a prefilter.
+  if ((semantic && q) || similarTo) {
+    const browserData = await searchRecords(params.datasetId, {
+      model: model || undefined,
+      text: similarTo ? undefined : q,
+      similarTo: similarTo || undefined,
+      k: SEMANTIC_LIMIT,
+      filters,
+      where: where || undefined,
+    });
+    return {
+      browserData,
+      pagination: { currentPage: 1, size: SEMANTIC_LIMIT, sort, order, filters, q, where },
+      semantic: { active: true, similarTo, model },
+    };
+  }
 
   const browserData = await listRecords(params.datasetId, {
     offset: (currentPage - 1) * size,
@@ -32,5 +55,6 @@ export const load: PageLoad = async ({ params, url }) => {
   return {
     browserData,
     pagination: { currentPage, size, sort, order, filters, q, where },
+    semantic: { active: false, similarTo: "", model: "" },
   };
 };


### PR DESCRIPTION
## Issue

Fixes #

## Description

Adds **record-level semantic search** on image datasets — text→records and find-similar — built on the realigned pixano-inference embedding task. The CLIP model runs on the pixano-inference server; **no ML model ever loads in the Pixano process**. This is the feature the inference realign (#712) was the foundation for.

**Stacked on #712** — its base retargets to `releases/0.8` once #711 and #712 merge.

### Storage (no model, survives restart / export)
- `RecordEmbedding`: a plain `Embedding` subclass with a `Vector(dim)` column, so the table opens with **no embedding-function registration**. Persisted via a sidecar `embeddings.json` (model/dim/metric) re-injected into `info.tables` on load — `DatasetInfo`, the canonical-name rule, and the JSONL round-trip are untouched (embeddings were already excluded from export).
- `Dataset`: `create_record_embedding_table` / `add_record_embeddings` (plain float vectors) / `build_record_embedding_index` (IVF + `record_id` BTREE, gracefully skipped when too few rows → exact brute force) / `search_records` (raw query vector, cosine, `record_id` prefilter, group-by-record min-distance rank) / `has_record_embeddings` / `record_embedding_space`.

### Compute job
- A background thread tracked in the shared `JobStore` embeds each record's image via `provider.embedding` in batches (data-URI from the view blob), builds the index, and invalidates the API dataset cache. **Idempotent resume** (skips already-embedded records); polled via `GET /io/jobs/{id}`.

### Endpoints
- `POST /datasets/{id}/records/search` — text or `similar_to`, structured-filter prefilter, ranked results with view previews.
- `POST /datasets/{id}/embeddings/compute` — launch the job.
- `GET /datasets/{id}/filters` advertises `search.modes=[text,semantic]` + the model once embeddings exist.
- `POST /inference/embedding` (parity).

### Frontend
- `searchRecords`/`computeEmbeddings`; the explorer branches to `/records/search` for a semantic text query or find-similar; a **Semantic** toggle appears once the mode is advertised; an **Enable semantic search** button computes embeddings (picks a model from the connected server, polls, reloads). Ranked results clear the column sort.

### Tests
- Backend: storage/search/persistence (asserting no model loads), app-level search (text, find-similar, filter-prefilter, 400s), and the compute job end-to-end with a mock provider + BYO vectors. Full backend suite **833 passed**.
- Frontend: `search.test` (query building, ranked-order preservation, compute); check/lint/build/vitest (200) green.

### Live smoke (needs a running server)
Run `pixano-inference --extra clip` (MobileCLIP2), connect it, click **Enable semantic search**, then search "a red car"; confirm ranked results and that a filter chip narrows them.

### Deferred (fast-follow)
A `pixano data embed --vectors <parquet>` CLI for a fully model-free BYO ingest path (the mechanism exists via `add_record_embeddings`); a per-row **find similar** action button (the `?similar_to=` route + backend are already in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)