### PR TITLE
feat: per-row find-similar and embedding-compute progress bar

### DIFF
--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -15,7 +15,7 @@ License: CECILL-C
   import { invalidateAll } from "$app/navigation";
   import { navigating } from "$app/state";
   import { computeEmbeddings, getIoJob, listInferenceModels } from "$lib/api";
-  import type { FilterSchemaResponse } from "$lib/api/restTypes";
+  import type { FilterSchemaResponse, IoJobResponse } from "$lib/api/restTypes";
   import { MultimodalImageNLPTask } from "$lib/types/inference";
   import type { DatasetBrowser } from "$lib/ui";
   import { EXPLORER_ROUTE_ID } from "$lib/utils/routes";
@@ -24,6 +24,8 @@ License: CECILL-C
     selectedDataset: DatasetBrowser;
     filterSchema: FilterSchemaResponse;
     semanticActive?: boolean;
+    /** Record id the current ranked view is "similar to" (find-similar mode). */
+    similarTo?: string;
     onSelectItem?: (itemId: string) => void;
     onNavigate: (updates: Record<string, string | string[] | undefined>) => void;
     pagination: {
@@ -41,25 +43,40 @@ License: CECILL-C
     selectedDataset,
     filterSchema,
     semanticActive = false,
+    similarTo = "",
     onSelectItem,
     onNavigate,
     pagination,
   }: Props = $props();
   const isLoadingTableItems = $derived(navigating.to?.route?.id === EXPLORER_ROUTE_ID);
+  const semanticAvailable = $derived((filterSchema.search?.modes ?? []).includes("semantic"));
 
   let computing = $state(false);
   let showConnectModal = $state(false);
