### PR TITLE
feat: explorer gallery view — record cards + resizable previews

### DIFF
--- a/src/pixano/api/models.py
+++ b/src/pixano/api/models.py
@@ -135,6 +135,7 @@ class PreviewDescriptor(ResponseModel):
     id: str
     kind: str
     preview_url: str
+    excerpt: str | None = None
 
 
 class RecordListResponse(RecordResponse):  # type: ignore[valid-type, misc]

--- a/src/pixano/api/routers/records.py
+++ b/src/pixano/api/routers/records.py
@@ -66,11 +66,16 @@ def _query_preview_rows(
         raise HTTPException(status_code=500, detail=f"Internal server error. {err}") from err
 
 
-def _preview_url(dataset_id: str, resource: str, row_id: str, uri: object) -> str:
+_PREVIEW_THUMBNAIL_SIZE = 256
+_TEXT_EXCERPT_LENGTH = 160
+
+
+def _preview_url(dataset_id: str, resource: str, row_id: str, uri: object, size: int | None = None) -> str:
     """Datalake rows (spec §6 uri mode) are browser-loadable directly; embedded rows go through /preview."""
     if isinstance(uri, str) and uri.startswith(("http://", "https://")):
         return uri
-    return f"/datasets/{dataset_id}/{resource}/{row_id}/preview"
+    url = f"/datasets/{dataset_id}/{resource}/{row_id}/preview"
+    return f"{url}?size={size}" if size else url
 
 
 def _resolve_view_previews(
@@ -89,7 +94,7 @@ def _resolve_view_previews(
             resource="images",
             id=row_id,
             kind="image",
-            preview_url=_preview_url(dataset_id, "images", row_id, row.get("uri")),
+            preview_url=_preview_url(dataset_id, "images", row_id, row.get("uri"), size=_PREVIEW_THUMBNAIL_SIZE),
         )
 
     # Only the first frame of each sequence is needed for a thumbnail. Filter to
@@ -116,8 +121,30 @@ def _resolve_view_previews(
             resource="sframes",
             id=row_id,
             kind="image",
-            preview_url=_preview_url(dataset_id, "sframes", row_id, row.get("uri")),
+            preview_url=_preview_url(dataset_id, "sframes", row_id, row.get("uri"), size=_PREVIEW_THUMBNAIL_SIZE),
         )
+
+    # Text views: no thumbnail, but an excerpt lets multi-modal cards (e.g. MEL image+text)
+    # show real content. Excerpting in Python is fine at page sizes ≤ 100.
+    if "texts" in dataset.info.tables:
+        text_rows = _query_preview_rows(dataset, "texts", ["id", "record_id", "logical_name", "content"], record_ids)
+        for row in text_rows:
+            record_id = str(row.get("record_id", "") or "")
+            logical_name = str(row.get("logical_name", "") or "")
+            row_id = str(row.get("id", "") or "")
+            if not record_id or not logical_name or not row_id:
+                continue
+            logical_previews = previews_by_record.setdefault(record_id, {})
+            if logical_name in logical_previews:
+                continue
+            content = str(row.get("content", "") or "")
+            logical_previews[logical_name] = PreviewDescriptor(
+                resource="texts",
+                id=row_id,
+                kind="text",
+                preview_url="",
+                excerpt=content[:_TEXT_EXCERPT_LENGTH],
+            )
 
     return previews_by_record
 

--- a/src/pixano/api/routers/views.py
+++ b/src/pixano/api/routers/views.py
@@ -7,8 +7,10 @@
 """Subtype-specific view routers."""
 
 import hashlib
+import io
 from typing import Annotated, Any
 
+import PIL.Image
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 
@@ -92,22 +94,62 @@ def _stream_blob(dataset: Dataset, table_name: str, row_id: str) -> Response:
     return Response(content=blob_data, media_type=media_type_from_format(fmt))
 
 
-def _stream_preview(dataset: Dataset, table_name: str, row_id: str) -> Response:
-    row = _get_row(dataset, table_name, row_id)
-    preview = getattr(row, "preview", b"") or b""
-    preview_format = getattr(row, "preview_format", "") or ""
-    if not preview or not preview_format:
-        raise HTTPException(status_code=404, detail=f"Resource '{row_id}' has no preview.")
+PREVIEW_SIZES = (128, 256, 512)
 
-    etag = hashlib.sha1(preview).hexdigest()  # noqa: S324
+
+def _resize_from_blob(dataset: Dataset, table_name: str, row_id: str, size: int) -> tuple[bytes, str] | None:
+    """Produce a `size`-bounded JPEG thumbnail from the row's full embedded blob, if any."""
+    try:
+        result = dataset.get_view_binary(table_name, row_id)
+    except DatasetAccessError:
+        return None
+    if result is None:
+        return None
+    blob, _fmt = result
+    if not blob:
+        return None
+    try:
+        image = PIL.Image.open(io.BytesIO(blob))
+        image.thumbnail((size, size))
+        buffer = io.BytesIO()
+        image.convert("RGB").save(buffer, format="JPEG", quality=85)
+    except Exception:  # noqa: BLE001 - unreadable blob → fall back to the stored preview
+        return None
+    return buffer.getvalue(), "jpeg"
+
+
+def _stream_preview(dataset: Dataset, table_name: str, row_id: str, size: int | None = None) -> Response:
+    row = _get_row(dataset, table_name, row_id)
+
+    content: bytes | None = None
+    content_format = ""
+    if size is not None:
+        # Larger-than-stored thumbnail, resized on demand from the full blob (cacheable).
+        resized = _resize_from_blob(dataset, table_name, row_id, size)
+        if resized is not None:
+            content, content_format = resized
+
+    if content is None:
+        content = getattr(row, "preview", b"") or b""
+        content_format = getattr(row, "preview_format", "") or ""
+        if not content or not content_format:
+            raise HTTPException(status_code=404, detail=f"Resource '{row_id}' has no preview.")
+
+    etag = hashlib.sha1(content).hexdigest()  # noqa: S324
     return Response(
-        content=preview,
-        media_type=media_type_from_format(preview_format),
+        content=content,
+        media_type=media_type_from_format(content_format),
         headers={
             "Cache-Control": "public, max-age=3600",
             "ETag": f'"{etag}"',
         },
     )
+
+
+def _validated_preview_size(size: int | None) -> int | None:
+    if size is not None and size not in PREVIEW_SIZES:
+        raise HTTPException(status_code=400, detail=f"Invalid preview size {size}; allowed: {sorted(PREVIEW_SIZES)}")
+    return size
 
 
 def _image_src(dataset_id: str, resource_name: str, row: Any) -> str:
@@ -266,9 +308,11 @@ def get_image_blob(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Resp
 
 
 @router.get("/images/{id}/preview", operation_id="get_image_preview")
-def get_image_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Response:
+def get_image_preview(
+    id: str, dataset: Dataset = Depends(get_dataset_dep), size: Annotated[int | None, Query()] = None
+) -> Response:
     """Stream the preview thumbnail of an image."""
-    return _stream_preview(dataset, IMAGE_TABLE, id)
+    return _stream_preview(dataset, IMAGE_TABLE, id, size=_validated_preview_size(size))
 
 
 @router.get("/texts", response_model=PaginatedResponse[TextResponse], operation_id="list_texts")
@@ -328,9 +372,11 @@ def get_sframe_blob(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Res
 
 
 @router.get("/sframes/{id}/preview", operation_id="get_sframe_preview")
-def get_sframe_preview(id: str, dataset: Dataset = Depends(get_dataset_dep)) -> Response:
+def get_sframe_preview(
+    id: str, dataset: Dataset = Depends(get_dataset_dep), size: Annotated[int | None, Query()] = None
+) -> Response:
     """Stream the preview thumbnail of a sequence frame."""
-    return _stream_preview(dataset, SFRAME_TABLE, id)
+    return _stream_preview(dataset, SFRAME_TABLE, id, size=_validated_preview_size(size))
 
 
 @router.get(

--- a/tests/app/test_api_preview_resize.py
+++ b/tests/app/test_api_preview_resize.py
@@ -1,0 +1,142 @@
+# =====================================
+# Copyright: CEA-LIST/DIASI/SIALV/LVA
+# Author : pixano@cea.fr
+# License: CECILL-C
+# =====================================
+
+"""Tests for resizable view previews (`?size=`) and text-excerpt view previews."""
+
+import io
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+
+import PIL.Image
+import pytest
+from fastapi.testclient import TestClient
+
+from pixano.api.main import create_app
+from pixano.api.settings import Settings, get_settings
+from pixano.datasets.dataset import Dataset
+from pixano.datasets.dataset_info import DatasetInfo
+from pixano.features import Image, Record, Text
+
+
+DATASET_ID = "preview_resize_dataset"
+BASE = f"/datasets/{DATASET_ID}"
+
+TEXT_CONTENT = "lorem ipsum " * 40  # 480 chars → excerpt must truncate at 160
+
+
+def _png_bytes(width: int, height: int) -> bytes:
+    buffer = io.BytesIO()
+    PIL.Image.new("RGB", (width, height), color=(30, 90, 200)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    tmp = Path(tempfile.mkdtemp())
+    target = tmp / "library" / DATASET_ID
+    dataset = Dataset.create(
+        target,
+        DatasetInfo(
+            id=DATASET_ID,
+            name=DATASET_ID,
+            description="d",
+            record=Record,
+            views={"image": Image, "text": Text},
+        ),
+    )
+    records = [Record(id=f"r{i}") for i in range(4)]
+    # r0: embedded image with a real full-resolution blob (800x600).
+    embedded = Image.from_bytes(record_id="r0", logical_name="image", raw_bytes=_png_bytes(800, 600), id="img_full")
+    # r1: image carrying only a stored preview (no raw_bytes) — resize must fall back.
+    preview_only = Image(
+        id="img_preview_only",
+        record_id="r1",
+        logical_name="image",
+        uri="r1.jpg",
+        width=64,
+        height=64,
+        format="png",
+        preview=_png_bytes(64, 64),
+        preview_format="png",
+    )
+    # r2: datalake image — the raw remote URL must pass through untouched.
+    datalake = Image(
+        id="img_remote",
+        record_id="r2",
+        logical_name="image",
+        uri="https://datalake.example.com/r2.jpg",
+        width=640,
+        height=480,
+        format="jpg",
+    )
+    # r3: text-only record — the card gets an excerpt, no thumbnail.
+    text = Text(id="txt_0", record_id="r3", logical_name="text", content=TEXT_CONTENT)
+
+    dataset.add_records({"records": records, "images": [embedded, preview_only, datalake], "texts": [text]})
+
+    models_dir = tmp / "models"
+    models_dir.mkdir()
+    settings = Settings(library_dir=str(target.parent), models_dir=str(models_dir))
+
+    @lru_cache
+    def get_settings_override():
+        return settings
+
+    app = create_app(settings)
+    app.dependency_overrides[get_settings] = get_settings_override
+    return TestClient(app)
+
+
+class TestPreviewResize:
+    def test_resized_preview_bounds_the_larger_dimension(self, client: TestClient):
+        resp = client.get(f"{BASE}/images/img_full/preview", params={"size": 256})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+        image = PIL.Image.open(io.BytesIO(resp.content))
+        assert max(image.size) == 256
+        assert min(image.size) < 256  # aspect ratio preserved (800x600 → 256x192)
+
+    def test_invalid_size_is_400(self, client: TestClient):
+        resp = client.get(f"{BASE}/images/img_full/preview", params={"size": 300})
+        assert resp.status_code == 400
+
+    def test_etag_varies_by_size(self, client: TestClient):
+        etag_small = client.get(f"{BASE}/images/img_full/preview", params={"size": 128}).headers["etag"]
+        etag_large = client.get(f"{BASE}/images/img_full/preview", params={"size": 256}).headers["etag"]
+        assert etag_small != etag_large
+
+    def test_size_without_blob_falls_back_to_stored_preview(self, client: TestClient):
+        resp = client.get(f"{BASE}/images/img_preview_only/preview", params={"size": 256})
+        assert resp.status_code == 200
+        assert resp.content == _png_bytes(64, 64)
+
+    def test_unsized_preview_still_serves_the_stored_blob(self, client: TestClient):
+        resp = client.get(f"{BASE}/images/img_preview_only/preview")
+        assert resp.status_code == 200
+        assert resp.content == _png_bytes(64, 64)
+
+
+class TestViewPreviewDescriptors:
+    @pytest.fixture()
+    def previews(self, client: TestClient) -> dict:
+        resp = client.get(f"{BASE}/records", params={"include": "view_previews", "limit": 10})
+        assert resp.status_code == 200
+        return {item["id"]: item.get("view_previews", {}) for item in resp.json()["items"]}
+
+    def test_embedded_image_gets_a_sized_preview_url(self, previews: dict):
+        assert previews["r0"]["image"]["preview_url"] == f"{BASE}/images/img_full/preview?size=256"
+
+    def test_datalake_uri_passes_through_unsized(self, previews: dict):
+        assert previews["r2"]["image"]["preview_url"] == "https://datalake.example.com/r2.jpg"
+
+    def test_text_view_yields_a_truncated_excerpt(self, previews: dict):
+        descriptor = previews["r3"]["text"]
+        assert descriptor["kind"] == "text"
+        assert descriptor["resource"] == "texts"
+        assert descriptor["preview_url"] == ""
+        assert descriptor["excerpt"] == TEXT_CONTENT[:160]
+        assert len(descriptor["excerpt"]) == 160

--- a/tests/app/test_api_v2.py
+++ b/tests/app/test_api_v2.py
@@ -210,7 +210,7 @@ class TestStaticImage:
             "resource": "images",
             "id": "image_0",
             "kind": "image",
-            "preview_url": f"{STATIC_BASE}/images/image_0/preview",
+            "preview_url": f"{STATIC_BASE}/images/image_0/preview?size=256",
         }
 
     def test_list_records_rejects_unknown_include(self, static_image_client: TestClient):
@@ -701,7 +701,7 @@ class TestVideo:
             "resource": "sframes",
             "id": "frame_0_0",
             "kind": "image",
-            "preview_url": f"{VIDEO_BASE}/sframes/frame_0_0/preview",
+            "preview_url": f"{VIDEO_BASE}/sframes/frame_0_0/preview?size=256",
         }
 
     def test_stream_sframe_blob(self, video_client: TestClient):

--- a/tests/datasets/io/test_previews.py
+++ b/tests/datasets/io/test_previews.py
@@ -79,12 +79,15 @@ class TestPreviewApi:
 
         records = client.get(f"/datasets/{dataset.info.id}/records", params={"include": "view_previews"}).json()
         descriptor = records["items"][0]["view_previews"]["image"]
-        assert descriptor["preview_url"].endswith("/preview")
+        # Explorer previews request a grid-sized thumbnail, resized from the embedded blob.
+        assert descriptor["preview_url"].endswith("/preview?size=256")
 
         response = client.get(descriptor["preview_url"])
         assert response.status_code == 200
-        assert response.headers["content-type"] == "image/png"
-        assert PIL.Image.open(io.BytesIO(response.content)).format == "PNG"
+        assert response.headers["content-type"] == "image/jpeg"
+        image = PIL.Image.open(io.BytesIO(response.content))
+        assert image.format == "JPEG"
+        assert max(image.size) <= 256
 
     def test_datalake_uri_rows_expose_the_remote_url(self, tmp_path: Path):
         dataset = _import_corpus("mixed_media", tmp_path)  # embedded photo + remote video
@@ -92,6 +95,6 @@ class TestPreviewApi:
 
         records = client.get(f"/datasets/{dataset.info.id}/records", params={"include": "view_previews"}).json()
         previews = records["items"][0]["view_previews"]
-        assert previews["image"]["preview_url"].endswith("/preview")  # embedded -> route
+        assert previews["image"]["preview_url"].endswith("/preview?size=256")  # embedded -> route
         embedded = client.get(previews["image"]["preview_url"])
         assert embedded.status_code == 200

--- a/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
+++ b/ui/apps/pixano/src/components/dataset/DatasetExplorer.svelte
@@ -9,13 +9,16 @@ License: CECILL-C
   import ConnectToServerModal from "../inference/ConnectToServerModal.svelte";
   import DatasetPagination from "./DatasetPagination.svelte";
   import ExplorerEmptyState from "./ExplorerEmptyState.svelte";
+  import GridSkeleton from "./GridSkeleton.svelte";
   import RecordFilterBar from "./RecordFilterBar.svelte";
+  import RecordGrid from "./RecordGrid.svelte";
   import { Table } from "./table";
   import TableSkeleton from "./TableSkeleton.svelte";
   import { invalidateAll } from "$app/navigation";
   import { navigating } from "$app/state";
   import { computeEmbeddings, getIoJob, listInferenceModels } from "$lib/api";
   import type { FilterSchemaResponse, IoJobResponse } from "$lib/api/restTypes";
+  import { DEFAULT_DATASET_GRID_SIZE, DEFAULT_DATASET_TABLE_SIZE } from "$lib/constants";
   import type { SplitStatusCount } from "$lib/types/dataset";
   import { MultimodalImageNLPTask } from "$lib/types/inference";
   import type { DatasetBrowser } from "$lib/ui";
@@ -29,6 +32,7 @@ License: CECILL-C
     /** Record id the current ranked view is "similar to" (find-similar mode). */
     similarTo?: string;
     searchError?: string;
+    view?: "grid" | "table";
     onSelectItem?: (itemId: string) => void;
     onNavigate: (updates: Record<string, string | string[] | undefined>) => void;
     pagination: {
@@ -49,6 +53,7 @@ License: CECILL-C
     semanticActive = false,
     similarTo = "",
     searchError = "",
+    view = "table",
     onSelectItem,
     onNavigate,
     pagination,
@@ -177,6 +182,18 @@ License: CECILL-C
     onNavigate({ page: "1", size: String(size) });
   }
 
+  function handleViewChange(nextView: "grid" | "table") {
+    if (nextView === view) return;
+    // Remember the choice per dataset; switching views resets to page 1 with the
+    // view's default page size.
+    localStorage.setItem(`pixano.explorer.view.${selectedDataset.id}`, nextView);
+    onNavigate({
+      page: "1",
+      view: nextView,
+      size: String(nextView === "grid" ? DEFAULT_DATASET_GRID_SIZE : DEFAULT_DATASET_TABLE_SIZE),
+    });
+  }
+
   function handleClearAllForEmptyState() {
     onNavigate({
       page: "1",
@@ -206,10 +223,12 @@ License: CECILL-C
         computeProgress={computeJob?.progress ?? null}
         {computeError}
         {searchError}
+        {view}
         onApply={handleApply}
         onSortChange={handleSortSelect}
         onCompute={handleCompute}
         onClearSimilar={handleClearSimilar}
+        onViewChange={handleViewChange}
       />
     </div>
 
@@ -218,14 +237,25 @@ License: CECILL-C
       class="flex-1 min-h-0 overflow-hidden flex flex-col border border-border/50 rounded-xl bg-card shadow-elevation-1"
     >
       {#if isLoadingTableItems}
-        <TableSkeleton
-          rows={pagination.size}
-          columns={Math.min(selectedDataset.table_data.columns.length, 6)}
-        />
+        {#if view === "grid"}
+          <GridSkeleton count={pagination.size} />
+        {:else}
+          <TableSkeleton
+            rows={pagination.size}
+            columns={Math.min(selectedDataset.table_data.columns.length, 6)}
+          />
+        {/if}
       {:else if isEmpty}
         <ExplorerEmptyState
           {hasActiveQuery}
           onClear={hasActiveQuery ? handleClearAllForEmptyState : undefined}
+        />
+      {:else if view === "grid"}
+        <RecordGrid
+          cards={selectedDataset.card_data ?? []}
+          {ranked}
+          onOpen={handleSelectItem}
+          onFindSimilar={semanticAvailable ? handleFindSimilar : undefined}
         />
       {:else}
         <div class="flex-1 min-h-0">
@@ -248,7 +278,7 @@ License: CECILL-C
         {selectedDataset}
         currentPage={pagination.currentPage}
         pageSize={pagination.size}
-        pageSizeOptions={ranked ? [] : [20, 50, 100]}
+        pageSizeOptions={ranked ? [] : view === "grid" ? [24, 48, 96] : [20, 50, 100]}
         onPageChange={handlePageChange}
         onPageSizeChange={handlePageSizeChange}
       />

--- a/ui/apps/pixano/src/components/dataset/GridSkeleton.svelte
+++ b/ui/apps/pixano/src/components/dataset/GridSkeleton.svelte
@@ -1,0 +1,37 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { Skeleton } from "$lib/ui";
+
+  interface Props {
+    /** Number of skeleton cards (mirror the grid page size, capped for sanity). */
+    count?: number;
+  }
+
+  let { count = 12 }: Props = $props();
+
+  const items = $derived(Array.from({ length: Math.min(Math.max(count, 6), 24) }, (_, k) => k));
+</script>
+
+<div class="w-full h-full overflow-hidden" aria-hidden="true">
+  <div
+    class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4 p-4"
+  >
+    {#each items as i (i)}
+      <div
+        class="flex flex-col overflow-hidden rounded-2xl border border-border bg-card"
+        style="opacity: {1 - i * 0.04}"
+      >
+        <Skeleton class="aspect-square w-full rounded-none" />
+        <div class="px-3 py-2.5 flex items-center gap-2">
+          <Skeleton class="h-3 flex-1 rounded-full" />
+          <Skeleton class="h-3 w-10 rounded-full" />
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/ui/apps/pixano/src/components/dataset/RecordCard.svelte
+++ b/ui/apps/pixano/src/components/dataset/RecordCard.svelte
@@ -1,0 +1,194 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import { ArrowRight, FilmStrip, Sparkle } from "phosphor-svelte";
+
+  import type { RecordCard } from "$lib/types/dataset";
+  import { cardLayout } from "$lib/utils/cardLayout";
+
+  interface Props {
+    record: RecordCard;
+    /** 1-based rank in ranked (semantic / find-similar) mode. */
+    rank?: number;
+    onOpen: (id: string) => void;
+    onFindSimilar?: (id: string) => void;
+  }
+
+  let { record, rank, onOpen, onFindSimilar }: Props = $props();
+
+  const layout = $derived(cardLayout(record.previews));
+  const primaryIsVideo = $derived(layout.media[0]?.resource === "sframes");
+
+  const statusToneClass = (status: string): string => {
+    switch (status) {
+      case "validated":
+      case "done":
+        return "bg-success/10 text-success";
+      case "in_progress":
+      case "reviewed":
+        return "bg-warning/10 text-warning";
+      default:
+        return "bg-muted text-muted-foreground";
+    }
+  };
+
+  const overlayButtonClass =
+    "flex h-10 w-10 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition-colors hover:bg-background hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+</script>
+
+<div
+  role="button"
+  tabindex="0"
+  aria-label="Open record {record.id}"
+  onclick={() => onOpen(record.id)}
+  onkeydown={(event: KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpen(record.id);
+    }
+  }}
+  class="group/card relative flex flex-col overflow-hidden bg-card rounded-2xl border border-border shadow-sm hover:shadow-2xl hover:border-primary/30 hover:-translate-y-1.5 transition-all duration-500 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+>
+  <!-- Media area -->
+  <div class="relative aspect-square w-full overflow-hidden bg-muted">
+    {#if layout.kind === "single" || layout.kind === "many"}
+      <img
+        src={layout.media[0].url}
+        alt="record preview"
+        loading="lazy"
+        class="w-full h-full object-cover transition-transform duration-700 group-hover/card:scale-105"
+      />
+    {:else if layout.kind === "duo"}
+      <div class="grid grid-cols-2 gap-px bg-border w-full h-full">
+        {#each layout.media as preview (preview.name)}
+          <img
+            src={preview.url}
+            alt="record preview — {preview.name}"
+            loading="lazy"
+            class="w-full h-full object-cover transition-transform duration-700 group-hover/card:scale-105"
+          />
+        {/each}
+      </div>
+    {:else if layout.kind === "imageText"}
+      <div class="flex flex-col w-full h-full">
+        <div class="relative flex-[3] min-h-0 overflow-hidden">
+          <img
+            src={layout.media[0].url}
+            alt="record preview"
+            loading="lazy"
+            class="w-full h-full object-cover transition-transform duration-700 group-hover/card:scale-105"
+          />
+        </div>
+        <div
+          class="flex-[2] min-h-0 p-3 text-xs text-muted-foreground font-mono leading-relaxed border-t border-border/40 bg-surface-2 overflow-hidden"
+        >
+          <p class="line-clamp-4">{layout.text?.excerpt}</p>
+        </div>
+      </div>
+    {:else if layout.kind === "textOnly"}
+      <div class="w-full h-full p-4 bg-surface-2 overflow-hidden">
+        <p class="text-xs text-muted-foreground font-mono leading-relaxed line-clamp-[10]">
+          {layout.text?.excerpt}
+        </p>
+      </div>
+    {:else}
+      <!-- No previews at all: typographic placeholder -->
+      <div class="w-full h-full flex items-center justify-center bg-primary/5">
+        <span class="text-4xl font-black text-primary/30 select-none uppercase">
+          {record.id.slice(0, 1) || "?"}
+        </span>
+      </div>
+    {/if}
+
+    <!-- Badges -->
+    {#if primaryIsVideo}
+      <span
+        class="absolute top-2 left-2 inline-flex items-center gap-1 px-2 py-1 rounded-full bg-background/80 backdrop-blur-md text-[10px] font-black uppercase tracking-widest text-foreground"
+      >
+        <FilmStrip size={12} />
+        Video
+      </span>
+    {/if}
+    {#if layout.extraCount > 0}
+      <span
+        class="absolute bottom-2 right-2 px-2 py-0.5 rounded-full bg-background/80 backdrop-blur-md text-[10px] font-black uppercase tracking-widest text-foreground"
+      >
+        +{layout.extraCount}
+        {layout.extraCount === 1 ? "view" : "views"}
+      </span>
+    {/if}
+    {#if rank !== undefined}
+      <span
+        class="absolute top-2 right-2 inline-flex items-center gap-1.5 text-[10px] font-black tabular-nums"
+      >
+        <span class="px-2 py-0.5 rounded-full bg-primary text-primary-foreground">#{rank}</span>
+        {#if record.distance !== undefined}
+          <span
+            class="px-2 py-0.5 rounded-full bg-background/80 backdrop-blur-md font-mono text-foreground"
+          >
+            {record.distance.toFixed(3)}
+          </span>
+        {/if}
+      </span>
+    {/if}
+
+    <!-- Hover overlay actions -->
+    <div
+      class="absolute inset-0 bg-black/40 backdrop-blur-[2px] opacity-0 group-hover/card:opacity-100 transition-all duration-300 flex items-center justify-center gap-3"
+    >
+      <button
+        type="button"
+        title="Open record"
+        aria-label="Open record"
+        class="{overlayButtonClass} translate-y-4 group-hover/card:translate-y-0 transition-transform duration-300"
+        onclick={(event: MouseEvent) => {
+          event.stopPropagation();
+          onOpen(record.id);
+        }}
+      >
+        <ArrowRight size={17} />
+      </button>
+      {#if onFindSimilar}
+        <button
+          type="button"
+          title="Find similar records"
+          aria-label="Find similar records"
+          class="{overlayButtonClass} translate-y-4 group-hover/card:translate-y-0 transition-transform duration-300 delay-75"
+          onclick={(event: MouseEvent) => {
+            event.stopPropagation();
+            onFindSimilar(record.id);
+          }}
+        >
+          <Sparkle size={17} />
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Meta strip -->
+  <div class="px-3 py-2 flex items-center gap-2 border-t border-border/40 min-h-[38px]">
+    <span class="font-mono text-[11px] text-muted-foreground truncate flex-1" title={record.id}>
+      {record.id}
+    </span>
+    {#if record.split}
+      <span
+        class="px-1.5 py-0.5 rounded-full bg-info/10 text-info text-[10px] font-bold uppercase tracking-wide shrink-0"
+      >
+        {record.split}
+      </span>
+    {/if}
+    {#if record.status}
+      <span
+        class="px-1.5 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide shrink-0 {statusToneClass(
+          record.status,
+        )}"
+      >
+        {record.status}
+      </span>
+    {/if}
+  </div>
+</div>

--- a/ui/apps/pixano/src/components/dataset/RecordFilterBar.svelte
+++ b/ui/apps/pixano/src/components/dataset/RecordFilterBar.svelte
@@ -11,9 +11,11 @@ License: CECILL-C
     FunnelSimple,
     MagnifyingGlass,
     Plus,
+    Rows,
     SortAscending,
     SortDescending,
     Sparkle,
+    SquaresFour,
     Warning,
     X,
   } from "phosphor-svelte";
@@ -52,10 +54,12 @@ License: CECILL-C
     computeProgress?: IoJobResponse["progress"] | null;
     computeError?: string;
     searchError?: string;
+    view?: "grid" | "table";
     onApply: (updates: { filter?: string[]; q?: string; semantic?: boolean }) => void;
     onSortChange?: (sort: string | undefined, order: string | undefined) => void;
     onCompute?: () => void;
     onClearSimilar?: () => void;
+    onViewChange?: (view: "grid" | "table") => void;
   }
 
   let {
@@ -72,10 +76,12 @@ License: CECILL-C
     computeProgress = null,
     computeError = "",
     searchError = "",
+    view = "table",
     onApply,
     onSortChange,
     onCompute,
     onClearSimilar,
+    onViewChange,
   }: Props = $props();
 
   const columns = $derived(filterSchema.columns);
@@ -317,6 +323,41 @@ License: CECILL-C
     </div>
 
     <div class="flex items-center gap-3 shrink-0">
+      {#if onViewChange}
+        <div
+          class="flex items-center rounded-xl border border-border overflow-hidden shadow-sm"
+          role="group"
+          aria-label="View mode"
+        >
+          <button
+            type="button"
+            title="Gallery view"
+            aria-label="Gallery view"
+            aria-pressed={view === "grid"}
+            class="px-3 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring {view ===
+            'grid'
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-background text-muted-foreground hover:text-foreground'}"
+            onclick={() => onViewChange("grid")}
+          >
+            <SquaresFour size={16} weight={view === "grid" ? "fill" : "regular"} />
+          </button>
+          <button
+            type="button"
+            title="Table view"
+            aria-label="Table view"
+            aria-pressed={view === "table"}
+            class="px-3 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring {view ===
+            'table'
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-background text-muted-foreground hover:text-foreground'}"
+            onclick={() => onViewChange("table")}
+          >
+            <Rows size={16} weight={view === "table" ? "fill" : "regular"} />
+          </button>
+        </div>
+      {/if}
+
       {#if onSortChange && sortableColumns.length > 0}
         <div
           class="flex items-center gap-1"

--- a/ui/apps/pixano/src/components/dataset/RecordGrid.svelte
+++ b/ui/apps/pixano/src/components/dataset/RecordGrid.svelte
@@ -1,0 +1,32 @@
+<!-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------->
+
+<script lang="ts">
+  import RecordCard from "./RecordCard.svelte";
+  import type { RecordCard as RecordCardType } from "$lib/types/dataset";
+
+  interface Props {
+    cards: RecordCardType[];
+    /** Ranked (semantic / find-similar) mode: show rank + distance chips. */
+    ranked?: boolean;
+    onOpen: (id: string) => void;
+    onFindSimilar?: (id: string) => void;
+  }
+
+  let { cards, ranked = false, onOpen, onFindSimilar }: Props = $props();
+</script>
+
+<div class="w-full h-full overflow-y-auto">
+  <div
+    class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4 p-4"
+  >
+    {#each cards as card, i (card.id)}
+      <div class="animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <RecordCard record={card} rank={ranked ? i + 1 : undefined} {onOpen} {onFindSimilar} />
+      </div>
+    {/each}
+  </div>
+</div>

--- a/ui/apps/pixano/src/lib/api/__tests__/adapters.test.ts
+++ b/ui/apps/pixano/src/lib/api/__tests__/adapters.test.ts
@@ -71,3 +71,59 @@ describe("toDatasetBrowser list attributes", () => {
     expect(browser.table_data.rows[0].image).toBe("/blob/v0");
   });
 });
+
+describe("toDatasetBrowser card_data", () => {
+  it("builds one card per record with previews, badges and custom attrs", () => {
+    const browser = toDatasetBrowser(
+      "ds",
+      paginated([
+        {
+          id: "r0",
+          split: "train",
+          status: "new",
+          created_at: "2026-01-01",
+          scene: "urban",
+          view_previews: {
+            rgb: { resource: "images", id: "i0", kind: "image", preview_url: "/i0?size=256" },
+            thermal: { resource: "images", id: "i1", kind: "image", preview_url: "/i1?size=256" },
+          },
+        },
+      ]),
+    );
+    const card = browser.card_data?.[0];
+    if (!card) throw new Error("card_data missing");
+    expect(card.id).toBe("r0");
+    expect(card.split).toBe("train");
+    expect(card.status).toBe("new");
+    expect(card.previews.map((p) => p.name)).toEqual(["rgb", "thermal"]);
+    expect(card.previews[0].url).toBe("/i0?size=256");
+    // system fields are excluded from the attr line; customs are kept
+    expect(card.attrs).toEqual({ scene: "urban" });
+  });
+
+  it("maps a text preview to an excerpt (card) and a str column (table)", () => {
+    const browser = toDatasetBrowser(
+      "ds",
+      paginated([
+        {
+          id: "r0",
+          view_previews: {
+            text: { resource: "texts", id: "t0", kind: "text", preview_url: "", excerpt: "lorem" },
+          },
+        },
+      ]),
+    );
+    const card = browser.card_data?.[0];
+    if (!card) throw new Error("card_data missing");
+    expect(card.previews[0]).toMatchObject({ kind: "text", resource: "texts", excerpt: "lorem" });
+    // the table shows the excerpt string, not an empty preview URL
+    expect(columnType(browser, "text")).toBe("str");
+    expect(browser.table_data.rows[0].text).toBe("lorem");
+  });
+
+  it("carries _distance into the card in ranked mode", () => {
+    const browser = toDatasetBrowser("ds", paginated([{ id: "r0", _distance: 0.42 }]));
+    expect(browser.card_data?.[0].distance).toBe(0.42);
+    expect(browser.card_data?.[0].attrs).toEqual({});
+  });
+});

--- a/ui/apps/pixano/src/lib/api/adapters.ts
+++ b/ui/apps/pixano/src/lib/api/adapters.ts
@@ -24,6 +24,8 @@ import {
   type DatasetSchema,
   type DS_Schema,
   type RawSchemaData,
+  type RecordCard,
+  type RecordPreview,
   type TableColumn,
   type TableRow,
 } from "$lib/types/dataset";
@@ -169,6 +171,16 @@ function inferColumnType(value: unknown): string {
   return "str";
 }
 
+/** Record fields that are system-owned and excluded from a card's attribute line. */
+const CARD_SYSTEM_FIELDS = new Set([
+  "id",
+  "split",
+  "status",
+  "created_at",
+  "updated_at",
+  "_distance",
+]);
+
 export function toDatasetBrowser(
   datasetId: string,
   records: PaginatedResponse<RecordResponse>,
@@ -180,29 +192,59 @@ export function toDatasetBrowser(
 
   const columnsMap = new Map<string, string>();
   const viewColumns = new Map<string, string>();
+  const cards: RecordCard[] = [];
   const rows: TableRow[] = items.map((record) => {
     const row: TableRow = {};
+    const attrs: RecordCard["attrs"] = {};
     for (const [key, value] of Object.entries(record)) {
       if (Array.isArray(value)) {
         // List attributes (e.g. LeRobot `tasks`) render as a joined string —
         // the table can only show primitives, and an instruction reads best
         // as text. The raw array stays available in the single-item view.
-        row[key] = value.map((item) => (item == null ? "" : String(item))).join("; ");
+        const joined = value.map((item) => (item == null ? "" : String(item))).join("; ");
+        row[key] = joined;
+        if (!CARD_SYSTEM_FIELDS.has(key)) attrs[key] = joined;
         if (!columnsMap.has(key)) columnsMap.set(key, "list");
         continue;
       }
       if (typeof value === "object" && value !== null) continue; // nested objects aren't renderable
       row[key] = (value ?? "") as string | number | boolean;
+      if (!CARD_SYSTEM_FIELDS.has(key) && key !== "view_previews") {
+        attrs[key] = (value ?? "") as string | number | boolean;
+      }
       if (!columnsMap.has(key)) {
         columnsMap.set(key, inferColumnType(value));
       }
     }
 
+    const previews: RecordPreview[] = [];
     const viewPreviews = record.view_previews;
     for (const [logicalName, preview] of Object.entries(viewPreviews ?? {})) {
-      row[logicalName] = preview.preview_url;
-      viewColumns.set(logicalName, preview.kind);
+      if (preview.kind === "text") {
+        // Text views carry an excerpt, not a thumbnail: the table shows the text.
+        row[logicalName] = preview.excerpt ?? "";
+        viewColumns.set(logicalName, "str");
+      } else {
+        row[logicalName] = preview.preview_url;
+        viewColumns.set(logicalName, preview.kind);
+      }
+      previews.push({
+        name: logicalName,
+        kind: preview.kind === "text" ? "text" : "image",
+        resource: preview.resource,
+        url: preview.preview_url,
+        excerpt: preview.excerpt ?? undefined,
+      });
     }
+
+    cards.push({
+      id: String(record.id ?? ""),
+      split: typeof record.split === "string" ? record.split : undefined,
+      status: typeof record.status === "string" ? record.status : undefined,
+      distance: typeof record._distance === "number" ? record._distance : undefined,
+      previews,
+      attrs,
+    });
 
     return row;
   });
@@ -222,6 +264,7 @@ export function toDatasetBrowser(
       columns,
       rows,
     },
+    card_data: cards,
     pagination: {
       current_page: Math.floor(records.offset / Math.max(records.limit, 1)) + 1,
       page_size: records.limit,

--- a/ui/apps/pixano/src/lib/api/restTypes.ts
+++ b/ui/apps/pixano/src/lib/api/restTypes.ts
@@ -103,6 +103,7 @@ export interface PreviewDescriptor {
   id: string;
   kind: string;
   preview_url: string;
+  excerpt?: string | null;
 }
 
 export interface RecordComponentResponse {

--- a/ui/apps/pixano/src/lib/constants.ts
+++ b/ui/apps/pixano/src/lib/constants.ts
@@ -9,6 +9,7 @@ import { Database, House } from "phosphor-svelte";
 // --- Dataset table defaults ---
 
 export const DEFAULT_DATASET_TABLE_SIZE = 20;
+export const DEFAULT_DATASET_GRID_SIZE = 48;
 export const DEFAULT_DATASET_TABLE_PAGE = 1;
 
 export const COUNTS_COLUMNS_PREFIX = "#";

--- a/ui/apps/pixano/src/lib/types/dataset.ts
+++ b/ui/apps/pixano/src/lib/types/dataset.ts
@@ -123,10 +123,34 @@ export interface PaginationInfo {
   total_size: number;
 }
 
+/** One view preview available to a record card (image thumbnail or text excerpt). */
+export interface RecordPreview {
+  /** Logical view name (e.g. "image", "front_camera", "text"). */
+  name: string;
+  kind: "image" | "text";
+  /** Backing resource ("images" | "sframes" | "texts") — sframes render a film badge. */
+  resource: string;
+  url: string;
+  excerpt?: string;
+}
+
+/** Card-oriented projection of a record for the gallery view. */
+export interface RecordCard {
+  id: string;
+  split?: string;
+  status?: string;
+  /** Similarity distance in ranked (semantic / find-similar) mode. */
+  distance?: number;
+  previews: RecordPreview[];
+  /** Scalar custom attributes (system fields excluded). */
+  attrs: Record<string, string | number | boolean>;
+}
+
 export interface DatasetBrowserType {
   id: string;
   name: string;
   table_data: TableData;
+  card_data?: RecordCard[];
   pagination: PaginationInfo;
   isErrored?: boolean;
 }
@@ -135,6 +159,7 @@ export class DatasetBrowser implements DatasetBrowserType {
   id: string;
   name: string;
   table_data: TableData;
+  card_data?: RecordCard[];
   pagination: PaginationInfo;
   isErrored?: boolean;
 
@@ -142,6 +167,7 @@ export class DatasetBrowser implements DatasetBrowserType {
     this.id = obj.id;
     this.name = obj.name;
     this.table_data = obj.table_data;
+    this.card_data = obj.card_data;
     this.pagination = obj.pagination;
     this.isErrored = obj.isErrored;
   }

--- a/ui/apps/pixano/src/lib/utils/__tests__/cardLayout.test.ts
+++ b/ui/apps/pixano/src/lib/utils/__tests__/cardLayout.test.ts
@@ -1,0 +1,71 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import { cardLayout } from "../cardLayout";
+import type { RecordPreview } from "$lib/types/dataset";
+
+const image = (name: string, resource = "images"): RecordPreview => ({
+  name,
+  kind: "image",
+  resource,
+  url: `/x/${name}/preview?size=256`,
+});
+
+const text = (name: string, excerpt = "lorem ipsum"): RecordPreview => ({
+  name,
+  kind: "text",
+  resource: "texts",
+  url: "",
+  excerpt,
+});
+
+describe("cardLayout", () => {
+  it("single image → full bleed", () => {
+    const layout = cardLayout([image("image")]);
+    expect(layout.kind).toBe("single");
+    expect(layout.media).toHaveLength(1);
+    expect(layout.extraCount).toBe(0);
+  });
+
+  it("two views (multi-camera) → duo mosaic", () => {
+    const layout = cardLayout([image("rgb"), image("thermal")]);
+    expect(layout.kind).toBe("duo");
+    expect(layout.media.map((m) => m.name)).toEqual(["rgb", "thermal"]);
+  });
+
+  it("three or more views → primary + '+N views'", () => {
+    const layout = cardLayout([image("cam_a"), image("cam_b"), image("cam_c")]);
+    expect(layout.kind).toBe("many");
+    expect(layout.media).toHaveLength(1);
+    expect(layout.extraCount).toBe(2);
+  });
+
+  it("image + text (MEL) → split card", () => {
+    const layout = cardLayout([image("image"), text("text", "some doc")]);
+    expect(layout.kind).toBe("imageText");
+    expect(layout.media).toHaveLength(1);
+    expect(layout.text?.excerpt).toBe("some doc");
+  });
+
+  it("text only → excerpt tile", () => {
+    const layout = cardLayout([text("text")]);
+    expect(layout.kind).toBe("textOnly");
+    expect(layout.media).toHaveLength(0);
+    expect(layout.text?.name).toBe("text");
+  });
+
+  it("no previews → typographic placeholder", () => {
+    expect(cardLayout([]).kind).toBe("none");
+  });
+
+  it("video frame preview keeps its sframes resource for the film badge", () => {
+    const layout = cardLayout([image("frames", "sframes")]);
+    expect(layout.kind).toBe("single");
+    expect(layout.media[0].resource).toBe("sframes");
+  });
+});

--- a/ui/apps/pixano/src/lib/utils/cardLayout.ts
+++ b/ui/apps/pixano/src/lib/utils/cardLayout.ts
@@ -1,0 +1,52 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import type { RecordPreview } from "$lib/types/dataset";
+
+/**
+ * Composition of a record card's media area, derived purely from the previews a
+ * record carries — one rule for every dataset type, no workspace branching.
+ */
+export interface CardLayout {
+  kind: "none" | "single" | "duo" | "many" | "imageText" | "textOnly";
+  /** Image previews to render (1 for single/many, 2 for duo). */
+  media: RecordPreview[];
+  /** Text preview to render (imageText / textOnly). */
+  text?: RecordPreview;
+  /** Number of additional views not shown ("+N views" badge). */
+  extraCount: number;
+}
+
+/** Decide how a record card composes its media area from the previews it has. */
+export function cardLayout(previews: RecordPreview[]): CardLayout {
+  const media = previews.filter((p) => p.kind === "image" && p.url !== "");
+  const texts = previews.filter((p) => p.kind === "text");
+  const text = texts[0];
+
+  if (media.length === 0 && text) {
+    return { kind: "textOnly", media: [], text, extraCount: previews.length - 1 };
+  }
+  if (media.length === 0) {
+    return { kind: "none", media: [], extraCount: 0 };
+  }
+  if (text) {
+    // Image + text (e.g. MEL): split card — primary image with the excerpt panel.
+    return {
+      kind: "imageText",
+      media: media.slice(0, 1),
+      text,
+      extraCount: previews.length - 2,
+    };
+  }
+  if (media.length === 1) {
+    return { kind: "single", media, extraCount: 0 };
+  }
+  if (media.length === 2) {
+    return { kind: "duo", media, extraCount: 0 };
+  }
+  // 3+ views (multi-camera): primary + "+N views" badge.
+  return { kind: "many", media: media.slice(0, 1), extraCount: media.length - 1 };
+}

--- a/ui/apps/pixano/src/lib/utils/routes.ts
+++ b/ui/apps/pixano/src/lib/utils/routes.ts
@@ -29,7 +29,15 @@ export const getWorkspaceRoute = (datasetId: string, itemId: string, query?: str
  * set (`getPageFromPosition`), not carried around; `size` IS carried so that
  * derivation matches the explorer's pagination.
  */
-export const EXPLORER_QUERY_KEYS = ["filter", "q", "sort", "order", "where", "size"] as const;
+export const EXPLORER_QUERY_KEYS = [
+  "filter",
+  "q",
+  "sort",
+  "order",
+  "where",
+  "size",
+  "view",
+] as const;
 
 /** Keep only the result-set-defining params (filter/sort/search) from a set. */
 export const pickExplorerQuery = (params: URLSearchParams): URLSearchParams => {

--- a/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.svelte
+++ b/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.svelte
@@ -53,6 +53,7 @@ License: CECILL-C
     semanticActive={data.semantic?.active ?? false}
     similarTo={data.semantic?.similarTo ?? ""}
     searchError={data.searchError ?? ""}
+    view={data.view ?? "table"}
     onSelectItem={handleSelectItem}
     onNavigate={navigateTable}
     pagination={data.pagination}

--- a/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.ts
+++ b/ui/apps/pixano/src/routes/explorer/[datasetId]/+page.ts
@@ -5,16 +5,42 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { PageLoad } from "./$types";
+import { browser } from "$app/environment";
 import { listRecords, searchRecords } from "$lib/api";
-import { DEFAULT_DATASET_TABLE_PAGE, DEFAULT_DATASET_TABLE_SIZE } from "$lib/constants";
+import {
+  DEFAULT_DATASET_GRID_SIZE,
+  DEFAULT_DATASET_TABLE_PAGE,
+  DEFAULT_DATASET_TABLE_SIZE,
+} from "$lib/constants";
+import type { DatasetBrowser } from "$lib/types/dataset";
 import { getRouteSearchParams } from "$lib/utils/routes";
 
 const SEMANTIC_LIMIT = 100;
 
+type ExplorerView = "grid" | "table";
+
+/** View precedence: URL param → per-dataset localStorage → data-driven default. */
+function resolveView(
+  datasetId: string,
+  urlView: string | null,
+  browserData: DatasetBrowser,
+): ExplorerView {
+  if (urlView === "grid" || urlView === "table") return urlView;
+  if (browser) {
+    const stored = localStorage.getItem(`pixano.explorer.view.${datasetId}`);
+    if (stored === "grid" || stored === "table") return stored;
+  }
+  // One unified rule, no workspace branching: grid whenever records carry previews.
+  const hasPreviews = (browserData.card_data ?? []).some((card) => card.previews.length > 0);
+  return hasPreviews ? "grid" : "table";
+}
+
 export const load: PageLoad = async ({ params, url }) => {
   const searchParams = getRouteSearchParams(url);
+  const urlView = searchParams.get("view");
   const currentPage = parseInt(searchParams.get("page") ?? String(DEFAULT_DATASET_TABLE_PAGE));
-  const size = parseInt(searchParams.get("size") ?? String(DEFAULT_DATASET_TABLE_SIZE));
+  const defaultSize = urlView === "table" ? DEFAULT_DATASET_TABLE_SIZE : DEFAULT_DATASET_GRID_SIZE;
+  const size = parseInt(searchParams.get("size") ?? String(defaultSize));
   const sort = searchParams.get("sort") ?? "";
   const order = searchParams.get("order") ?? "asc";
   const filters = searchParams.getAll("filter").filter((value) => value !== "");
@@ -41,6 +67,7 @@ export const load: PageLoad = async ({ params, url }) => {
         pagination: { currentPage: 1, size: SEMANTIC_LIMIT, sort, order, filters, q, where },
         semantic: { active: true, similarTo, model },
         searchError: "",
+        view: resolveView(params.datasetId, urlView, browserData),
       };
     } catch {
       // A failed semantic search (e.g. unreachable embedding provider) degrades to the
@@ -58,6 +85,7 @@ export const load: PageLoad = async ({ params, url }) => {
         semantic: { active: false, similarTo: "", model: "" },
         searchError:
           "Semantic search failed — showing the unranked list. Check the inference server connection.",
+        view: resolveView(params.datasetId, urlView, browserData),
       };
     }
   }
@@ -77,5 +105,6 @@ export const load: PageLoad = async ({ params, url }) => {
     pagination: { currentPage, size, sort, order, filters, q, where },
     semantic: { active: false, similarTo: "", model: "" },
     searchError: "",
+    view: resolveView(params.datasetId, urlView, browserData),
   };
 };


### PR DESCRIPTION
## Issue

Fixes #

## Description

**PR-B of the explorer redesign** — the gallery. **Stacked on #715** (retarget to `releases/0.8` once it merges).

One unified card design for every dataset shape, composed **data-driven from the previews a record carries** — no per-workspace branching:

| Record shape | Card media area |
|---|---|
| 1 image | full-bleed thumbnail |
| 2 views (multi-camera) | 2-up mosaic |
| 3+ views | primary + "+N views" badge |
| image + text (MEL) | split card with excerpt panel |
| text only | excerpt tile |
| video | frame thumbnail + film badge |
| no previews | typographic placeholder |

Cards show mono id + split/status badges, hover-reveal **Open** / **Find similar** actions, and **rank + distance chips** in semantic/find-similar mode. View toggle in the toolbar; precedence `?view=` → per-dataset localStorage → data-driven default (grid iff any record has a preview). Grid page sizes 24/48/96.

### Backend (small, two additions)
- `?size=` on the image/sframe preview routes (whitelist 128/256/512): resized on demand from the full embedded blob (PIL, JPEG q85), **fallback to the stored 64px preview when no blob**, ETag varies by size, cache headers kept. Record previews now link `?size=256` (datalake http URLs pass through untouched) — cards are sharp instead of upscaled 64px thumbs.
- Text views yield `kind:"text"` descriptors with a 160-char `excerpt` in `view_previews` — MEL/text records get real card content, and the table shows the excerpt instead of nothing. Ranked search shares the same helper.

### Tests
- Backend: new `test_api_preview_resize.py` (resize bounds/aspect, 400 on bad size, ETag-per-size, no-blob fallback, sized URLs, datalake passthrough, excerpt truncation); full app suite **162 passed**.
- Frontend: `cardLayout` rules + `card_data` adapter mapping; vitest **213** · check 0 errors · lint · format · build.

### Live smoke
Image dataset → grid by default, sharp 256px thumbs (network tab shows `?size=256` + cache hits); multi-camera → mosaics; MEL → image+text split; video → film badge; semantic search → rank/distance chips on cards; toggle to table and back → choice remembered; `?view=` survives the workspace round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)