+  let computeJob = $state<IoJobResponse | null>(null);
+  let computeError = $state("");
 
   async function runCompute(): Promise<boolean> {
     // Returns false when no embedding model is reachable (caller prompts to connect).
     const models = await listInferenceModels();
     const embeddingModels = models.filter((m) => m.task === MultimodalImageNLPTask.EMBEDDING);
     if (embeddingModels.length === 0) return false;
+    computeError = "";
     const jobId = await computeEmbeddings(selectedDataset.id, embeddingModels[0].name);
-    for (;;) {
-      const job = await getIoJob(jobId);
-      if (["done", "error", "cancelled"].includes(job.status)) break;
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+    try {
+      for (;;) {
+        const job = await getIoJob(jobId);
+        computeJob = job;
+        if (["done", "error", "cancelled"].includes(job.status)) {
+          if (job.status === "error") {
+            computeError = job.error?.message ?? "Embedding computation failed.";
+          }
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
+    } finally {
+      computeJob = null;
     }
     await invalidateAll();
     return true;
@@ -93,6 +110,23 @@ License: CECILL-C
       similar_to: undefined, // a text search or filter change exits find-similar mode
       ...(semantic ? { sort: undefined, order: undefined } : {}),
     });
+  }
+
+  function handleFindSimilar(recordId: string) {
+    // Ranked by similarity to the record: keep filter chips (they prefilter), clear the
+    // text query, semantic-text mode, and any column sort.
+    onNavigate({
+      page: "1",
+      similar_to: recordId,
+      q: undefined,
+      semantic: undefined,
+      sort: undefined,
+      order: undefined,
+    });
+  }
+
+  function handleClearSimilar() {
+    onNavigate({ page: "1", similar_to: undefined });
   }
 
   async function handleCompute() {
@@ -144,9 +178,13 @@ License: CECILL-C
           q={pagination.q}
           total={selectedDataset.pagination.total_size}
           {semanticActive}
+          {similarTo}
           {computing}
+          computeProgress={computeJob?.progress ?? null}
+          {computeError}
           onApply={handleApply}
           onCompute={handleCompute}
+          onClearSimilar={handleClearSimilar}
         />
       </div>
 
@@ -166,6 +204,7 @@ License: CECILL-C
                 activeSort={{ col: pagination.sort, order: pagination.order }}
                 onSelectItem={handleSelectItem}
                 onColsort={handleColSort}
+                onFindSimilar={semanticAvailable ? handleFindSimilar : undefined}
               />
             {/key}
           </div>

--- a/ui/apps/pixano/src/components/dataset/RecordFilterBar.svelte
+++ b/ui/apps/pixano/src/components/dataset/RecordFilterBar.svelte
@@ -8,7 +8,7 @@ License: CECILL-C
   import { CircleNotch, FunnelSimple, MagnifyingGlass, Plus, Sparkle, X } from "phosphor-svelte";
 
   import FilterChipEditor from "./FilterChipEditor.svelte";
-  import type { FilterSchemaResponse } from "$lib/api/restTypes";
+  import type { FilterSchemaResponse, IoJobResponse } from "$lib/api/restTypes";
   import {
     isListOperator,
     OPERATOR_LABELS,
@@ -23,9 +23,15 @@ License: CECILL-C
     q: string;
     total: number;
     semanticActive?: boolean;
+    /** Record id the current ranked view is "similar to" (find-similar mode). */
+    similarTo?: string;
     computing?: boolean;
+    /** Live progress of the embedding-compute job (while `computing`). */
+    computeProgress?: IoJobResponse["progress"] | null;
+    computeError?: string;
     onApply: (updates: { filter?: string[]; q?: string; semantic?: boolean }) => void;
     onCompute?: () => void;
+    onClearSimilar?: () => void;
   }
 
   let {
@@ -34,10 +40,21 @@ License: CECILL-C
     q,
     total,
     semanticActive = false,
+    similarTo = "",
     computing = false,
+    computeProgress = null,
+    computeError = "",
     onApply,
     onCompute,
+    onClearSimilar,
   }: Props = $props();
+
+  // Determinate compute progress (pulse fallback while the total is unknown).
+  const computeDone = $derived(computeProgress?.done ?? 0);
+  const computeTotal = $derived(computeProgress?.total ?? null);
+  const computePercent = $derived(
+    computeTotal ? Math.min(100, Math.round((computeDone / computeTotal) * 100)) : null,
+  );
 
   const columns = $derived(filterSchema.columns);
   const hasSearchable = $derived(columns.some((c) => c.searchable));
@@ -175,6 +192,23 @@ License: CECILL-C
       <Plus size={14} />
     </button>
 
+    {#if similarTo}
+      <div
+        class="inline-flex items-center gap-1 h-7 pl-2.5 pr-1 rounded-full border border-primary/30 bg-primary/10 text-xs text-foreground"
+      >
+        <Sparkle size={12} class="text-primary" />
+        <span class="font-medium">Similar to {similarTo}</span>
+        <button
+          type="button"
+          onclick={() => onClearSimilar?.()}
+          aria-label="Exit find-similar mode"
+          class="p-0.5 rounded-full hover:bg-primary/20"
+        >
+          <X size={12} />
+        </button>
+      </div>
+    {/if}
+
     <span class="ml-auto text-sm text-muted-foreground tabular-nums">
       {#if semanticActive}
         <span class="text-primary">Ranked by similarity ·</span>
@@ -183,6 +217,33 @@ License: CECILL-C
       {total === 1 ? "record" : "records"}
     </span>
   </div>
+
+  {#if computing && computeProgress}
+    <div class="flex items-center gap-3">
+      <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-border">
+        {#if computePercent !== null}
+          <div
+            class="h-full rounded-full bg-primary transition-[width] duration-500"
+            style="width: {computePercent}%"
+          ></div>
+        {:else}
+          <div class="h-full w-1/3 animate-pulse rounded-full bg-primary/60"></div>
+        {/if}
+      </div>
+      <span class="shrink-0 text-xs text-muted-foreground tabular-nums">
+        {#if computeTotal !== null}
+          {computeDone.toLocaleString()} / {computeTotal.toLocaleString()} records
+          {#if computePercent !== null}· {computePercent}%{/if}
+        {:else}
+          Embedding records…
+        {/if}
+      </span>
+    </div>
+  {/if}
+
+  {#if computeError}
+    <p class="text-xs text-destructive">Embedding computation failed: {computeError}</p>
+  {/if}
 
   {#if activeFilters.length > 0}
     <div class="flex flex-wrap items-center gap-1.5">

--- a/ui/apps/pixano/src/components/dataset/table/Table.svelte
+++ b/ui/apps/pixano/src/components/dataset/table/Table.svelte
@@ -15,7 +15,7 @@ License: CECILL-C
   } from "@tanstack/table-core";
   // Pixano Core Imports
   import { Button, Checkbox } from "bits-ui";
-  import { CaretDoubleDown, CaretDoubleUp, CaretUpDown, Check } from "phosphor-svelte";
+  import { CaretDoubleDown, CaretDoubleUp, CaretUpDown, Check, Sparkle } from "phosphor-svelte";
   import { untrack } from "svelte";
   import SortableList from "svelte-sortable-list";
 
@@ -31,9 +31,11 @@ License: CECILL-C
     activeSort?: { col: string; order: string };
     onColsort?: (sortKeys: { id: string; order: string }[]) => void;
     onSelectItem?: (id: string) => void;
+    /** When set, each row shows a "Find similar" action emitting the record id. */
+    onFindSimilar?: (id: string) => void;
   }
 
-  let { items, activeSort, onColsort, onSelectItem }: Props = $props();
+  let { items, activeSort, onColsort, onSelectItem, onFindSimilar }: Props = $props();
 
   // Build column definitions from items.columns
   const buildColumns = (): ColumnDef<TableRow>[] => {
@@ -295,6 +297,23 @@ License: CECILL-C
             </td>
           {/each}
           <td class="w-full border-b border-border"></td>
+          {#if onFindSimilar}
+            <!-- Find-similar action (semantic search) -->
+            <td class="border-b border-border">
+              <button
+                type="button"
+                title="Find similar records"
+                aria-label="Find similar records"
+                class="flex h-8 w-8 mx-auto ml-3 items-center justify-center border rounded-full border-border text-foreground transition-colors hover:bg-accent hover:text-primary"
+                onclick={(event: MouseEvent) => {
+                  event.stopPropagation();
+                  onFindSimilar(items.rows[Number(row.id)].id as string);
+                }}
+              >
+                <Sparkle size={16} />
+              </button>
+            </td>
+          {/if}
           <!-- Go Button -->
           <td class="border-b border-border">
             <svg

--- a/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.svelte
@@ -62,6 +62,7 @@ License: CECILL-C
     selectedDataset={data.browserData}
     filterSchema={data.filterSchema}
     semanticActive={data.semantic?.active ?? false}
+    similarTo={data.semantic?.similarTo ?? ""}
     onSelectItem={handleSelectItem}
     onNavigate={navigateTable}
     pagination={data.pagination}


### PR DESCRIPTION
## Issue

Fixes #

## Description

Two semantic-search fast-follows deferred from #713 — frontend only, both building on plumbing that already works (`POST /records/search` with `similar_to`; the compute job's `progress.done/total` in the shared job store).

### Per-row "Find similar"
- Each explorer row gains a Sparkle button (shown only when the dataset advertises semantic search in `/filters`). Clicking it navigates to the ranked similar view (`?similar_to=<id>`), keeping active filter chips as the prefilter and clearing the text query and column sort. `stopPropagation` keeps the row click (open workspace) independent.
- While active, the filter bar shows a removable **"Similar to <id> ×"** pill; the × returns to the normal list.

### Compute progress bar
- "Enable semantic search" now shows a determinate progress bar (`N / M records · %`, pulse fallback while the total is unknown) driven by the polled job progress, instead of only a spinner.
- A job that ends in `error` — previously swallowed — surfaces its message inline.

### Tests
- check (0 errors) + lint + format + build + vitest (200) green. No API-layer changes (covered by existing `search.test.ts`).

### Live smoke
On a dataset with embeddings: Sparkle on a row → ranked similar results + pill; × → back; a filter chip narrows the similar results. On a fresh dataset: Enable semantic search → bar advances to done → Semantic toggle appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)