### PR TITLE
feat(web): live 3D box projection into image widgets

### DIFF
--- a/docs/ARCHITECTURE_TOOLING.md
+++ b/docs/ARCHITECTURE_TOOLING.md
@@ -106,7 +106,8 @@ select tool. (It was renamed from `tools/` in the 2026-06-29 refactor; it is not
 
 ```
 scene/
-  sceneContext.ts   SceneContextBase, MutationSink, Scene2DReadContext,
+  sceneContext.ts   SceneContextBase, MutationSink, LiveAnnotationDraft,
+                    LiveDraftSource / LiveDraftChannel, Scene2DReadContext,
                     Scene2DContext, Scene3DContext
   renderer.ts       AnnotationRenderer2D + AnnotationEditor2D (+Factory),
                     AnnotationRenderer3DFactory
@@ -180,8 +181,8 @@ interface ToolHandle3D { activeDragging: boolean; editingId: string | null }
 ### 4. Renderer registries (per kind, per scene type)
 
 ```ts
-interface AnnotationRenderer2D { kind; sync(); destroy() }              // display only (read-only ctx)
-interface AnnotationEditor2D   { kind; syncSelection(); destroy() }     // input: transformer + commit
+interface AnnotationRenderer2D { kind; sync(); syncDraft(draft); destroy() }  // display only (read-only ctx)
+interface AnnotationEditor2D   { kind; syncSelection(); destroy() }           // input: transformer + commit
 interface AnnotationRenderer3DFactory { kind; component: Component<{ ctx: Scene3DContext }> }  // declarative
 ```
 
@@ -190,7 +191,9 @@ pushed into it. On 2D, display and input are separate objects (D4): the
 `AnnotationRenderer2D` takes a read-only `Scene2DReadContext` (so it *cannot* write
 to the queue) and the optional `AnnotationEditor2D` owns the `Konva.Transformer` and
 commits — the widget builds both from the same factory. 2D widgets call `sync()` /
-`syncSelection()` on change; the 3D scene mounts one component per
+`syncSelection()` on change, and `syncDraft()` on every live-draft change (see the
+live-projection note in the worked example: `sync()` is proportional to the
+collection, `syncDraft()` must stay proportional to the draft); the 3D scene mounts one component per
 `RENDERER_FACTORIES_3D` entry and Svelte reactivity redraws it. The scene names no
 kind in either case.
 
@@ -252,8 +255,8 @@ renderers — the 3D wireframe (`BBox3DRenderer.svelte`) and a projected 2D wire
 the image widget (`kinds/2d/bbox3d/bbox3dRenderer2D.ts`). Because the collection is
 record-scoped and `ViewScopedAnnotations` passes record-scoped kinds through every view
 filter, the bbox3ds are *already* in the image widget's store; moving a box in 3D
-updates the same object, so the projection follows live. Adding this display touched
-**no tool, widget, or queue** — it is display-only:
+updates the same object, so a **saved** edit re-projects with no extra plumbing.
+Adding the display touched **no tool, widget, or queue** — it is display-only:
 
 1. `kinds/2d/bbox3d/bbox3dRenderer2D.ts` implements `AnnotationRenderer2D`
    (`kind: "bbox3d"`, read-only `Scene2DReadContext`). `sync()` reads
@@ -266,6 +269,31 @@ updates the same object, so the projection follows live. Adding this display tou
 4. The projection math mirrors the backend `src/pixano/schemas/annotations/bbox.py`
    (`get_3dbbox_corners`, `project_points`): the 8 corners of a unit cube × size ×
    rotation + center, then extrinsics → perspective divide → intrinsics.
+
+**Live projection (2026-07-30) — where "display-only" stopped being true.** The
+paragraph above holds for *committed* geometry. Previewing a gesture **while it is
+still in the pointer's hand** is a different problem: the in-flight box is not in the
+collection at all (the store contract covers committed annotations — membership,
+selection, deletion), so there was nothing for the image widget to re-project. That
+needed a real seam addition, not just a renderer:
+
+1. `LiveAnnotationDraft` + a `liveDraft` slot on `WorkspaceSession`, exposed through
+   `SceneContextBase` as a read/write `LiveDraftChannel` and to renderers as a
+   read-only `LiveDraftSource` (D4: a renderer still cannot publish).
+2. `AnnotationRenderer2D.syncDraft(draft)` — a **required** second entry point.
+   `sync()` reconciles the whole collection; `syncDraft` reconciles only the preview
+   and runs at pointer rate, so it must stay proportional to the draft, never to the
+   collection. `ImageWidget` splits its effect accordingly: structural changes take
+   the full reconcile, the draft takes the narrow path. Required rather than optional
+   so a renamed or mistyped implementation is a compile error, not a silent opt-out;
+   kinds with no cross-widget preview implement a documented no-op.
+3. The 3D tool publishes on every editor change (`BBox3DSession.reportPreview`) and
+   clears on gesture end/unmount — clearing only a draft it owns, since the slot is
+   shared workspace-wide.
+
+The lesson for the next kind: **cross-widget *live* feedback is a seam feature, not a
+renderer feature.** A renderer alone can mirror committed state; it cannot see a
+gesture happening in another medium.
 
 ## History — the refactor stages
 
@@ -317,16 +345,56 @@ check` at baseline error count and `vitest` green:
   `commit*` helpers). Adding a 3D kind no longer needs widget surgery. _Residual
   resolved 2026-07-01 (DEBT-5): the confirm UI + save orchestration also left the widget._
 
-- **DEBT-3 — renderer sync tests (partial).** The 2D *editor* now has coverage
-  (`bboxEditor2D.test.ts` fires drag/transform → asserts the commit). `bboxRenderer2D.sync()`
-  and the 3D Threlte scene still lack node-level tests (need a Konva/Threlte mock
-  harness). _Target: alongside the next 2D kind (mask RLE)._
+- **DEBT-3 — renderer sync tests (partial → mostly resolved for 2D, 2026-07-30).**
+  The 2D *editor* has coverage (`bboxEditor2D.test.ts` fires drag/transform → asserts
+  the commit). `bbox3dRenderer2D` now has node-level tests too
+  (`bbox3dRenderer2D.test.ts`, 21 cases): projection math against hand-computed
+  pixels, per-box independence of the shared scratch buffers, create/destroy
+  lifecycle, entity-visibility filtering, degraded inputs (no calibration / no loaded
+  image), rotation, and the whole `syncDraft` fast path including its gesture
+  start/end transitions. The suite is mutation-checked — removing the visibility
+  check, the rotation matrix, the scratch indexing or the draft-visibility guard each
+  turns it red. **The blocker is gone:** the "Konva mock harness" that debt was
+  waiting on now exists (a `vi.mock("konva")` fake `Line` plus a parameterisable
+  `Scene2DReadContext`), so covering `bboxRenderer2D.sync()` is a copy-and-adapt job.
+  _Remaining: `bboxRenderer2D.sync()`, and the 3D Threlte scene (still needs a Threlte
+  harness — a genuinely separate problem). Target: alongside the next 2D kind (mask RLE)._
 
-- **DEBT-4 — 3D boxes can't be deleted (this branch).** The point-cloud pipeline
-  has no delete path (no Trash button / Delete-key handler / `collection.remove`).
-  `deleteLocalAnnotation` already supports `bbox3d` — it is purely unwired. Fix
-  needs a UX decision (button vs confirm overlay; confirm-on-delete?). _Target: with
-  the next point-cloud UX pass, before GA._
+- **DEBT-7 — 3D boxes can't be selected from an image view (2026-07-30).** The
+  projected wireframes are display-only: they carry no click handler, and
+  `bbox3dRenderer2DFactory` has no `createEditor`, so nothing ever puts a bbox3d id
+  in `collection.selectedId`. `bbox3dRenderer2D` used to build a `Konva.Transformer`
+  for that selection; it was **unreachable code** (the lookup was keyed by bbox3d id
+  against a `selectedId` only ever holding 2D bbox ids) and was deleted rather than
+  left to mislead — it had already cost one round of debugging in `d5e3e505`. The
+  wireframes are now `listening: false`, since a listening line with no handler could
+  only swallow `selectTool2D`'s click-empty-canvas-to-deselect.
+  Wiring selection up means: a click handler + `listening: true` on the **persisted**
+  lines only (never the live draft, which mirrors another widget's in-flight gesture),
+  and a UX decision on what "selected" does — a `Konva.Transformer` is the wrong
+  affordance, since resizing a perspective-projected 8-corner shape has no
+  well-defined mapping back to a 3D edit. Highlight-only is the plausible version.
+  _Target: with the next point-cloud UX pass, alongside DEBT-4._
+
+- **DEBT-4 — ~~3D boxes can't be deleted~~ → RESOLVED (#662), narrowed 2026-07-30.**
+  The delete path shipped in `f57f59a2` *"link entities to 2D/3D boxes (deferred
+  entity, reassign, delete)"*: `BBox3DSession.deleteBox()` routes through the shared
+  `deleteLocalAnnotation` (queueing a delete for a saved box, dropping the pending
+  creates for an unsaved one) and is wired to a Delete button in `BBox3DHud.svelte`.
+  `deleteBox()` and `changeEntity()` shipped untested; both are now covered in
+  `bbox3dSession.test.ts` (2026-07-30).
+  _Residual, all UX rather than plumbing:_
+  - **No keyboard delete in the point cloud.** `selectTool2D` handles
+    `Delete`/`Backspace` for 2D only; the 3D scene has no equivalent.
+  - **No confirmation step.** The original debt asked for that call ("button vs
+    confirm overlay; confirm-on-delete?"); the button deletes immediately. The
+    mutation is queued rather than flushed, so it is recoverable until save — but
+    nothing tells the user that.
+  - **Discoverability.** Delete is reachable *only* through the edit-confirm HUD:
+    you must click a box to enter the `confirming` phase. There is no delete from a
+    selection, from the entities panel, or from the toolbar.
+
+  _Target: with the next point-cloud UX pass, alongside DEBT-7._
 
 - **DEBT-5 — ~~PointCloudWidget owns bbox3d UI + save orchestration~~ → RESOLVED
   (2026-07-01, review A1).** The confirm state, gizmo visibility and commit moved into
@@ -343,5 +411,9 @@ check` at baseline error count and `vitest` green:
   reduced-but-present: the tool's session/props still travel as `unknown` through
   `toolProps` / `ToolHudProps` (the host is a deliberately kind-agnostic courier). The
   HUD mount is now guarded (`sessions[tool.id]` truthy) so a `hud`-without-`createSession`
-  tool can't crash, but the pairing is still by-convention.
+  tool can't crash, but the pairing is still by-convention. **The guard covers session
+  *absence*, not session *type*:** `BBox3DHud` and `BBox3DTool` both downcast
+  (`rawSession as BBox3DSession`) with no runtime check, and `BBox3DTool` declares
+  `session?: BBox3DSession` optional while using it as required — so a mismatched
+  `hud`/`createSession` pairing is still a runtime crash, not a compile error.
   _Target: a typed per-tool session contract when a second 3D tool lands._

--- a/ui/apps/web/src/lib/annotations/__tests__/coordinateTransforms.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/coordinateTransforms.test.ts
@@ -4,9 +4,8 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { describe, expect, it } from "vitest";
-
 import * as THREE from "three";
+import { describe, expect, it } from "vitest";
 
 import {
   bboxTransform,
@@ -15,7 +14,8 @@ import {
   threeBoxToLanceXYZWHD,
   threeQuaternionToLanceRotation,
 } from "../coordinateTransforms";
-import type { LocalBBox3D } from "$lib/api/annotations";
+import type { BBox3DGeometry } from "$lib/annotations/annotationCollection.svelte.js";
+import type { Rotation3x3 } from "$lib/annotations/types.js";
 
 // ─── lanceToThree ─────────────────────────────────────────────────────────────
 
@@ -69,16 +69,13 @@ describe("lanceRotationToThree", () => {
 
 // ─── bboxTransform ────────────────────────────────────────────────────────────
 
-function makeBbox(overrides: Partial<LocalBBox3D>): LocalBBox3D {
+// `bboxTransform` takes validated local geometry, not a raw server row — the
+// identifying fields a `LocalBBox3D` carries are irrelevant to it.
+function makeBbox(overrides: Partial<BBox3DGeometry>): BBox3DGeometry {
   return {
-    id: "bbox-1",
-    record_id: "rec-1",
-    entity_id: "ent-1",
-    view_id: "view-1",
     coords: [0, 0, 0, 1, 1, 1],
     format: "xyzwhd",
     rotation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-    is_normalized: false,
     ...overrides,
   };
 }
@@ -127,13 +124,13 @@ describe("bboxTransform — xyzxyz", () => {
 describe("threeQuaternionToLanceRotation", () => {
   it("returns identity matrix for identity quaternion", () => {
     const rot = threeQuaternionToLanceRotation(new THREE.Quaternion());
-    const identity = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    const identity: Rotation3x3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
     for (let i = 0; i < 9; i++) expect(rot[i]).toBeCloseTo(identity[i]);
   });
 
   it("round-trips with lanceRotationToThree for a 90° Z rotation", () => {
     // The 90° CCW about Lance Z matrix, in row-major:
-    const lanceRot = [0, -1, 0, 1, 0, 0, 0, 0, 1];
+    const lanceRot: Rotation3x3 = [0, -1, 0, 1, 0, 0, 0, 0, 1];
     const q = lanceRotationToThree(lanceRot);
     const recovered = threeQuaternionToLanceRotation(q);
     for (let i = 0; i < 9; i++) expect(recovered[i]).toBeCloseTo(lanceRot[i]);

--- a/ui/apps/web/src/lib/annotations/annotationCollection.svelte.ts
+++ b/ui/apps/web/src/lib/annotations/annotationCollection.svelte.ts
@@ -4,7 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { CoordsNorm } from "./types.js";
+import type { CoordsNorm, Rotation3x3 } from "./types.js";
 
 /**
  * Every annotation kind the workspace can hold. Adding a kind means adding a
@@ -54,7 +54,7 @@ export interface BBox3DGeometry {
   coords: [number, number, number, number, number, number];
   /** Server rows may arrive as either; editor output is always "xyzwhd". */
   format: "xyzwhd" | "xyzxyz";
-  rotation?: number[];
+  rotation?: Rotation3x3;
 }
 
 export type LocalBBox = LocalAnnotation<BBoxGeometry>;

--- a/ui/apps/web/src/lib/annotations/buildPayloads.ts
+++ b/ui/apps/web/src/lib/annotations/buildPayloads.ts
@@ -6,7 +6,7 @@ License: CECILL-C
 
 import { BBOX3D_RESOURCE, BBOX_RESOURCE, ENTITY_RESOURCE } from "$lib/api/resourceNames.js";
 
-import type { CoordsNorm, ResourceMutation } from "./types.js";
+import type { CoordsNorm, ResourceMutation, Rotation3x3 } from "./types.js";
 
 const ID_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -184,14 +184,14 @@ export function buildBBoxUpdate(
  * Coordinates are in Lance/backend space (xyzwhd, Z-up). Rotation defaults to
  * identity — axis-aligned boxes only for now.
  */
-export const DEFAULT_3D_ROTATION = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+export const DEFAULT_3D_ROTATION: Rotation3x3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
 
 export function buildBBox3DUpdate(
   ctx: BuildContext,
   bboxId: string,
   entityId: string,
   coordsLance: [number, number, number, number, number, number],
-  rotation?: number[],
+  rotation?: Rotation3x3,
 ): Record<string, unknown> {
   return {
     id: bboxId,
@@ -210,7 +210,7 @@ export function buildBBox3DUpdate(
 export function buildBBox3DCreate(
   ctx: BuildContext,
   coordsLance: [number, number, number, number, number, number],
-  opts: BuildBBoxOpts & { rotation?: number[] } = {},
+  opts: BuildBBoxOpts & { rotation?: Rotation3x3 } = {},
 ): BuildBBoxResult {
   const entityId = opts.entityId ?? generateShortId();
   const bboxId = opts.bboxId ?? generateShortId();

--- a/ui/apps/web/src/lib/annotations/coordinateTransforms.ts
+++ b/ui/apps/web/src/lib/annotations/coordinateTransforms.ts
@@ -7,6 +7,7 @@ License: CECILL-C
 import * as THREE from "three";
 
 import type { BBox3DGeometry } from "$lib/annotations/annotationCollection.svelte.js";
+import type { Rotation3x3 } from "$lib/annotations/types.js";
 
 // S maps Lance coords → Three.js coords: lanceToThree(x,y,z) = [x, z, -y].
 // Correct change of basis for rotation matrices: R_three = S * R_lance * S⁻¹ = S * R_lance * Sᵀ
@@ -17,9 +18,11 @@ export function lanceToThree(x: number, y: number, z: number): [number, number, 
   return [x, z, -y];
 }
 
-export function lanceRotationToThree(rotation: number[] | undefined): THREE.Quaternion {
+export function lanceRotationToThree(rotation: Rotation3x3 | undefined): THREE.Quaternion {
   const m = new THREE.Matrix4();
-  if (rotation && rotation.length === 9) {
+  // No length check: `Rotation3x3` guarantees nine entries, and the seed loader
+  // is the one boundary where unvalidated server rows can enter (B2).
+  if (rotation) {
     const r = rotation;
     m.set(r[0], r[1], r[2], 0, r[3], r[4], r[5], 0, r[6], r[7], r[8], 0, 0, 0, 0, 1);
   }
@@ -68,7 +71,7 @@ export function bboxTransform(bbox: BBox3DGeometry): {
  *   lanceToThree(x,y,z) = [x, z, -y]
  *   S = [[1,0,0],[0,0,1],[0,-1,0]]
  */
-export function threeQuaternionToLanceRotation(q: THREE.Quaternion): number[] {
+export function threeQuaternionToLanceRotation(q: THREE.Quaternion): Rotation3x3 {
   const R_three = new THREE.Matrix4().makeRotationFromQuaternion(q);
   const R_lance = new THREE.Matrix4().multiplyMatrices(_ST, R_three).multiply(_S);
   const e = R_lance.elements; // Three.js stores elements column-major

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/drawBBoxTool.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/drawBBoxTool.test.ts
@@ -74,6 +74,7 @@ function makeHarness(opts: { image?: Konva.Image | null } = {}) {
       patchPendingCreate: vi.fn(),
       dropForLocalAnnotation: vi.fn(),
     },
+    liveDraft: { get: () => null },
     stage: { getPointerPosition: () => pointer } as unknown as Konva.Stage,
     annotationLayer: { add: vi.fn(), batchDraw: vi.fn() } as unknown as Konva.Layer,
     camera: { imageWidth: 100, imageHeight: 100, calibration: null },

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxEditor2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxEditor2D.ts
@@ -26,7 +26,7 @@ const MIN_BBOX_PIXELS = 1;
  * listens at the **layer** level, so display and input stay decoupled (D4).
  */
 class BBoxEditor2D implements AnnotationEditor2D {
-  readonly kind = "bbox" as const;
+  readonly kind = "bbox";
 
   private readonly transformer: Konva.Transformer;
 

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxRenderer2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxRenderer2D.ts
@@ -15,6 +15,7 @@ import type { Scene2DReadContext } from "$lib/annotations/scene/sceneContext.js"
 import {
   BBOX_COLOR_DRAFT,
   BBOX_COLOR_PERSISTED,
+  DRAFT_DASH,
   getPixelFrame,
   normalizedToPixel,
   type PixelFrame,
@@ -31,7 +32,7 @@ import { createBBoxEditor2D } from "./bboxEditor2D.js";
  * to the queue — the drag/transform → commit path lives in `bboxEditor2D.ts` (D4).
  */
 class BBoxRenderer2D implements AnnotationRenderer2D {
-  readonly kind = "bbox" as const;
+  readonly kind = "bbox";
 
   private readonly rectByBBoxId = new Map<string, Konva.Rect>();
   private readonly labelByBBoxId = new Map<string, Konva.Label>();
@@ -61,7 +62,7 @@ class BBoxRenderer2D implements AnnotationRenderer2D {
         rect.width(pixel.width);
         rect.height(pixel.height);
         rect.stroke(bbox.persisted ? BBOX_COLOR_PERSISTED : BBOX_COLOR_DRAFT);
-        rect.dash(bbox.persisted ? [] : [6, 4]);
+        rect.dash(bbox.persisted ? [] : [...DRAFT_DASH]);
       }
 
       let label = this.labelByBBoxId.get(bbox.id);
@@ -84,6 +85,13 @@ class BBoxRenderer2D implements AnnotationRenderer2D {
 
     this.ctx.annotationLayer.batchDraw();
   }
+
+  /**
+   * No-op: a 2D box is drawn inside this widget by its own draw tool, which
+   * owns its rubber-band preview — there is no cross-widget gesture to mirror.
+   * The draft an image widget could receive here is always another medium's.
+   */
+  syncDraft(): void {}
 
   destroy(): void {
     for (const rect of this.rectByBBoxId.values()) rect.destroy();
@@ -113,7 +121,7 @@ class BBoxRenderer2D implements AnnotationRenderer2D {
       height: pixel.height,
       stroke,
       strokeWidth: 2,
-      dash: bbox.persisted ? undefined : [6, 4],
+      dash: bbox.persisted ? undefined : [...DRAFT_DASH],
       draggable: true,
       name: BBOX_NODE_NAME,
     });

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/drawBBoxTool.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/drawBBoxTool.ts
@@ -12,6 +12,7 @@ import { generateShortId } from "$lib/annotations/buildPayloads.js";
 import { commitDraftWithEntity } from "$lib/annotations/payloadBuilders.js";
 import {
   BBOX_COLOR_DRAFT,
+  DRAFT_DASH,
   getPixelFrame,
   PIXEL_THRESHOLD,
   pixelToNormalized,
@@ -43,7 +44,7 @@ class DrawBBoxHandler implements ToolHandler2D {
       height: 0,
       stroke: BBOX_COLOR_DRAFT,
       strokeWidth: 2,
-      dash: [6, 4],
+      dash: [...DRAFT_DASH],
       listening: false,
     });
     this.ctx.annotationLayer.add(this.draftRect);

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox3d/__tests__/bbox3dRenderer2D.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox3d/__tests__/bbox3dRenderer2D.test.ts
@@ -1,0 +1,444 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import type Konva from "konva";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bbox3dRenderer2DFactory } from "../bbox3dRenderer2D.js";
+import {
+  AnnotationCollection,
+  type BBox3DGeometry,
+} from "$lib/annotations/annotationCollection.svelte.js";
+import type {
+  LiveAnnotationDraft,
+  Scene2DReadContext,
+} from "$lib/annotations/scene/sceneContext.js";
+import type { CameraCalibration } from "$lib/annotations/types.js";
+
+// The renderer's only Konva node is the wireframe line; the layer it draws into
+// is a fake supplied by the harness.
+vi.mock("konva", () => {
+  class Line {
+    destroyed = false;
+    readonly listening: boolean;
+    readonly dash: number[] | undefined;
+    private _points: number[] = [];
+    private _visible: boolean;
+    constructor(cfg: { visible?: boolean; dash?: number[]; listening?: boolean }) {
+      this._visible = cfg.visible ?? true;
+      this.dash = cfg.dash;
+      this.listening = cfg.listening ?? true;
+    }
+    points(value?: number[]): number[] {
+      if (value !== undefined) this._points = value;
+      return this._points;
+    }
+    visible(value?: boolean): boolean {
+      if (value !== undefined) this._visible = value;
+      return this._visible;
+    }
+    moveToTop(): void {}
+    destroy(): void {
+      this.destroyed = true;
+    }
+  }
+  return { default: { Line } };
+});
+
+/** Identity extrinsics + unit focal length: world coords pass straight through. */
+const CALIBRATION: CameraCalibration = {
+  f: [1, 1],
+  c: [0, 0],
+  distortion: [],
+  extrinsicMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+  egoToWorld: [],
+};
+
+/** Centred 2 units in front of the camera, so all 8 corners stay at z > 0. */
+const GEOMETRY: BBox3DGeometry = { coords: [0, 0, 2, 1, 1, 1], format: "xyzwhd" };
+
+function fakeImage(): Konva.Image {
+  return { x: () => 0, y: () => 0, width: () => 100, height: () => 100 } as unknown as Konva.Image;
+}
+
+function draftFor(editingId: string | null, z = 2): LiveAnnotationDraft {
+  return {
+    kind: "bbox3d",
+    geometry: { coords: [0, 0, z, 1, 1, 1], format: "xyzwhd" },
+    editingId,
+    sourceWidgetId: "w1",
+  };
+}
+
+interface FakeLine {
+  destroyed: boolean;
+  readonly listening: boolean;
+  readonly dash: number[] | undefined;
+  points(): number[];
+  visible(): boolean;
+}
+
+interface HarnessOptions {
+  /** null models a widget whose view has no camera calibration. */
+  calibration?: CameraCalibration | null;
+  /** null models a widget whose image has not loaded yet. */
+  image?: Konva.Image | null;
+  /** Entity ids to treat as hidden by the show/hide filter. */
+  hiddenEntityIds?: string[];
+}
+
+function makeHarness(opts: HarnessOptions = {}) {
+  const { calibration = CALIBRATION, image = fakeImage(), hiddenEntityIds = [] } = opts;
+  const hidden = new Set(hiddenEntityIds);
+  const collection = new AnnotationCollection();
+  let liveDraft: LiveAnnotationDraft | null = null;
+  const added: FakeLine[] = [];
+  const ctx = {
+    widgetId: "w1",
+    buildContext: { datasetId: "ds", recordId: "rec", viewId: "" },
+    collection,
+    // The renderer never reads the stage; only the layer it draws into.
+    stage: {} as Konva.Stage,
+    annotationLayer: {
+      add: (node: unknown) => added.push(node as FakeLine),
+      batchDraw: vi.fn(),
+    } as unknown as Konva.Layer,
+    camera: { imageWidth: 100, imageHeight: 100, calibration },
+    liveDraft: { get: () => liveDraft },
+    getKonvaImage: () => image,
+    requestRedraw: vi.fn(),
+    isEntityVisible: (entityId: string) => !hidden.has(entityId),
+  } satisfies Scene2DReadContext;
+
+  return {
+    ctx,
+    collection,
+    renderer: bbox3dRenderer2DFactory.create(ctx),
+    setDraft: (draft: LiveAnnotationDraft | null) => (liveDraft = draft),
+    /** Every line node the renderer has ever added to the layer. */
+    lines: added,
+    liveLines: () => added.filter((line) => !line.destroyed),
+  };
+}
+
+/** Add a persisted bbox3d to the harness collection. */
+function addBox(
+  env: ReturnType<typeof makeHarness>,
+  id: string,
+  geometry: BBox3DGeometry,
+  opts: { entityId?: string; persisted?: boolean } = {},
+) {
+  env.collection.add({
+    id,
+    entityId: opts.entityId ?? "e1",
+    kind: "bbox3d",
+    viewId: "",
+    geometry,
+    persisted: opts.persisted ?? true,
+  });
+}
+
+/** Every distinct endpoint across a wireframe's lines, sorted for comparison. */
+function cornerPixels(lines: FakeLine[]): string[] {
+  const points = new Set<string>();
+  for (const line of lines) {
+    const [x1, y1, x2, y2] = line.points();
+    points.add(`${x1.toFixed(4)},${y1.toFixed(4)}`);
+    points.add(`${x2.toFixed(4)},${y2.toFixed(4)}`);
+  }
+  return [...points].sort();
+}
+
+describe("BBox3DRenderer2D.sync", () => {
+  it("projects a box through the calibration into stage pixels", () => {
+    const env = makeHarness();
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+
+    // f=1, c=0, identity extrinsics, and a 100px image on a 100px frame reduce
+    // the pinhole projection to x/z. BOX_EDGES[0] joins corner 0 (-0.5,-0.5,1.5)
+    // to corner 1 (0.5,-0.5,1.5), i.e. -1/3 px to +1/3 px at y = -1/3 px.
+    const [x1, y1, x2, y2] = env.liveLines()[0].points();
+    expect(x1).toBeCloseTo(-1 / 3);
+    expect(y1).toBeCloseTo(-1 / 3);
+    expect(x2).toBeCloseTo(1 / 3);
+    expect(y2).toBeCloseTo(-1 / 3);
+  });
+
+  it("gives every box its own wireframe, projected independently", () => {
+    const env = makeHarness();
+    addBox(env, "b1", GEOMETRY);
+    addBox(env, "b2", { coords: [10, 0, 2, 1, 1, 1], format: "xyzwhd" });
+    env.renderer.sync();
+
+    const all = env.liveLines();
+    expect(all.length % 2).toBe(0);
+    const [first, second] = [all.slice(0, all.length / 2), all.slice(all.length / 2)];
+    // Guards the shared projection scratch buffers: one box must never inherit
+    // the corner pixels left behind by the box projected before it.
+    expect(cornerPixels(first)).not.toEqual(cornerPixels(second));
+    expect(first[0].points()[0]).toBeCloseTo(-1 / 3);
+    expect(second[0].points()[0]).toBeCloseTo(9.5 / 1.5);
+  });
+
+  it("destroys a box's lines when it leaves the collection", () => {
+    const env = makeHarness();
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+    const lines = env.liveLines().slice();
+
+    env.collection.remove("b1");
+    env.renderer.sync();
+
+    expect(lines.every((line) => line.destroyed)).toBe(true);
+    expect(env.liveLines()).toHaveLength(0);
+  });
+
+  it("hides a persisted box whose entity is filtered out", () => {
+    const env = makeHarness({ hiddenEntityIds: ["e-hidden"] });
+    addBox(env, "b1", GEOMETRY, { entityId: "e-hidden" });
+    env.renderer.sync();
+
+    expect(env.liveLines()).toHaveLength(0);
+  });
+
+  it("still shows an unsaved box whose entity is filtered out", () => {
+    const env = makeHarness({ hiddenEntityIds: ["e-hidden"] });
+    addBox(env, "b1", GEOMETRY, { entityId: "e-hidden", persisted: false });
+    env.renderer.sync();
+
+    expect(env.liveLines().length).toBeGreaterThan(0);
+  });
+
+  it("hides the wireframe when the view has no calibration", () => {
+    const env = makeHarness({ calibration: null });
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+
+    expect(env.liveLines().length).toBeGreaterThan(0);
+    expect(env.liveLines().every((line) => !line.visible())).toBe(true);
+  });
+
+  it("draws nothing until the image has loaded", () => {
+    const env = makeHarness({ image: null });
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+
+    expect(env.liveLines()).toHaveLength(0);
+  });
+
+  it("treats an identity rotation matrix as no rotation", () => {
+    const plain = makeHarness();
+    addBox(plain, "b1", GEOMETRY);
+    plain.renderer.sync();
+
+    const identity = makeHarness();
+    addBox(identity, "b1", { ...GEOMETRY, rotation: [1, 0, 0, 0, 1, 0, 0, 0, 1] });
+    identity.renderer.sync();
+
+    expect(cornerPixels(identity.liveLines())).toEqual(cornerPixels(plain.liveLines()));
+  });
+
+  it("applies the rotation matrix: a quarter turn about Z swaps the extents", () => {
+    const rotated = makeHarness();
+    addBox(rotated, "b1", {
+      coords: [0, 0, 2, 2, 1, 1],
+      format: "xyzwhd",
+      rotation: [0, -1, 0, 1, 0, 0, 0, 0, 1], // +90° about Z, row-major
+    });
+    rotated.renderer.sync();
+
+    // Turning a box a quarter turn about Z lands its 8 corners exactly where
+    // the same box with width and height swapped already has them.
+    const swapped = makeHarness();
+    addBox(swapped, "b1", { coords: [0, 0, 2, 1, 2, 1], format: "xyzwhd" });
+    swapped.renderer.sync();
+
+    expect(cornerPixels(rotated.liveLines())).toEqual(cornerPixels(swapped.liveLines()));
+  });
+
+  // NaN defeats the ordinary `z <= 0` bail-out, since every comparison with NaN
+  // is false — so without an explicit guard the renderer would write NaN line
+  // points instead of hiding the box.
+  it("hides the wireframe rather than drawing NaN when the geometry is not finite", () => {
+    const env = makeHarness();
+    addBox(env, "b1", { coords: [0, 0, NaN, 1, 1, 1], format: "xyzwhd" });
+    env.renderer.sync();
+
+    expect(env.liveLines().length).toBeGreaterThan(0);
+    expect(env.liveLines().every((line) => !line.visible())).toBe(true);
+  });
+
+  it("hides the wireframe when the calibration matrix is not finite", () => {
+    const env = makeHarness({
+      calibration: { ...CALIBRATION, extrinsicMatrix: Array.from({ length: 16 }, () => NaN) },
+    });
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+
+    expect(env.liveLines().every((line) => !line.visible())).toBe(true);
+  });
+
+  it("destroys every line it owns", () => {
+    const env = makeHarness();
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+    env.renderer.syncDraft(draftFor(null, 3));
+    expect(env.liveLines().length).toBeGreaterThan(0);
+
+    env.renderer.destroy();
+
+    expect(env.liveLines()).toHaveLength(0);
+  });
+});
+
+describe("BBox3DRenderer2D.syncDraft", () => {
+  let env: ReturnType<typeof makeHarness>;
+
+  beforeEach(() => {
+    env = makeHarness();
+    env.collection.add({
+      id: "b1",
+      entityId: "e1",
+      kind: "bbox3d",
+      viewId: "",
+      geometry: GEOMETRY,
+      persisted: true,
+    });
+  });
+
+  it("draws a dashed preview and leaves persisted boxes untouched mid-gesture", () => {
+    env.renderer.sync();
+    const persisted = env.liveLines().slice();
+    const persistedPoints = persisted.map((line) => [...line.points()]);
+
+    env.renderer.syncDraft(draftFor(null, 3));
+
+    // The persisted wireframe was not re-projected...
+    expect(persisted.map((line) => line.points())).toEqual(persistedPoints);
+    expect(persisted.every((line) => !line.destroyed)).toBe(true);
+    // ...and a second, dashed wireframe appeared for the draft.
+    const draftLines = env.liveLines().filter((line) => !persisted.includes(line));
+    expect(draftLines).toHaveLength(persisted.length);
+    expect(draftLines.every((line) => line.visible())).toBe(true);
+  });
+
+  // The regression this guards: a gesture on an existing box must hide the
+  // persisted copy, or the box shows up twice — solid and dashed at once.
+  it("hides the edited box when a gesture starts on it (no ghost copy)", () => {
+    env.renderer.sync();
+    const persisted = env.liveLines().slice();
+
+    env.renderer.syncDraft(draftFor("b1"));
+
+    expect(persisted.every((line) => line.destroyed)).toBe(true);
+    expect(env.liveLines().length).toBe(persisted.length); // only the draft remains
+  });
+
+  it("restores the edited box and drops the preview when the gesture ends", () => {
+    env.renderer.sync();
+    env.renderer.syncDraft(draftFor("b1"));
+    const duringGesture = env.liveLines().slice();
+
+    env.setDraft(null);
+    env.renderer.syncDraft(null);
+
+    // The dashed preview is gone and a fresh persisted wireframe is back.
+    expect(duringGesture.every((line) => line.destroyed)).toBe(true);
+    expect(env.liveLines().length).toBe(duringGesture.length);
+    expect(env.liveLines().every((line) => line.visible())).toBe(true);
+  });
+
+  // Wireframes are display-only. A listening line would sit between the user
+  // and the stage, so `selectTool2D`'s click-empty-canvas-to-deselect (which
+  // tests `event.target === stage`) would silently stop firing over the box.
+  it("never lets a wireframe intercept pointer events", () => {
+    env.renderer.sync();
+    env.renderer.syncDraft(draftFor(null, 3));
+
+    expect(env.liveLines()).not.toHaveLength(0);
+    expect(env.liveLines().every((line) => line.listening === false)).toBe(true);
+  });
+
+  it("gives each line its own dash array rather than sharing one", () => {
+    env.renderer.sync();
+    const persisted = env.liveLines().slice();
+    env.renderer.syncDraft(draftFor(null, 3));
+
+    const draftLines = env.liveLines().filter((line) => !persisted.includes(line));
+    expect(draftLines.every((line) => line.dash?.join() === "6,4")).toBe(true);
+    expect(new Set(draftLines.map((line) => line.dash)).size).toBe(draftLines.length);
+  });
+
+  // The persisted copy of a hidden box is already suppressed by the reconcile,
+  // so drawing its preview would blink it into view for exactly the length of
+  // the gesture — visible while dragged, gone before and after.
+  it("keeps the preview hidden when the edited box's entity is filtered out", () => {
+    const env = makeHarness({ hiddenEntityIds: ["e-hidden"] });
+    addBox(env, "b1", GEOMETRY, { entityId: "e-hidden" });
+    env.renderer.sync();
+    expect(env.liveLines()).toHaveLength(0);
+
+    env.renderer.syncDraft(draftFor("b1"));
+
+    expect(env.liveLines()).toHaveLength(0);
+  });
+
+  it("shows the preview when the edited box's entity is visible", () => {
+    const env = makeHarness();
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+
+    env.renderer.syncDraft(draftFor("b1"));
+
+    expect(env.liveLines().length).toBeGreaterThan(0);
+  });
+
+  it("shows the preview of a brand-new box, which has no entity to filter on", () => {
+    const env = makeHarness({ hiddenEntityIds: ["e1", ""] });
+    addBox(env, "b1", GEOMETRY);
+    env.renderer.sync();
+
+    env.renderer.syncDraft(draftFor(null, 3));
+
+    expect(env.liveLines().length).toBeGreaterThan(0);
+  });
+
+  it("shows the preview of an unsaved box, whose entity id is not set yet", () => {
+    const env = makeHarness({ hiddenEntityIds: [""] });
+    addBox(env, "b1", GEOMETRY, { entityId: "", persisted: false });
+    env.renderer.sync();
+
+    env.renderer.syncDraft(draftFor("b1"));
+
+    expect(env.liveLines().length).toBeGreaterThan(0);
+  });
+
+  it("ignores a draft belonging to another kind", () => {
+    env.renderer.sync();
+    const before = env.liveLines().length;
+
+    env.renderer.syncDraft({
+      kind: "bbox",
+      geometry: [0, 0, 1, 1],
+      editingId: null,
+      sourceWidgetId: "w2",
+    });
+
+    expect(env.liveLines().length).toBe(before);
+  });
+
+  it("hides the preview rather than drawing stale points when it cannot project", () => {
+    env.renderer.sync();
+    const persisted = env.liveLines().slice();
+    // z = -1 puts every corner behind the camera.
+    env.renderer.syncDraft(draftFor(null, -1));
+
+    const draftLines = env.liveLines().filter((line) => !persisted.includes(line));
+    expect(draftLines).toHaveLength(persisted.length);
+    expect(draftLines.every((line) => !line.visible())).toBe(true);
+  });
+});

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox3d/bbox3dRenderer2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox3d/bbox3dRenderer2D.ts
@@ -7,7 +7,7 @@ License: CECILL-C
 import Konva from "konva";
 import { Matrix3, Matrix4, Vector3, Vector4 } from "three";
 
-import type { LocalBBox3DAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
+import type { BBox3DGeometry } from "$lib/annotations/annotationCollection.svelte.js";
 import type {
   AnnotationRenderer2D,
   AnnotationRenderer2DFactory,
@@ -21,16 +21,41 @@ import {
 } from "$lib/annotations/scene/scene2dGeometry.js";
 
 /**
- * Renders the "bbox3d" kind on the Konva scene: one rect (+ optional entity
- * label) per annotation, a shared transformer for the selection, and the
- * drag/transform handlers that write geometry changes back through the
- * collection and the mutation queue.
+ * Corner pairs of the projected wireframe: the cube's 12 edges plus the two
+ * front-face diagonals that mark the box's facing direction. Corner order
+ * matches `_get3dbboxCorners` (bottom face 0-3, top face 4-7).
+ */
+const BOX_EDGES: readonly (readonly [number, number])[] = [
+  [0, 1],
+  [1, 2],
+  [2, 3],
+  [3, 0],
+  [4, 5],
+  [5, 6],
+  [6, 7],
+  [7, 4],
+  [0, 4],
+  [1, 5],
+  [2, 6],
+  [3, 7],
+  [2, 5],
+  [1, 6],
+];
+
+const PROJECTED_EDGE_COLOR = "#f59e0b";
+const PROJECTED_EDGE_WIDTH = 2;
+
+/**
+ * Renders the "bbox3d" kind on the Konva scene: each 3D box is projected
+ * through the widget's camera calibration into a wireframe of `BOX_EDGES`
+ * lines, plus a shared transformer for the selection. Each box always owns its
+ * full set of lines; a projection that fails (missing calibration, or a corner
+ * behind the camera) hides them rather than leaving stale geometry.
  */
 class BBox3DRenderer2D implements AnnotationRenderer2D {
   readonly kind = "bbox3d" as const;
 
   private readonly boxByBBoxId = new Map<string, Konva.Line[]>();
-  private readonly labelByBBoxId = new Map<string, Konva.Label>();
   private readonly transformer: Konva.Transformer;
 
   constructor(private readonly ctx: Scene2DReadContext) {
@@ -50,21 +75,24 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
     const activeIds = new Set<string>();
 
     for (const bbox of this.ctx.collection.byKind("bbox3d")) {
+      // Entity-driven visibility, mirroring the 2D bbox renderer: a persisted
+      // box whose entity is hidden gets no lines. Drafts are always shown.
+      if (bbox.persisted && !this.ctx.isEntityVisible(bbox.entityId)) continue;
       activeIds.add(bbox.id);
       let projectedBox = this.boxByBBoxId.get(bbox.id);
-      if (!projectedBox) {
-        const newBox = this._makeProjectedBox(bbox, frame);
-        if (!newBox) continue;
-        newBox.forEach(line => this.ctx.annotationLayer.add(line));
-        this.boxByBBoxId.set(bbox.id, newBox);
-        projectedBox = newBox;
-      } else if (frame) {
-        this._updateProjectedBox(projectedBox, bbox, frame);
+      if (!projectedBox && frame) {
+        projectedBox = this._makeProjectedBox();
+        for (const line of projectedBox) this.ctx.annotationLayer.add(line);
+        this.boxByBBoxId.set(bbox.id, projectedBox);
       }
+      if (projectedBox && frame) this._applyProjection(projectedBox, bbox.geometry, frame);
     }
 
-    for (const [id, projectedbbox] of this.boxByBBoxId) {
-      if (!activeIds.has(id)) { projectedbbox.forEach(line => line.destroy()); this.boxByBBoxId.delete(id); }
+    for (const [id, projectedBox] of this.boxByBBoxId) {
+      if (!activeIds.has(id)) {
+        for (const line of projectedBox) line.destroy();
+        this.boxByBBoxId.delete(id);
+      }
     }
 
     this._syncTransformer();
@@ -74,22 +102,16 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
   destroy(): void {
     this.transformer.destroy();
     for (const projectedBox of this.boxByBBoxId.values()) {
-      for (const line of projectedBox) {
-        line.destroy();
-      }
+      for (const line of projectedBox) line.destroy();
     }
     this.boxByBBoxId.clear();
-    for (const label of this.labelByBBoxId.values()) label.destroy();
-    this.labelByBBoxId.clear();
   }
 
   private _syncTransformer(): void {
     const id = this.ctx.collection.selectedId;
     const projectedBox = id ? this.boxByBBoxId.get(id) : undefined;
     if (projectedBox) {
-      for (const line of projectedBox) {
-          this.transformer.nodes([line]);
-      }
+      this.transformer.nodes(projectedBox);
       this.transformer.moveToTop();
     } else {
       this.transformer.nodes([]);
@@ -97,25 +119,47 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
     this.transformer.getLayer()?.batchDraw();
   }
 
-  private _makeLine(p1: { x: number; y: number }, p2: { x: number; y: number }): Konva.Line {
-    const line = new Konva.Line({
-      points: [p1.x, p1.y, p2.x, p2.y],
-      stroke: "#f59e0b",
-      strokeWidth: 2,
-    });
-    return line;
+  /** One hidden line per `BOX_EDGES` entry; `_applyProjection` fills them in. */
+  private _makeProjectedBox(dash?: number[]): Konva.Line[] {
+    return BOX_EDGES.map(
+      () =>
+        new Konva.Line({
+          points: [],
+          stroke: PROJECTED_EDGE_COLOR,
+          strokeWidth: PROJECTED_EDGE_WIDTH,
+          visible: false,
+          dash,
+        }),
+    );
   }
 
-  private _get3dbboxCorners(bbox: LocalBBox3DAnnotation): { x: number; y: number; z: number }[] {
-    const [x, y, z, w, h, d] = bbox.geometry.coords;
-    let rotation_matrix;
-    if (!bbox.geometry.rotation){
-      rotation_matrix = new Matrix3().identity();
-    }else{
-      rotation_matrix = new Matrix3().fromArray(bbox.geometry.rotation).transpose();
+  /**
+   * Project the geometry and update every wireframe line, or hide them all
+   * when the projection fails (no calibration / a corner behind the camera) —
+   * lines must never keep stale points, since a box can cross the camera
+   * plane between two syncs.
+   */
+  private _applyProjection(lines: Konva.Line[], geometry: BBox3DGeometry, frame: PixelFrame): void {
+    const pixels = this._getProjectedPixels(geometry, frame);
+    if (!pixels) {
+      for (const line of lines) line.visible(false);
+      return;
     }
+    for (let i = 0; i < BOX_EDGES.length; i++) {
+      const [a, b] = BOX_EDGES[i];
+      lines[i].points([pixels[a].x, pixels[a].y, pixels[b].x, pixels[b].y]);
+      lines[i].visible(true);
+    }
+  }
+
+  /** The box's 8 corners in world (Lance, Z-up) space. */
+  private _get3dbboxCorners(geometry: BBox3DGeometry): { x: number; y: number; z: number }[] {
+    const [x, y, z, w, h, d] = geometry.coords;
+    const rotationMatrix = geometry.rotation
+      ? new Matrix3().fromArray(geometry.rotation).transpose()
+      : new Matrix3().identity();
     const unitCube = [
-      [-0.5,-0.5, -0.5],
+      [-0.5, -0.5, -0.5],
       [0.5, -0.5, -0.5],
       [0.5, 0.5, -0.5],
       [-0.5, 0.5, -0.5],
@@ -123,86 +167,54 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
       [0.5, -0.5, 0.5],
       [0.5, 0.5, 0.5],
       [-0.5, 0.5, 0.5],
-    ]
-    let scaledCorners = unitCube.map(([cx, cy, cz]) => [cx * w, cy * h, cz * d]);
-    let rotatedCorners = scaledCorners.map(([cx, cy, cz]) => (new Vector3(cx, cy, cz)).applyMatrix3(rotation_matrix));
-    let translatedCorners = rotatedCorners.map((corner) => ({ x: corner.x + x, y: corner.y + y, z: corner.z + z }));
-    return translatedCorners;
-  }
-
-  private _projectPoint(bbox: LocalBBox3DAnnotation): { x: number; y: number }[] | null {
-    if (!this.ctx.camera.calibration) return null;
-    const f = this.ctx.camera.calibration.f;
-    const c = this.ctx.camera.calibration.c;
-    const extrinsics = new Matrix4().fromArray(this.ctx.camera.calibration.extrinsicMatrix).transpose();
-    // Homogenous points
-    let points_h = this._get3dbboxCorners(bbox).map(point => [point.x, point.y, point.z, 1]);
-    // world -> cam
-    let pointsCam = points_h.map(([x, y, z, w]) => {
-      let vec = new Vector4(x, y, z, w).applyMatrix4(extrinsics);
-      return { x: vec.x, y: vec.y, z: vec.z };
-    });
-    let projectedPoints = pointsCam.map(({x, y, z}) => {
-      if (z <= 0) return null; // Behind the camera
-      return {
-        x: f[0] * x / z + c[0],
-        y: f[1] * y / z + c[1],
-      };
-    });
-    return projectedPoints.every(p => p !== null) ? projectedPoints as { x: number; y: number }[] : null;
-  }
-
-  private _makeProjectedBox(bbox: LocalBBox3DAnnotation, frame: PixelFrame | null): Konva.Line[] | null {
-    if (!frame) return null;
-    const edges = [
-      [0, 1], [1, 2], [2, 3], [3, 0],
-      [4, 5], [5, 6], [6, 7], [7, 4],
-      [0, 4], [1, 5], [2, 6], [3, 7],
-      [2, 5], [1, 6]
     ];
-    const pixels = this._getNormalizedProjectedPoints(bbox, frame);
-    let lines = [];
-        for (const [a, b] of edges) {
-          if (pixels?.[a] && pixels?.[b]) {
-            const konvaLine = this._makeLine(pixels[a], pixels[b]);
-            lines.push(konvaLine);
-          }
-        }
-    return lines;
+    return unitCube.map(([cx, cy, cz]) => {
+      const corner = new Vector3(cx * w, cy * h, cz * d).applyMatrix3(rotationMatrix);
+      return { x: corner.x + x, y: corner.y + y, z: corner.z + z };
+    });
   }
 
-  private _updateProjectedBox(lines: Konva.Line[], bbox: LocalBBox3DAnnotation, frame: PixelFrame): void {
-    if (!frame) return;
-    const edges = [
-      [0, 1], [1, 2], [2, 3], [3, 0],
-      [4, 5], [5, 6], [6, 7], [7, 4],
-      [0, 4], [1, 5], [2, 6], [3, 7],
-      [2, 5], [1, 6]
-    ];
-    const pixels = this._getNormalizedProjectedPoints(bbox,frame);
-    if (pixels) {
-      for (let i = 0; i<edges.length; i++){
-        const p1 = pixels[edges[i][0]];
-        const p2 = pixels[edges[i][1]];
-
-        if (!p1 || !p2) continue;
-        lines[i].points([p1.x, p1.y, p2.x, p2.y]);
-
-      }
+  /**
+   * Pinhole-project the corners into image pixel coordinates, or null when the
+   * widget has no calibration or any corner sits behind the camera.
+   */
+  private _projectCorners(geometry: BBox3DGeometry): { x: number; y: number }[] | null {
+    const calibration = this.ctx.camera.calibration;
+    if (!calibration) return null;
+    const { f, c } = calibration;
+    const extrinsics = new Matrix4().fromArray(calibration.extrinsicMatrix).transpose();
+    const projected: { x: number; y: number }[] = [];
+    for (const corner of this._get3dbboxCorners(geometry)) {
+      // world -> camera
+      const cam = new Vector4(corner.x, corner.y, corner.z, 1).applyMatrix4(extrinsics);
+      if (cam.z <= 0) return null; // Behind the camera
+      projected.push({
+        x: (f[0] * cam.x) / cam.z + c[0],
+        y: (f[1] * cam.y) / cam.z + c[1],
+      });
     }
+    return projected;
   }
 
-  private _getNormalizedProjectedPoints(bbox: LocalBBox3DAnnotation, frame: PixelFrame): ({ x: number; y: number } | null)[] {
-    let projectedPoints = this._projectPoint(bbox);
-    let normalizedPoints = projectedPoints?.map(point => {
-          const dx = point.x /this.ctx.camera.imageWidth;
-          const dy = point.y /this.ctx.camera.imageHeight;
-          return {x:dx,y:dy};
-          });
-    const pixels = normalizedPoints?.map(point => normalizedPointToPixel(point.x, point.y, frame));
-    if (!pixels) return [];
+  /** Corner pixels in Konva stage space, or null when projection fails. */
+  private _getProjectedPixels(
+    geometry: BBox3DGeometry,
+    frame: PixelFrame,
+  ): { x: number; y: number }[] | null {
+    const projected = this._projectCorners(geometry);
+    if (!projected) return null;
+    const pixels: { x: number; y: number }[] = [];
+    for (const point of projected) {
+      const pixel = normalizedPointToPixel(
+        point.x / this.ctx.camera.imageWidth,
+        point.y / this.ctx.camera.imageHeight,
+        frame,
+      );
+      if (!pixel) return null;
+      pixels.push(pixel);
+    }
     return pixels;
-    }
+  }
 }
 
 export const bbox3dRenderer2DFactory: AnnotationRenderer2DFactory = {

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox3d/bbox3dRenderer2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox3d/bbox3dRenderer2D.ts
@@ -12,18 +12,23 @@ import type {
   AnnotationRenderer2D,
   AnnotationRenderer2DFactory,
 } from "$lib/annotations/scene/renderer.js";
-import type { Scene2DReadContext } from "$lib/annotations/scene/sceneContext.js";
 import {
-  BBOX_COLOR_PERSISTED,
+  DRAFT_DASH,
   getPixelFrame,
   normalizedPointToPixel,
   type PixelFrame,
+  type PixelPoint,
 } from "$lib/annotations/scene/scene2dGeometry.js";
+import type {
+  LiveAnnotationDraft,
+  Scene2DReadContext,
+} from "$lib/annotations/scene/sceneContext.js";
 
 /**
  * Corner pairs of the projected wireframe: the cube's 12 edges plus the two
- * front-face diagonals that mark the box's facing direction. Corner order
- * matches `_get3dbboxCorners` (bottom face 0-3, top face 4-7).
+ * front-face diagonals that mark the box's facing direction. Indexes are into
+ * `UNIT_CUBE_CORNERS` (bottom face 0-3, top face 4-7); the two tables must stay
+ * in the same order.
  */
 const BOX_EDGES: readonly (readonly [number, number])[] = [
   [0, 1],
@@ -42,42 +47,111 @@ const BOX_EDGES: readonly (readonly [number, number])[] = [
   [1, 6],
 ];
 
+/**
+ * Corner offsets of a unit cube centred on the origin, in the order
+ * `BOX_EDGES` indexes them (bottom face 0-3, top face 4-7). Scaled by the box
+ * size, rotated, then translated by its centre to give the 8 world-space
+ * corners — mirroring the backend's `unit_cube_corners`
+ * (`src/pixano/schemas/annotations/bbox.py`).
+ */
+const UNIT_CUBE_CORNERS: readonly (readonly [number, number, number])[] = [
+  [-0.5, -0.5, -0.5],
+  [0.5, -0.5, -0.5],
+  [0.5, 0.5, -0.5],
+  [-0.5, 0.5, -0.5],
+  [-0.5, -0.5, 0.5],
+  [0.5, -0.5, 0.5],
+  [0.5, 0.5, 0.5],
+  [-0.5, 0.5, 0.5],
+];
+
+const BOX_CORNER_COUNT = UNIT_CUBE_CORNERS.length;
+
+/** The live-draft union narrowed to this renderer's kind. */
+type BBox3DDraft = Extract<LiveAnnotationDraft, { kind: "bbox3d" }>;
+
 const PROJECTED_EDGE_COLOR = "#f59e0b";
 const PROJECTED_EDGE_WIDTH = 2;
 
 /**
  * Renders the "bbox3d" kind on the Konva scene: each 3D box is projected
  * through the widget's camera calibration into a wireframe of `BOX_EDGES`
- * lines, plus a shared transformer for the selection. Each box always owns its
- * full set of lines; a projection that fails (missing calibration, or a corner
- * behind the camera) hides them rather than leaving stale geometry.
+ * lines. Each box always owns its full set of lines; a projection that fails
+ * (missing calibration, or a corner behind the camera) hides them rather than
+ * leaving stale geometry.
+ *
+ * Display-only, and non-interactive with it: the wireframes never listen for
+ * pointer events. Nothing selects a bbox3d from an image view today, and the
+ * kind has no `createEditor`, so a listening wireframe could only swallow the
+ * select tool's click-empty-canvas-to-deselect. Making 3D boxes selectable here
+ * means adding a click handler *and* flipping `listening` back on for the
+ * persisted lines only — never for the draft, which mirrors another widget's
+ * in-flight gesture.
  */
 class BBox3DRenderer2D implements AnnotationRenderer2D {
-  readonly kind = "bbox3d" as const;
+  readonly kind = "bbox3d";
 
   private readonly boxByBBoxId = new Map<string, Konva.Line[]>();
-  private readonly transformer: Konva.Transformer;
+  /** Dashed wireframe of the live editing gesture, present only mid-gesture. */
+  private draftLines: Konva.Line[] | null = null;
 
-  constructor(private readonly ctx: Scene2DReadContext) {
-    this.transformer = new Konva.Transformer({
-      rotateEnabled: false,
-      anchorStroke: BBOX_COLOR_PERSISTED,
-      anchorFill: "#0f172a",
-      borderStroke: BBOX_COLOR_PERSISTED,
-      keepRatio: false,
-      ignoreStroke: true,
-    });
-    ctx.annotationLayer.add(this.transformer);
-  }
+  // ─── Projection scratch ───────────────────────────────────────────────────
+  // `syncDraft` runs on every pointer move while a 3D box is dragged in another
+  // widget, so the projection path must not allocate — CODING_STANDARDS: "never
+  // allocate in pointer-event or render-loop code paths". Every buffer below is
+  // overwritten per box and is only valid until the next `_projectInto` call;
+  // `_applyProjection` is their single, immediate consumer.
+  private readonly rotationScratch = new Matrix3();
+  private readonly extrinsicsScratch = new Matrix4();
+  private readonly centerScratch = new Vector3();
+  private readonly cameraPointScratch = new Vector4();
+  /** The box's 8 corners in world (Lance, Z-up) space. */
+  private readonly worldCorners = UNIT_CUBE_CORNERS.map(() => new Vector3());
+  /** The same 8 corners in Konva stage space. */
+  private readonly pixelCorners: PixelPoint[] = UNIT_CUBE_CORNERS.map(() => ({ x: 0, y: 0 }));
+
+  /**
+   * `editingId` seen at the last reconcile. A change means a gesture started or
+   * ended on a persisted box, which flips whether that box is drawn at all —
+   * the one thing the `syncDraft` fast path may not decide on its own.
+   */
+  private lastEditingId: string | null = null;
+
+  /**
+   * Whether the current draft may be drawn at all, decided at reconcile time.
+   * Cached rather than recomputed in `_syncDraft` because answering it needs
+   * `collection.find`, a linear scan over a freshly filtered array — far too
+   * costly for a path that runs on every pointer move. Safe to cache: both of
+   * its inputs (the edited id, the visible-entity filter) already force a full
+   * reconcile whenever they change.
+   */
+  private draftVisible = true;
+
+  constructor(private readonly ctx: Scene2DReadContext) {}
 
   sync(): void {
+    this._reconcileAll(this._asBBox3DDraft(this.ctx.liveDraft.get()));
+  }
+
+  /**
+   * Full reconcile against a given draft. Both entry points funnel here so the
+   * draft is read once per pass: `sync()` pulls it from the context, while
+   * `syncDraft` forwards the one it was handed. Re-reading the context here
+   * instead would give the two paths separate sources of truth for one value.
+   */
+  private _reconcileAll(draft: BBox3DDraft | null): void {
     const frame = getPixelFrame(this.ctx.getKonvaImage());
     const activeIds = new Set<string>();
+    this.lastEditingId = draft?.editingId ?? null;
+    this.draftVisible = this._computeDraftVisible(draft);
 
     for (const bbox of this.ctx.collection.byKind("bbox3d")) {
       // Entity-driven visibility, mirroring the 2D bbox renderer: a persisted
       // box whose entity is hidden gets no lines. Drafts are always shown.
       if (bbox.persisted && !this.ctx.isEntityVisible(bbox.entityId)) continue;
+      // While a box is being edited, the live draft is the only copy on
+      // screen — same rule as the 3D renderer's editingId skip.
+      if (bbox.id === draft?.editingId) continue;
       activeIds.add(bbox.id);
       let projectedBox = this.boxByBBoxId.get(bbox.id);
       if (!projectedBox && frame) {
@@ -95,32 +169,83 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
       }
     }
 
-    this._syncTransformer();
+    this._syncDraft(draft, frame);
+    // Persisted wireframes are (re)built above, so lift the preview back on top
+    // — Konva paints in insertion order. Done here rather than in `syncDraft`
+    // so the pointer-rate path stays free of it.
+    if (this.draftLines) for (const line of this.draftLines) line.moveToTop();
     this.ctx.annotationLayer.batchDraw();
   }
 
+  /**
+   * Pointer-rate fast path: reproject only the dashed preview and leave every
+   * persisted wireframe alone, so the cost is one box rather than the whole
+   * collection. Gesture start/end are the exception — they flip whether the
+   * edited box is drawn at all — and delegate to the full reconcile.
+   */
+  syncDraft(rawDraft: LiveAnnotationDraft | null): void {
+    const draft = this._asBBox3DDraft(rawDraft);
+    if ((draft?.editingId ?? null) !== this.lastEditingId) {
+      this._reconcileAll(draft);
+      return;
+    }
+    this._syncDraft(draft, getPixelFrame(this.ctx.getKonvaImage()));
+    this.ctx.annotationLayer.batchDraw();
+  }
+
+  /**
+   * A gesture editing a persisted box inherits that box's entity visibility:
+   * hiding an entity must keep its box hidden while it is dragged too, or the
+   * box would blink into view for exactly the duration of the gesture. A draft
+   * with no `editingId` is a brand-new box, and an unsaved one has no entity id
+   * yet (`isEntityVisible("")` is false under an active filter) — neither has
+   * anything to filter on, so both always show.
+   */
+  private _computeDraftVisible(draft: BBox3DDraft | null): boolean {
+    if (!draft?.editingId) return true;
+    const edited = this.ctx.collection.find(draft.editingId);
+    if (!edited?.persisted) return true;
+    return this.ctx.isEntityVisible(edited.entityId);
+  }
+
+  /** Narrow the kind-agnostic union the widget hands us down to our own kind. */
+  private _asBBox3DDraft(draft: LiveAnnotationDraft | null): BBox3DDraft | null {
+    return draft?.kind === "bbox3d" ? draft : null;
+  }
+
   destroy(): void {
-    this.transformer.destroy();
     for (const projectedBox of this.boxByBBoxId.values()) {
       for (const line of projectedBox) line.destroy();
     }
     this.boxByBBoxId.clear();
+    this._destroyDraft();
   }
 
-  private _syncTransformer(): void {
-    const id = this.ctx.collection.selectedId;
-    const projectedBox = id ? this.boxByBBoxId.get(id) : undefined;
-    if (projectedBox) {
-      this.transformer.nodes(projectedBox);
-      this.transformer.moveToTop();
-    } else {
-      this.transformer.nodes([]);
+  /**
+   * Project the live editing gesture (a 3D box mid-draw/drag broadcast by the
+   * 3D widget) as a dashed wireframe, so it tracks the pointer in every image
+   * view before being saved.
+   */
+  private _syncDraft(draft: BBox3DDraft | null, frame: PixelFrame | null): void {
+    if (!draft || !frame || !this.draftVisible) {
+      this._destroyDraft();
+      return;
     }
-    this.transformer.getLayer()?.batchDraw();
+    if (!this.draftLines) {
+      this.draftLines = this._makeProjectedBox(DRAFT_DASH);
+      for (const line of this.draftLines) this.ctx.annotationLayer.add(line);
+    }
+    this._applyProjection(this.draftLines, draft.geometry, frame);
+  }
+
+  private _destroyDraft(): void {
+    if (!this.draftLines) return;
+    for (const line of this.draftLines) line.destroy();
+    this.draftLines = null;
   }
 
   /** One hidden line per `BOX_EDGES` entry; `_applyProjection` fills them in. */
-  private _makeProjectedBox(dash?: number[]): Konva.Line[] {
+  private _makeProjectedBox(dash?: readonly number[]): Konva.Line[] {
     return BOX_EDGES.map(
       () =>
         new Konva.Line({
@@ -128,7 +253,11 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
           stroke: PROJECTED_EDGE_COLOR,
           strokeWidth: PROJECTED_EDGE_WIDTH,
           visible: false,
-          dash,
+          // Konva keeps the array by reference, so hand each line its own copy
+          // rather than letting all 14 share the module constant.
+          dash: dash ? [...dash] : undefined,
+          // Display-only (see the class doc): must never intercept a click.
+          listening: false,
         }),
     );
   }
@@ -140,80 +269,66 @@ class BBox3DRenderer2D implements AnnotationRenderer2D {
    * plane between two syncs.
    */
   private _applyProjection(lines: Konva.Line[], geometry: BBox3DGeometry, frame: PixelFrame): void {
-    const pixels = this._getProjectedPixels(geometry, frame);
-    if (!pixels) {
+    if (!this._projectInto(geometry, frame)) {
       for (const line of lines) line.visible(false);
       return;
     }
     for (let i = 0; i < BOX_EDGES.length; i++) {
       const [a, b] = BOX_EDGES[i];
-      lines[i].points([pixels[a].x, pixels[a].y, pixels[b].x, pixels[b].y]);
+      const from = this.pixelCorners[a];
+      const to = this.pixelCorners[b];
+      lines[i].points([from.x, from.y, to.x, to.y]);
       lines[i].visible(true);
     }
   }
 
-  /** The box's 8 corners in world (Lance, Z-up) space. */
-  private _get3dbboxCorners(geometry: BBox3DGeometry): { x: number; y: number; z: number }[] {
+  /** Fill `worldCorners` with the box's 8 corners in world (Lance, Z-up) space. */
+  private _computeWorldCorners(geometry: BBox3DGeometry): void {
     const [x, y, z, w, h, d] = geometry.coords;
-    const rotationMatrix = geometry.rotation
-      ? new Matrix3().fromArray(geometry.rotation).transpose()
-      : new Matrix3().identity();
-    const unitCube = [
-      [-0.5, -0.5, -0.5],
-      [0.5, -0.5, -0.5],
-      [0.5, 0.5, -0.5],
-      [-0.5, 0.5, -0.5],
-      [-0.5, -0.5, 0.5],
-      [0.5, -0.5, 0.5],
-      [0.5, 0.5, 0.5],
-      [-0.5, 0.5, 0.5],
-    ];
-    return unitCube.map(([cx, cy, cz]) => {
-      const corner = new Vector3(cx * w, cy * h, cz * d).applyMatrix3(rotationMatrix);
-      return { x: corner.x + x, y: corner.y + y, z: corner.z + z };
-    });
+    if (geometry.rotation) this.rotationScratch.fromArray(geometry.rotation).transpose();
+    else this.rotationScratch.identity();
+    this.centerScratch.set(x, y, z);
+    for (let i = 0; i < BOX_CORNER_COUNT; i++) {
+      const [cx, cy, cz] = UNIT_CUBE_CORNERS[i];
+      this.worldCorners[i]
+        .set(cx * w, cy * h, cz * d)
+        .applyMatrix3(this.rotationScratch)
+        .add(this.centerScratch);
+    }
   }
 
   /**
-   * Pinhole-project the corners into image pixel coordinates, or null when the
-   * widget has no calibration or any corner sits behind the camera.
+   * Pinhole-project the box's corners into `pixelCorners` (Konva stage space).
+   * Returns false — leaving the buffer stale — when the widget has no
+   * calibration or any corner sits behind the camera, which is why callers
+   * must hide the lines rather than draw whatever is left in the buffer.
    */
-  private _projectCorners(geometry: BBox3DGeometry): { x: number; y: number }[] | null {
+  private _projectInto(geometry: BBox3DGeometry, frame: PixelFrame): boolean {
     const calibration = this.ctx.camera.calibration;
-    if (!calibration) return null;
+    if (!calibration) return false;
     const { f, c } = calibration;
-    const extrinsics = new Matrix4().fromArray(calibration.extrinsicMatrix).transpose();
-    const projected: { x: number; y: number }[] = [];
-    for (const corner of this._get3dbboxCorners(geometry)) {
+    this.extrinsicsScratch.fromArray(calibration.extrinsicMatrix).transpose();
+    this._computeWorldCorners(geometry);
+    for (let i = 0; i < BOX_CORNER_COUNT; i++) {
+      const corner = this.worldCorners[i];
       // world -> camera
-      const cam = new Vector4(corner.x, corner.y, corner.z, 1).applyMatrix4(extrinsics);
-      if (cam.z <= 0) return null; // Behind the camera
-      projected.push({
-        x: (f[0] * cam.x) / cam.z + c[0],
-        y: (f[1] * cam.y) / cam.z + c[1],
-      });
-    }
-    return projected;
-  }
-
-  /** Corner pixels in Konva stage space, or null when projection fails. */
-  private _getProjectedPixels(
-    geometry: BBox3DGeometry,
-    frame: PixelFrame,
-  ): { x: number; y: number }[] | null {
-    const projected = this._projectCorners(geometry);
-    if (!projected) return null;
-    const pixels: { x: number; y: number }[] = [];
-    for (const point of projected) {
-      const pixel = normalizedPointToPixel(
-        point.x / this.ctx.camera.imageWidth,
-        point.y / this.ctx.camera.imageHeight,
+      const cam = this.cameraPointScratch
+        .set(corner.x, corner.y, corner.z, 1)
+        .applyMatrix4(this.extrinsicsScratch);
+      // Written as `!(z > 0)`, not `z <= 0`: every comparison with NaN is false,
+      // so the `<=` form would wave NaN through and write NaN line points. NaN
+      // can reach here from corrupt coords or a bad calibration matrix, so this
+      // is the guard that makes "a failed projection hides its lines" true.
+      if (!(cam.z > 0)) return false; // Behind the camera, or not a number
+      // camera -> image pixels -> normalized -> stage pixels
+      normalizedPointToPixel(
+        ((f[0] * cam.x) / cam.z + c[0]) / this.ctx.camera.imageWidth,
+        ((f[1] * cam.y) / cam.z + c[1]) / this.ctx.camera.imageHeight,
         frame,
+        this.pixelCorners[i],
       );
-      if (!pixel) return null;
-      pixels.push(pixel);
     }
-    return pixels;
+    return true;
   }
 }
 

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DTool.svelte
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DTool.svelte
@@ -7,9 +7,13 @@ License: CECILL-C
 <script lang="ts">
   import { T } from "@threlte/core";
   import { HTML } from "@threlte/extras";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
-  import { bboxTransform } from "$lib/annotations/coordinateTransforms";
+  import {
+    bboxTransform,
+    threeBoxToLanceXYZWHD,
+    threeQuaternionToLanceRotation,
+  } from "$lib/annotations/coordinateTransforms";
   import type { Scene3DContext } from "$lib/annotations/scene/sceneContext.js";
   import type { ToolHandle3D } from "$lib/annotations/scene/tool.js";
   import { pickEntityLabel } from "$lib/annotations/types";
@@ -87,6 +91,24 @@ License: CECILL-C
     session.setResetEditor(() => editor.reset());
     reportHandle?.(handle);
   });
+
+  // Broadcast the live preview geometry (Lance space) on every change, so
+  // image widgets can re-project the box while it is being drawn/dragged.
+  // `clearPreview` only clears a draft this widget owns, which makes the
+  // mount-time run (previewVisible starts false) and unmount safe when
+  // another 3D widget is mid-gesture.
+  $effect(() => {
+    if (!editor.previewVisible) {
+      session.clearPreview();
+      return;
+    }
+    session.reportPreview(
+      threeBoxToLanceXYZWHD(editor.previewCenter, editor.previewSize),
+      threeQuaternionToLanceRotation(editor.previewQuaternion),
+      editor.editingBoxId ?? undefined,
+    );
+  });
+  onDestroy(() => session.clearPreview());
 
   // Precise tuple (CODING_STANDARDS: geometry is tuples, not number[]).
   const previewQuaternionArr = $derived<[number, number, number, number]>([

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSeedLoader.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSeedLoader.test.ts
@@ -80,4 +80,39 @@ describe("bbox3dSeedLoader", () => {
     ctx.gateway = { ...ctx.gateway, listBBox3Ds: () => Promise.reject(new Error("boom")) };
     expect(await bbox3dSeedLoader.load(ctx)).toEqual([]);
   });
+
+  // This is the one boundary where an unvalidated rotation can enter. Downstream
+  // consumers feed it straight to `Matrix3.fromArray`, which reads nine slots and
+  // yields NaN geometry from anything shorter — so a malformed matrix must be
+  // dropped here, not carried inward.
+  describe("rotation validation", () => {
+    async function rotationOf(rotation: unknown) {
+      const anns = await bbox3dSeedLoader.load(
+        makeContext([makeRow({ rotation: rotation as number[] })]),
+      );
+      return (anns[0].geometry as BBox3DGeometry).rotation;
+    }
+
+    it("passes a well-formed 3×3 matrix through unchanged", async () => {
+      const rotation = [0, -1, 0, 1, 0, 0, 0, 0, 1];
+      expect(await rotationOf(rotation)).toEqual(rotation);
+    });
+
+    it("drops a matrix with too few entries", async () => {
+      expect(await rotationOf([1, 0, 0])).toBeUndefined();
+    });
+
+    it("drops a matrix with too many entries", async () => {
+      expect(await rotationOf([1, 0, 0, 0, 1, 0, 0, 0, 1, 1])).toBeUndefined();
+    });
+
+    it("drops a matrix containing NaN or Infinity", async () => {
+      expect(await rotationOf([1, 0, 0, 0, NaN, 0, 0, 0, 1])).toBeUndefined();
+      expect(await rotationOf([1, 0, 0, 0, Infinity, 0, 0, 0, 1])).toBeUndefined();
+    });
+
+    it("drops a missing rotation", async () => {
+      expect(await rotationOf(undefined)).toBeUndefined();
+    });
+  });
 });

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSession.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSession.test.ts
@@ -11,19 +11,24 @@ import {
   AnnotationCollection,
   type BBox3DGeometry,
 } from "$lib/annotations/annotationCollection.svelte.js";
-import type { SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
-import type { PendingAnnotation, ResourceMutation } from "$lib/annotations/types.js";
+import type {
+  LiveAnnotationDraft,
+  SeamContext,
+} from "$lib/annotations/scene/sceneContext.js";
+import type { PendingAnnotation, ResourceMutation, Rotation3x3 } from "$lib/annotations/types.js";
 
 const COORDS: [number, number, number, number, number, number] = [1, 2, 3, 4, 5, 6];
-const ROTATION = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+const ROTATION: Rotation3x3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
 
 function makeSeam() {
   const collection = new AnnotationCollection();
   const queued: ResourceMutation[] = [];
   const updates: Extract<ResourceMutation, { op: "update" }>[] = [];
   const entities: Record<string, Record<string, unknown>> = {};
+  const dropped: string[] = [];
   let pending: PendingAnnotation | null = null;
-  const seam: SceneContextBase = {
+  let liveDraft: LiveAnnotationDraft | null = null;
+  const seam: SeamContext = {
     widgetId: "w1",
     buildContext: { datasetId: "ds", recordId: "rec", viewId: "v1" },
     collection,
@@ -34,7 +39,15 @@ function makeSeam() {
       queue: (m) => queued.push(m),
       upsertUpdate: (m) => updates.push(m),
       patchPendingCreate: () => {},
-      dropForLocalAnnotation: () => {},
+      dropForLocalAnnotation: (id) => dropped.push(id),
+    },
+    // Mirrors buildSeam: publish stamps this widget, clear only clears its own.
+    liveDraft: {
+      get: () => liveDraft,
+      publish: (draft) => (liveDraft = { ...draft, sourceWidgetId: "w1" }),
+      clear: () => {
+        if (liveDraft?.sourceWidgetId === "w1") liveDraft = null;
+      },
     },
     setActiveTool: () => {},
     requestRedraw: () => {},
@@ -42,7 +55,16 @@ function makeSeam() {
     findEntity: (id) => entities[id],
     isEntityVisible: () => true,
   };
-  return { seam, collection, queued, updates, entities, getPending: () => pending };
+  return {
+    seam,
+    collection,
+    queued,
+    updates,
+    entities,
+    dropped,
+    getPending: () => pending,
+    getLiveDraft: () => liveDraft,
+  };
 }
 
 describe("BBox3DSession", () => {
@@ -120,6 +142,143 @@ describe("BBox3DSession", () => {
     expect(env.collection.count).toBe(0);
     expect(env.queued).toHaveLength(0);
     expect(resetCalls).toBe(0);
+  });
+
+  it("reportPreview broadcasts a live bbox3d draft through the seam", () => {
+    session.reportPreview(COORDS, ROTATION);
+    expect(env.getLiveDraft()).toEqual({
+      kind: "bbox3d",
+      geometry: { coords: COORDS, format: "xyzwhd", rotation: ROTATION },
+      editingId: null,
+      sourceWidgetId: "w1",
+    });
+  });
+
+  it("reportPreview carries the id of the box being edited", () => {
+    session.reportPreview(COORDS, ROTATION, "b1");
+    expect(env.getLiveDraft()?.editingId).toBe("b1");
+  });
+
+  it("clearPreview clears this widget's own draft", () => {
+    session.reportPreview(COORDS, ROTATION);
+    session.clearPreview();
+    expect(env.getLiveDraft()).toBeNull();
+  });
+
+  // Both of these are commit paths that write to the mutation queue, and both
+  // were shipped untested (see DEBT-4).
+  describe("deleteBox", () => {
+    function addPersisted(id = "b1") {
+      env.collection.add({
+        id,
+        entityId: "e1",
+        kind: "bbox3d",
+        viewId: "v1",
+        geometry: { coords: COORDS, format: "xyzwhd", rotation: ROTATION },
+        persisted: true,
+      });
+    }
+
+    it("queues a delete for a saved box and drops it from the collection", () => {
+      addPersisted();
+      session.reportReady(COORDS, ROTATION, "b1");
+
+      session.deleteBox();
+
+      expect(env.queued).toHaveLength(1);
+      expect(env.queued[0]).toMatchObject({ op: "delete", resource: "bbox3ds", id: "b1" });
+      expect(env.collection.find("b1")).toBeUndefined();
+      expect(session.confirm).toBeNull();
+      expect(resetCalls).toBe(1);
+    });
+
+    // An unsaved box has no backend row yet, so deleting it must cancel its
+    // queued creates rather than queue a delete for something that never existed.
+    it("drops the pending creates for an unsaved box instead of queueing a delete", () => {
+      session.reportReady(COORDS, ROTATION);
+      session.save(); // stages an unsaved draft, defers the create
+      const draftId = env.collection.items[0].id;
+      session.reportReady(COORDS, ROTATION, draftId);
+
+      session.deleteBox();
+
+      expect(env.queued.filter((m) => m.op === "delete")).toHaveLength(0);
+      expect(env.dropped).toEqual([draftId]);
+      expect(env.collection.find(draftId)).toBeUndefined();
+    });
+
+    it("is a no-op when no box is being edited", () => {
+      addPersisted();
+      session.deleteBox();
+
+      expect(env.queued).toHaveLength(0);
+      expect(env.collection.count).toBe(1);
+      expect(resetCalls).toBe(0);
+    });
+
+    it("is a no-op when the edited box is no longer in the collection", () => {
+      session.reportReady(COORDS, ROTATION, "gone");
+
+      session.deleteBox();
+
+      expect(env.queued).toHaveLength(0);
+      expect(session.confirm).toBeNull();
+    });
+  });
+
+  describe("changeEntity", () => {
+    function addPersisted() {
+      env.collection.add({
+        id: "b1",
+        entityId: "e1",
+        kind: "bbox3d",
+        viewId: "v1",
+        geometry: { coords: COORDS, format: "xyzwhd", rotation: ROTATION },
+        persisted: true,
+      });
+    }
+
+    it("opens the entity picker and reassigns the box on confirm", () => {
+      addPersisted();
+      env.entities["e2"] = { id: "e2", category: "bus" };
+      session.reportReady(COORDS, ROTATION, "b1");
+
+      session.changeEntity();
+
+      expect(session.confirm).toBeNull();
+      expect(resetCalls).toBe(1);
+      env.getPending()!.onConfirm({ mode: "existing", entityId: "e2" });
+      expect(env.collection.find("b1")?.entityId).toBe("e2");
+      expect(env.updates).toHaveLength(1);
+      expect(env.updates[0].id).toBe("b1");
+    });
+
+    // Reassignment only makes sense once the box has an entity to move away from.
+    it("is a no-op for a box that has not been saved yet", () => {
+      env.collection.add({
+        id: "draft",
+        entityId: "",
+        kind: "bbox3d",
+        viewId: "v1",
+        geometry: { coords: COORDS, format: "xyzwhd", rotation: ROTATION },
+        persisted: false,
+      });
+      session.reportReady(COORDS, ROTATION, "draft");
+
+      session.changeEntity();
+
+      expect(env.getPending()).toBeNull();
+      expect(session.confirm).not.toBeNull();
+      expect(resetCalls).toBe(0);
+    });
+
+    it("is a no-op when no box is being edited", () => {
+      addPersisted();
+      session.changeEntity();
+
+      expect(env.getPending()).toBeNull();
+      expect(resetCalls).toBe(0);
+    });
   });
 
   it("toggleGizmo flips a visibility key", () => {

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dSeedLoader.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dSeedLoader.ts
@@ -6,7 +6,25 @@ License: CECILL-C
 
 import type { LocalBBox3DAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
 import type { AnnotationSeedLoader, SeedLoadContext } from "$lib/annotations/seedLoaders.js";
+import type { Rotation3x3 } from "$lib/annotations/types.js";
 import type { BBox3DRow } from "$lib/api/annotations.js";
+
+/** A row-major 3×3 matrix has exactly nine entries. */
+const ROTATION_LENGTH = 9;
+
+/**
+ * The one boundary where unvalidated rotations enter: a server row is typed
+ * `number[]`, but every consumer downstream feeds it to `Matrix3.fromArray`,
+ * which reads nine slots and produces NaN geometry from a shorter array — and
+ * NaN defeats the renderers' own "is this projectable?" guards, since every
+ * comparison with NaN is false. Anything malformed is dropped to `undefined`,
+ * which every consumer already handles as "no rotation".
+ */
+function toRotation3x3(rotation: number[] | undefined): Rotation3x3 | undefined {
+  if (!rotation || rotation.length !== ROTATION_LENGTH) return undefined;
+  if (!rotation.every((n) => Number.isFinite(n))) return undefined;
+  return rotation as Rotation3x3;
+}
 
 /**
  * REST→local mapping for 3D boxes. Record-scoped kind: rows are kept
@@ -28,7 +46,7 @@ export const bbox3dSeedLoader: AnnotationSeedLoader = {
         entityId: row.entity_id,
         kind: "bbox3d",
         viewId: row.view_id ?? "",
-        geometry: { coords: row.coords, format: row.format, rotation: row.rotation },
+        geometry: { coords: row.coords, format: row.format, rotation: toRotation3x3(row.rotation) },
         persisted: true,
         entity: row.entity_id ? ctx.entitiesById.get(row.entity_id) : undefined,
       }),

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dSession.svelte.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dSession.svelte.ts
@@ -16,12 +16,13 @@ import {
   deleteLocalAnnotation,
   reassignEntity,
 } from "$lib/annotations/payloadBuilders.js";
-import type { SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
+import type { SeamContext } from "$lib/annotations/scene/sceneContext.js";
+import type { Rotation3x3 } from "$lib/annotations/types.js";
 
 /** A 3D box the editor has staged and is waiting for the user to confirm. */
 export interface PendingConfirm {
   coords: [number, number, number, number, number, number];
-  rotation?: number[];
+  rotation?: Rotation3x3;
   /** Set when editing an existing box; absent when creating a new one. */
   editingId?: string;
 }
@@ -42,7 +43,7 @@ export class BBox3DSession {
 
   private resetEditor: () => void = () => {};
 
-  constructor(private readonly seam: SceneContextBase) {}
+  constructor(private readonly seam: SeamContext) {}
 
   /** The overlay's editor registers how to clear its in-progress draft. */
   setResetEditor(reset: () => void): void {
@@ -52,7 +53,7 @@ export class BBox3DSession {
   /** Editor reports a draft ready to confirm. */
   reportReady(
     coords: [number, number, number, number, number, number],
-    rotation?: number[],
+    rotation?: Rotation3x3,
     editingId?: string,
   ): void {
     this.confirm = { coords, rotation, editingId };
@@ -61,6 +62,33 @@ export class BBox3DSession {
   /** Editor reports its draft was canceled/cleared. */
   reportCanceled(): void {
     this.confirm = null;
+  }
+
+  /**
+   * Broadcast the in-progress geometry (called on every pointer move) so other
+   * widgets can preview the gesture live — e.g. image widgets re-projecting the
+   * box while it is dragged. Always publishes a fresh object: consumers track
+   * the `$state` reassignment, so mutating a draft in place would go unnoticed.
+   */
+  reportPreview(
+    coords: [number, number, number, number, number, number],
+    rotation?: Rotation3x3,
+    editingId?: string,
+  ): void {
+    this.seam.liveDraft.publish({
+      kind: "bbox3d",
+      geometry: { coords, format: "xyzwhd", rotation },
+      editingId: editingId ?? null,
+    });
+  }
+
+  /**
+   * Clear the broadcast preview. Safe to call from a mounting, idling or
+   * unmounting widget: the seam clears only a draft this widget published, so
+   * another widget's active gesture is never wiped.
+   */
+  clearPreview(): void {
+    this.seam.liveDraft.clear();
   }
 
   /**

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/boxEditor.svelte.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/boxEditor.svelte.ts
@@ -8,6 +8,7 @@ import * as THREE from "three";
 import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
 import { threeBoxToLanceXYZWHD, threeQuaternionToLanceRotation } from "$lib/annotations/coordinateTransforms";
+import type { Rotation3x3 } from "$lib/annotations/types";
 
 import {
   ARROW_DEFS,
@@ -188,7 +189,7 @@ export class BoxEditor {
     private readonly getGizmoVisibility: () => GizmoVisibility,
     private readonly onReadyToConfirm?: (
       coords: [number, number, number, number, number, number],
-      rotation?: number[],
+      rotation?: Rotation3x3,
       editingId?: string,
     ) => void,
     private readonly onDrawCanceled?: () => void,

--- a/ui/apps/web/src/lib/annotations/scene/__tests__/scene2dGeometry.test.ts
+++ b/ui/apps/web/src/lib/annotations/scene/__tests__/scene2dGeometry.test.ts
@@ -7,9 +7,14 @@ License: CECILL-C
 import type Konva from "konva";
 import { describe, expect, it } from "vitest";
 
+import {
+  getPixelFrame,
+  normalizedPointToPixel,
+  normalizedToPixel,
+  pixelToNormalized,
+  type PixelFrame,
+} from "../scene2dGeometry.js";
 import type { CoordsNorm } from "$lib/annotations/types.js";
-
-import { getPixelFrame, normalizedToPixel, pixelToNormalized, type PixelFrame } from "../scene2dGeometry.js";
 
 /** Minimal Konva.Image stand-in: getPixelFrame only reads x/y/width/height. */
 function fakeImage(x: number, y: number, w: number, h: number): Konva.Image {
@@ -29,12 +34,49 @@ describe("getPixelFrame", () => {
 describe("normalizedToPixel", () => {
   it("maps normalized xywh onto a frame at the origin", () => {
     const frame: PixelFrame = { x: 0, y: 0, w: 100, h: 200 };
-    expect(normalizedToPixel([0.1, 0.2, 0.3, 0.4], frame)).toEqual({ x: 10, y: 40, width: 30, height: 80 });
+    expect(normalizedToPixel([0.1, 0.2, 0.3, 0.4], frame)).toEqual({
+      x: 10,
+      y: 40,
+      width: 30,
+      height: 80,
+    });
   });
 
   it("offsets by the frame position (letterboxed image)", () => {
     const frame: PixelFrame = { x: 50, y: 20, w: 100, h: 100 };
-    expect(normalizedToPixel([0, 0, 1, 1], frame)).toEqual({ x: 50, y: 20, width: 100, height: 100 });
+    expect(normalizedToPixel([0, 0, 1, 1], frame)).toEqual({
+      x: 50,
+      y: 20,
+      width: 100,
+      height: 100,
+    });
+  });
+});
+
+describe("normalizedPointToPixel", () => {
+  it("maps a normalized point onto a frame at the origin", () => {
+    const frame: PixelFrame = { x: 0, y: 0, w: 100, h: 200 };
+    expect(normalizedPointToPixel(0.1, 0.2, frame, { x: 0, y: 0 })).toEqual({ x: 10, y: 40 });
+  });
+
+  it("offsets by the frame position (letterboxed image)", () => {
+    const frame: PixelFrame = { x: 50, y: 20, w: 100, h: 100 };
+    expect(normalizedPointToPixel(0, 0, frame, { x: 0, y: 0 })).toEqual({ x: 50, y: 20 });
+  });
+
+  it("maps points outside the frame without clamping (corner behind/off-image)", () => {
+    const frame: PixelFrame = { x: 0, y: 0, w: 100, h: 100 };
+    expect(normalizedPointToPixel(-0.5, 1.5, frame, { x: 0, y: 0 })).toEqual({ x: -50, y: 150 });
+  });
+
+  // The bbox3d projection reuses one scratch point per corner, so the write
+  // must land in the caller's object rather than in a fresh one.
+  it("writes into the target and returns that same object", () => {
+    const frame: PixelFrame = { x: 0, y: 0, w: 100, h: 200 };
+    const target = { x: -1, y: -1 };
+    const returned = normalizedPointToPixel(0.5, 0.5, frame, target);
+    expect(returned).toBe(target);
+    expect(target).toEqual({ x: 50, y: 100 });
   });
 });
 

--- a/ui/apps/web/src/lib/annotations/scene/__tests__/selectTool2D.test.ts
+++ b/ui/apps/web/src/lib/annotations/scene/__tests__/selectTool2D.test.ts
@@ -36,6 +36,7 @@ function makeContext(collection: AnnotationCollection) {
       patchPendingCreate: vi.fn(),
       dropForLocalAnnotation: vi.fn(),
     },
+    liveDraft: { get: () => null },
     stage,
     annotationLayer: {} as Konva.Layer,
     camera: { imageWidth: 100, imageHeight: 100, calibration: null },

--- a/ui/apps/web/src/lib/annotations/scene/renderer.ts
+++ b/ui/apps/web/src/lib/annotations/scene/renderer.ts
@@ -7,8 +7,12 @@ License: CECILL-C
 import type { Component } from "svelte";
 
 import type { AnnotationKind } from "../annotationCollection.svelte.js";
-
-import type { Scene2DContext, Scene2DReadContext, Scene3DContext } from "./sceneContext.js";
+import type {
+  LiveAnnotationDraft,
+  Scene2DContext,
+  Scene2DReadContext,
+  Scene3DContext,
+} from "./sceneContext.js";
 
 /**
  * Displays one annotation kind on the 2D scene: pure display plus selection.
@@ -20,6 +24,19 @@ export interface AnnotationRenderer2D {
   readonly kind: AnnotationKind;
   /** Reconcile scene nodes with the collection. */
   sync(): void;
+  /**
+   * Reconcile ONLY the live-gesture preview, leaving persisted nodes untouched.
+   * Called at pointer rate while a gesture runs in another widget, so it must
+   * stay proportional to the draft — never to the size of the collection.
+   * Receives the whole `LiveAnnotationDraft` union (the widget is kind-agnostic
+   * and cannot narrow it); implementations narrow on `draft.kind`. `null` means
+   * "no gesture in flight" and must tear any preview down.
+   *
+   * Required, not optional: an optional method would let a renamed or
+   * mistyped implementation silently opt out with no compile error. Kinds with
+   * no cross-widget preview implement a documented no-op.
+   */
+  syncDraft(draft: LiveAnnotationDraft | null): void;
   destroy(): void;
 }
 

--- a/ui/apps/web/src/lib/annotations/scene/scene2dGeometry.ts
+++ b/ui/apps/web/src/lib/annotations/scene/scene2dGeometry.ts
@@ -12,11 +12,25 @@ export const PIXEL_THRESHOLD = 3;
 export const BBOX_COLOR_PERSISTED = "#22d3ee";
 export const BBOX_COLOR_DRAFT = "#f59e0b";
 
+/**
+ * Dash pattern marking a shape as not-yet-saved: the draw tool's rubber band,
+ * an unsaved bbox, and the live 3D preview all share it so "dashed = draft"
+ * reads the same everywhere. Frozen because Konva keeps the array by reference
+ * — a mutation here would silently restyle every draft on screen.
+ */
+export const DRAFT_DASH: readonly number[] = Object.freeze([6, 4]);
+
 export interface PixelFrame {
   x: number;
   y: number;
   w: number;
   h: number;
+}
+
+/** A point in Konva stage space. */
+export interface PixelPoint {
+  x: number;
+  y: number;
 }
 
 export function getPixelFrame(konvaImage: Konva.Image | null): PixelFrame | null {
@@ -36,12 +50,23 @@ export function normalizedToPixel(
   };
 }
 
-export function normalizedPointToPixel(x: number, y: number, frame: PixelFrame): { x: number; y: number } | null {
-    return {
-      x: frame.x + x * frame.w,
-      y: frame.y + y * frame.h,
-    };
-  }
+/**
+ * Map a normalized point onto the frame, writing the result into `target`
+ * (Three.js `getWorldPosition(target)` convention) rather than returning a
+ * fresh object: the bbox3d projection calls this once per corner, per box, per
+ * sync — and sync runs on every pointer move while a 3D box is dragged, so the
+ * path must not allocate (CODING_STANDARDS). Returns `target` for chaining.
+ */
+export function normalizedPointToPixel(
+  x: number,
+  y: number,
+  frame: PixelFrame,
+  target: PixelPoint,
+): PixelPoint {
+  target.x = frame.x + x * frame.w;
+  target.y = frame.y + y * frame.h;
+  return target;
+}
 
 export function pixelToNormalized(
   rectX: number,

--- a/ui/apps/web/src/lib/annotations/scene/sceneContext.ts
+++ b/ui/apps/web/src/lib/annotations/scene/sceneContext.ts
@@ -8,9 +8,62 @@ import type Konva from "konva";
 import type { PerspectiveCamera } from "three";
 import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
-import type { AnnotationStore } from "../annotationCollection.svelte.js";
+import type {
+  AnnotationKind,
+  AnnotationStore,
+  GeometryByKind,
+} from "../annotationCollection.svelte.js";
 import type { BuildContext } from "../buildPayloads.js";
 import type { CameraCalibration, PendingAnnotation, ResourceMutation } from "../types.js";
+
+/**
+ * Transient in-progress geometry an editing tool broadcasts on every pointer
+ * move, so widgets in other mediums can preview the gesture live (e.g. an image
+ * widget re-projecting a 3D box while it is dragged). Deliberately NOT an
+ * `AnnotationStore` entry: the store contract covers committed annotations
+ * (membership, selection, deletion), while this is per-frame editor state that
+ * dies with the gesture. A distributed union so `draft.kind` narrows `geometry`.
+ */
+export type LiveAnnotationDraft = {
+  [K in AnnotationKind]: LiveDraftBody<K> & {
+    /** Widget owning the gesture, stamped by the seam — never by the publisher. */
+    readonly sourceWidgetId: string;
+  };
+}[AnnotationKind];
+
+/**
+ * The part of a draft a publisher supplies. `sourceWidgetId` is deliberately
+ * absent: the seam stamps it, so a tool can neither forge another widget's id
+ * nor forget to set its own.
+ */
+type LiveDraftBody<K extends AnnotationKind> = {
+  readonly kind: K;
+  readonly geometry: GeometryByKind[K];
+  /** Persisted annotation being edited, or null when creating a new one. */
+  readonly editingId: string | null;
+};
+
+/** What a tool hands to `LiveDraftChannel.publish`. */
+export type LiveDraftPublication = {
+  [K in AnnotationKind]: LiveDraftBody<K>;
+}[AnnotationKind];
+
+/** Read side of the live-draft slot — all a renderer, or any 2D tool, may hold (D4). */
+export interface LiveDraftSource {
+  get(): LiveAnnotationDraft | null;
+}
+
+/**
+ * Write side, handed only to the pieces that own a gesture (see `SeamContext`).
+ * Ownership is structural rather than by convention: `publish` stamps the
+ * caller's widget id, and `clear` is a no-op unless the live draft belongs to
+ * that same widget — so no tool can wipe a gesture running in another widget,
+ * whether or not its author remembered the rule.
+ */
+export interface LiveDraftChannel extends LiveDraftSource {
+  publish(draft: LiveDraftPublication): void;
+  clear(): void;
+}
 
 /**
  * Narrow view of the mutation queue handed to tools and renderers: enough to
@@ -46,6 +99,12 @@ export interface SceneContextBase {
   /** View-scoped window onto the record's shared annotation collection. */
   readonly collection: AnnotationStore;
   readonly mutations: MutationSink;
+  /**
+   * Shared slot for the in-progress geometry of the active editing gesture.
+   * Read-only here: observing a gesture is medium-agnostic, but *publishing* one
+   * is a capability handed explicitly through `SeamContext`.
+   */
+  readonly liveDraft: LiveDraftSource;
   /** Switch the widget's active tool (e.g. back to "select" after a draw). */
   setActiveTool(id: string): void;
   /** Ask the host to re-sync annotation rendering. */
@@ -59,6 +118,19 @@ export interface SceneContextBase {
   findEntity(entityId: string): Record<string, unknown> | undefined;
   /** Whether an entity's persisted annotations should currently be shown. */
   isEntityVisible(entityId: string): boolean;
+}
+
+/**
+ * What `buildSeam` returns: `SceneContextBase` plus the live-draft *write* side.
+ * Handed only to the pieces that own a gesture — today a 3D tool's session, via
+ * `Tool3D.createSession`. Every narrower contract (`Scene2DContext`,
+ * `Scene3DContext`) sees `liveDraft` as a read-only `LiveDraftSource`, so
+ * publishing is a capability granted deliberately rather than one every tool in
+ * every medium inherits. Same technique as `Scene2DReadContext`: one object,
+ * handed out through progressively narrower types (D4).
+ */
+export interface SeamContext extends SceneContextBase {
+  readonly liveDraft: LiveDraftChannel;
 }
 
 /**
@@ -86,6 +158,8 @@ export interface Scene2DReadContext {
   readonly annotationLayer: Konva.Layer;
   /** Media size + calibration, for kinds that project into the image. */
   readonly camera: Scene2DCamera;
+  /** Read-only view of the shared live-draft slot, for live previews. */
+  readonly liveDraft: LiveDraftSource;
   getKonvaImage(): Konva.Image | null;
   requestRedraw(): void;
   /** Whether an entity's persisted annotations should currently be shown. */

--- a/ui/apps/web/src/lib/annotations/scene/tool.ts
+++ b/ui/apps/web/src/lib/annotations/scene/tool.ts
@@ -8,7 +8,7 @@ import type { Component } from "svelte";
 
 import type Konva from "konva";
 
-import type { Scene2DContext, Scene3DContext, SceneContextBase } from "./sceneContext.js";
+import type { Scene2DContext, Scene3DContext, SeamContext } from "./sceneContext.js";
 import type { ToolDefinition } from "./toolDefinition.js";
 
 export type { ToolDefinition } from "./toolDefinition.js";
@@ -80,5 +80,5 @@ export interface ToolHudProps {
 export interface Tool3D extends ToolDefinition {
   overlay?: Component<AnnotationTool3DProps>;
   hud?: Component<ToolHudProps>;
-  createSession?: (seam: SceneContextBase) => unknown;
+  createSession?: (seam: SeamContext) => unknown;
 }

--- a/ui/apps/web/src/lib/annotations/types.ts
+++ b/ui/apps/web/src/lib/annotations/types.ts
@@ -11,6 +11,25 @@ License: CECILL-C
 export type CoordsNorm = [number, number, number, number];
 
 /**
+ * A row-major 3×3 rotation matrix — exactly nine numbers. A precise tuple, not
+ * `number[]`: consumers feed it straight to `Matrix3.fromArray`, which reads
+ * nine slots and silently yields `undefined` (→ NaN geometry) on a shorter
+ * array. Server rows are validated into this shape by the bbox3d seed loader,
+ * so everything downstream of that boundary can trust the length.
+ */
+export type Rotation3x3 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+
+/**
  * Pick a human-friendly label from an entity row. Returns the first non-empty
  * string field that isn't an id / linkage column. Falls back to the entity id
  * (truncated) when no descriptive field exists so the user still has a handle.

--- a/ui/apps/web/src/lib/components/shell/EntitiesPanel.svelte
+++ b/ui/apps/web/src/lib/components/shell/EntitiesPanel.svelte
@@ -5,7 +5,7 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Eye } from "lucide-svelte";
+  import { Eye, EyeOff } from "lucide-svelte";
 
   import type { EntityRow } from "$lib/api/annotations.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
@@ -48,14 +48,19 @@ License: CECILL-C
       </p>
       <button
         type="button"
-        onclick={() => manager.showAllEntities()}
-        title="Show every entity's annotations"
+        onclick={() => manager.toggleAllEntitiesVisible()}
+        title={showingAll ? "Hide every entity's annotations" : "Show every entity's annotations"}
         class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] transition-colors {showingAll
           ? 'bg-accent text-accent-foreground'
           : 'text-muted-foreground hover:bg-accent/50'}"
       >
-        <Eye class="h-3 w-3" />
-        Show all
+        {#if showingAll}
+          <EyeOff class="h-3 w-3" />
+          Hide all
+        {:else}
+          <Eye class="h-3 w-3" />
+          Show all
+        {/if}
       </button>
     </div>
     <div class="space-y-1.5">

--- a/ui/apps/web/src/lib/components/widgets/__tests__/sceneSeam.test.ts
+++ b/ui/apps/web/src/lib/components/widgets/__tests__/sceneSeam.test.ts
@@ -1,0 +1,111 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import { buildSeam } from "../sceneSeam.js";
+import {
+  AnnotationCollection,
+  type BBox3DGeometry,
+} from "$lib/annotations/annotationCollection.svelte.js";
+import type { LiveAnnotationDraft } from "$lib/annotations/scene/sceneContext.js";
+import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
+
+const GEOMETRY: BBox3DGeometry = { coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd" };
+
+/** Only the slice of the manager `buildSeam` actually touches. */
+function fakeManager() {
+  let liveDraft: LiveAnnotationDraft | null = null;
+  return {
+    annotations: new AnnotationCollection(),
+    entities: [],
+    pendingMutations: [],
+    get liveDraft() {
+      return liveDraft;
+    },
+    setLiveDraft: (draft: LiveAnnotationDraft | null) => (liveDraft = draft),
+    queueMutation: () => {},
+    upsertUpdateMutation: () => {},
+    patchPendingCreateMutation: () => {},
+    dropMutationsForLocalAnnotation: () => {},
+    beginPendingAnnotation: () => {},
+    isEntityVisible: () => true,
+  };
+}
+
+function seamFor(manager: ReturnType<typeof fakeManager>, widgetId: string) {
+  return buildSeam(manager as unknown as WorkspaceManager, {
+    widgetId,
+    buildContext: { datasetId: "ds", recordId: "rec", viewId: "v1" },
+    storage: { activeToolId: "select" },
+  });
+}
+
+// The live-draft slot is shared workspace-wide, so these rules are what stop one
+// widget's tool from wiping a gesture running in another. They live in the seam
+// rather than in each tool precisely so a tool author cannot get them wrong.
+describe("buildSeam — live-draft ownership", () => {
+  it("stamps the publishing widget's id, so a tool cannot forge another's", () => {
+    const manager = fakeManager();
+
+    seamFor(manager, "widget-a").liveDraft.publish({
+      kind: "bbox3d",
+      geometry: GEOMETRY,
+      editingId: null,
+    });
+
+    expect(manager.liveDraft).toEqual({
+      kind: "bbox3d",
+      geometry: GEOMETRY,
+      editingId: null,
+      sourceWidgetId: "widget-a",
+    });
+  });
+
+  it("clears a draft the widget published itself", () => {
+    const manager = fakeManager();
+    const seam = seamFor(manager, "widget-a");
+
+    seam.liveDraft.publish({ kind: "bbox3d", geometry: GEOMETRY, editingId: null });
+    seam.liveDraft.clear();
+
+    expect(manager.liveDraft).toBeNull();
+  });
+
+  it("leaves another widget's in-flight gesture untouched", () => {
+    const manager = fakeManager();
+    seamFor(manager, "widget-a").liveDraft.publish({
+      kind: "bbox3d",
+      geometry: GEOMETRY,
+      editingId: null,
+    });
+
+    // B idles/unmounts and clears — A is mid-gesture and must survive it.
+    seamFor(manager, "widget-b").liveDraft.clear();
+
+    expect(manager.liveDraft?.sourceWidgetId).toBe("widget-a");
+  });
+
+  it("clearing an already-empty slot is a no-op", () => {
+    const manager = fakeManager();
+
+    seamFor(manager, "widget-a").liveDraft.clear();
+
+    expect(manager.liveDraft).toBeNull();
+  });
+
+  it("exposes the shared slot for reading regardless of which widget published", () => {
+    const manager = fakeManager();
+    const a = seamFor(manager, "widget-a");
+    const b = seamFor(manager, "widget-b");
+
+    a.liveDraft.publish({ kind: "bbox3d", geometry: GEOMETRY, editingId: "box-1" });
+
+    // B observes A's gesture — that is the whole point of the slot.
+    expect(b.liveDraft.get()?.editingId).toBe("box-1");
+    expect(b.liveDraft.get()?.sourceWidgetId).toBe("widget-a");
+  });
+});

--- a/ui/apps/web/src/lib/components/widgets/image/ImageWidget.svelte
+++ b/ui/apps/web/src/lib/components/widgets/image/ImageWidget.svelte
@@ -253,12 +253,22 @@ License: CECILL-C
     if (containerEl) containerEl.style.cursor = tool.cursor ?? "default";
   });
 
+  // Structural changes — membership, selection, the visible-entity filter — are
+  // discrete (one per click) and can afford a full reconcile of every renderer.
   $effect(() => {
     void annotations.items.length;
     void annotations.selectedId;
-    // Re-render when the visible-entity filter changes (show/hide annotations).
     void manager.visibleEntityIds;
     if (imageLoaded) syncRenderers();
+  });
+
+  // The live draft is different: it changes on every pointer move of a gesture
+  // running in another widget. A full reconcile there would rewrite every shape
+  // on the record to move one box, so it gets its own narrow path. Kept as a
+  // separate effect so a draft change never triggers the reconcile above.
+  $effect(() => {
+    const draft = manager.liveDraft;
+    if (imageLoaded) for (const renderer of renderers) renderer.syncDraft(draft);
   });
 
   const hasSelection = $derived(annotations.selectedId !== null);

--- a/ui/apps/web/src/lib/components/widgets/sceneSeam.ts
+++ b/ui/apps/web/src/lib/components/widgets/sceneSeam.ts
@@ -6,7 +6,7 @@ License: CECILL-C
 
 import { ViewScopedAnnotations } from "$lib/annotations/annotationCollection.svelte.js";
 import type { BuildContext } from "$lib/annotations/buildPayloads.js";
-import type { MutationSink, SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
+import type { MutationSink, SeamContext } from "$lib/annotations/scene/sceneContext.js";
 import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
 /**
@@ -43,12 +43,23 @@ export function buildSeam(
     storage: { activeToolId: string };
     requestRedraw?: () => void;
   },
-): SceneContextBase {
+): SeamContext {
   return {
     widgetId: opts.widgetId,
     buildContext: opts.buildContext,
     collection: new ViewScopedAnnotations(() => manager.annotations, opts.buildContext.viewId),
     mutations: buildMutationSink(manager),
+    // The live-draft slot is shared workspace-wide, so ownership is enforced
+    // here rather than left to each tool: `publish` stamps this widget's id, and
+    // `clear` only ever clears a draft this widget published. A tool physically
+    // cannot wipe a gesture running in another widget.
+    liveDraft: {
+      get: () => manager.liveDraft,
+      publish: (draft) => manager.setLiveDraft({ ...draft, sourceWidgetId: opts.widgetId }),
+      clear: () => {
+        if (manager.liveDraft?.sourceWidgetId === opts.widgetId) manager.setLiveDraft(null);
+      },
+    },
     setActiveTool: (id) => {
       opts.storage.activeToolId = id;
     },

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
@@ -4,25 +4,17 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { describe, expect, it } from "vitest";
-
-import type {
-  BBox3DRow,
-  BBoxRow,
-  EntityRow,
-} from "$lib/api/annotations.js";
-import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
-import { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
-import type {
-  WidgetComponentProps,
-  WidgetExtensionConfig,
-} from "$lib/extensions/types.js";
-import type { Dataset } from "$lib/types/dataset";
-import { DatasetInfo } from "$lib/types/dataset";
 import type { Component } from "svelte";
+import { describe, expect, it } from "vitest";
 
 import type { DatasetGateway } from "../datasetGateway.js";
 import { WorkspaceManager } from "../workspaceManager.svelte.js";
+import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
+import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
+import type { WidgetComponentProps, WidgetExtensionConfig } from "$lib/extensions/types.js";
+import { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
+import type { Dataset } from "$lib/types/dataset";
+import { DatasetInfo } from "$lib/types/dataset";
 
 // ─── Fake gateway ───────────────────────────────────────────────────────────
 // In-memory implementation of `DatasetGateway`. Each scenario builds one
@@ -255,6 +247,60 @@ describe("WorkspaceManager entity visibility", () => {
     expect(manager.isEntityVisible("e2")).toBe(true);
   });
 
+  it("hideAllEntities hides every entity", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.hideAllEntities();
+
+    expect(manager.visibleEntityIds?.size).toBe(0);
+    expect(manager.isEntityVisible("e1")).toBe(false);
+  });
+
+  it("toggleAllEntitiesVisible hides everything when all entities are shown", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleAllEntitiesVisible();
+
+    expect(manager.isEntityVisible("e1")).toBe(false);
+  });
+
+  it("toggleAllEntitiesVisible shows everything when an entity is isolated", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleEntityVisible("e1");
+    manager.toggleAllEntitiesVisible();
+
+    expect(manager.visibleEntityIds).toBeNull();
+    expect(manager.isEntityVisible("e2")).toBe(true);
+  });
+
+  it("toggleAllEntitiesVisible returns to show-all after hiding everything", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+
+    manager.toggleAllEntitiesVisible();
+    manager.toggleAllEntitiesVisible();
+
+    expect(manager.visibleEntityIds).toBeNull();
+    expect(manager.isEntityVisible("e1")).toBe(true);
+  });
+
+  it("clears the selection when hiding all entities", () => {
+    const manager = new WorkspaceManager(makeRegistry());
+    manager.annotations.add({
+      id: "b-eB",
+      entityId: "eB",
+      kind: "bbox",
+      viewId: "v1",
+      geometry: [0, 0, 1, 1],
+      persisted: true,
+    });
+    manager.annotations.select("b-eB");
+
+    manager.hideAllEntities();
+
+    expect(manager.annotations.selectedId).toBeNull();
+  });
+
   it("clears a selection that isolation has just hidden (no delete on an unseen box)", () => {
     const manager = new WorkspaceManager(makeRegistry());
     manager.annotations.add({
@@ -325,7 +371,11 @@ describe("WorkspaceManager.deleteAnnotation", () => {
     expect(manager.annotations.find("b1")).toBeUndefined();
     // Only the annotation row; the orphan entity is pruned server-side.
     expect(manager.pendingMutations).toHaveLength(1);
-    expect(manager.pendingMutations[0]).toMatchObject({ op: "delete", resource: "bbox3ds", id: "b1" });
+    expect(manager.pendingMutations[0]).toMatchObject({
+      op: "delete",
+      resource: "bbox3ds",
+      id: "b1",
+    });
   });
 
   it("drops pending creates for an unsaved annotation instead of queueing a delete", () => {
@@ -357,8 +407,14 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
       dataset,
       entities: [],
       imagesByLogicalName: new Map([
-        ["cam_front", { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse],
-        ["cam_back", { id: "img-back", src: "/b.png", width: 100, height: 50 } as CalibratedImageResponse],
+        [
+          "cam_front",
+          { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse,
+        ],
+        [
+          "cam_back",
+          { id: "img-back", src: "/b.png", width: 100, height: 50 } as CalibratedImageResponse,
+        ],
       ]),
       pointCloudsByLogicalName: new Map([
         ["lidar_top", { id: "pc-top", src: "/lidar.pcd" } as PointCloudResponse],
@@ -370,16 +426,8 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
     const manager = new WorkspaceManager(makeRegistry(), gateway);
     await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
 
-    expect(manager.widgets.map((w) => w.title)).toEqual([
-      "cam_front",
-      "lidar_top",
-      "cam_back",
-    ]);
-    expect(manager.widgets.map((w) => w.extensionName)).toEqual([
-      "image",
-      "point-cloud",
-      "image",
-    ]);
+    expect(manager.widgets.map((w) => w.title)).toEqual(["cam_front", "lidar_top", "cam_back"]);
+    expect(manager.widgets.map((w) => w.extensionName)).toEqual(["image", "point-cloud", "image"]);
     expect(manager.datasetId).toBe("ds-1");
     expect(manager.recordId).toBe("rec-1");
   });
@@ -472,7 +520,10 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
       dataset,
       entities: [{ id: "ent-old", record_id: "rec-1" } as EntityRow],
       imagesByLogicalName: new Map([
-        ["cam_front", { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse],
+        [
+          "cam_front",
+          { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse,
+        ],
       ]),
       pointCloudsByLogicalName: new Map(),
       bboxes: [],
@@ -506,9 +557,9 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
     });
 
     const manager = new WorkspaceManager(makeRegistry(), gateway);
-    await expect(
-      manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT),
-    ).rejects.toThrow("No renderable views");
+    await expect(manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT)).rejects.toThrow(
+      "No renderable views",
+    );
 
     // datasetId/recordId are still set so any subsequent flushSave knows
     // which dataset to target — the error case shouldn't make the manager
@@ -536,7 +587,17 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
         return entitiesPromise;
       },
       loadImageByLogicalName: () =>
-        Promise.resolve({ id: "img-1", src: "", width: 1, height: 1, f: null, c: null, distortion: null, extrinsic_matrix: null, ego_to_world: null } as CalibratedImageResponse),
+        Promise.resolve({
+          id: "img-1",
+          src: "",
+          width: 1,
+          height: 1,
+          f: null,
+          c: null,
+          distortion: null,
+          extrinsic_matrix: null,
+          ego_to_world: null,
+        } as CalibratedImageResponse),
       listBBoxes: () => Promise.resolve([]),
       loadPointCloudByLogicalName: () => Promise.resolve(null),
       listBBox3Ds: () => Promise.resolve([]),

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceSession.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceSession.svelte.test.ts
@@ -46,6 +46,12 @@ describe("WorkspaceSession", () => {
     session.recordId = "rec-42";
     session.entities = [{ id: "e1", record_id: "rec-1" }];
     session.entitySchemaName = "VOCEntity";
+    session.liveDraft = {
+      kind: "bbox3d",
+      geometry: { coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd" },
+      editingId: null,
+      sourceWidgetId: "w1",
+    };
 
     session.reset();
 
@@ -53,6 +59,7 @@ describe("WorkspaceSession", () => {
     expect(session.recordId).toBeNull();
     expect(session.entities).toEqual([]);
     expect(session.entitySchemaName).toBeNull();
+    expect(session.liveDraft).toBeNull();
   });
 
   it("reset() is idempotent on an already-empty session", () => {

--- a/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
@@ -4,8 +4,17 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { AnnotationCollection, LocalAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
+import { httpDatasetGateway, type DatasetGateway } from "./datasetGateway.js";
+import type { Viewport } from "./layoutPlanner.js";
+import { MutationQueue } from "./mutationQueue.svelte.js";
+import { RecordLoader } from "./recordLoader.js";
+import { WorkspaceSession } from "./workspaceSession.svelte.js";
+import type {
+  AnnotationCollection,
+  LocalAnnotation,
+} from "$lib/annotations/annotationCollection.svelte.js";
 import { deleteLocalAnnotation } from "$lib/annotations/payloadBuilders.js";
+import type { LiveAnnotationDraft } from "$lib/annotations/scene/sceneContext.js";
 import type {
   PendingAnnotation,
   PendingEntityChoice,
@@ -15,12 +24,6 @@ import type { EntityRow } from "$lib/api/annotations.js";
 import type { WidgetInstance, WidgetLayout, WorkspacePreset } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
 import type { FieldInfo } from "$lib/types/dataset.js";
-
-import { httpDatasetGateway, type DatasetGateway } from "./datasetGateway.js";
-import type { Viewport } from "./layoutPlanner.js";
-import { MutationQueue } from "./mutationQueue.svelte.js";
-import { RecordLoader } from "./recordLoader.js";
-import { WorkspaceSession } from "./workspaceSession.svelte.js";
 
 /**
  * Reactive workspace facade. Owns:
@@ -108,6 +111,15 @@ export class WorkspaceManager {
 
   get entitySchemaFields(): Record<string, FieldInfo> | null {
     return this.session.entitySchemaFields;
+  }
+
+  /** In-progress geometry of the active editing gesture, or null (see `WorkspaceSession`). */
+  get liveDraft(): LiveAnnotationDraft | null {
+    return this.session.liveDraft;
+  }
+
+  setLiveDraft(draft: LiveAnnotationDraft | null): void {
+    this.session.liveDraft = draft;
   }
 
   // ─── Entity-driven annotation visibility ──────────────────────────────────

--- a/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
@@ -123,7 +123,8 @@ export class WorkspaceManager {
   }
 
   // ─── Entity-driven annotation visibility ──────────────────────────────────
-  // `null` = all entities visible (default). A set isolates the listed entities.
+  // `null` = all entities visible (default). A set isolates the listed entities;
+  // an empty set therefore hides every one of them.
   // Display-only: renderers/derived lists consult `isEntityVisible`; the
   // annotation collection's lifecycle (find/drafts/save) is never filtered.
 
@@ -142,18 +143,39 @@ export class WorkspaceManager {
     const visible = this.session.visibleEntityIds;
     const isolated = visible !== null && visible.size === 1 && visible.has(entityId);
     this.session.visibleEntityIds = isolated ? null : new Set([entityId]);
-    // Keep the shared selection coherent with what's now displayed: a selection
-    // pointing at an annotation this filter just hid would otherwise leave the
-    // delete button/key acting on something no widget shows.
+    this.dropSelectionIfHidden();
+  }
+
+  /** Reveal every entity's annotations. */
+  showAllEntities(): void {
+    this.session.visibleEntityIds = null;
+  }
+
+  /** Hide every entity's annotations (an empty filter matches no entity). */
+  hideAllEntities(): void {
+    this.session.visibleEntityIds = new Set();
+    this.dropSelectionIfHidden();
+  }
+
+  /**
+   * The "Show all" control: reveal every entity, or — when everything is
+   * already shown — hide every one of them.
+   */
+  toggleAllEntitiesVisible(): void {
+    if (this.session.visibleEntityIds === null) this.hideAllEntities();
+    else this.showAllEntities();
+  }
+
+  /**
+   * Keep the shared selection coherent with what's displayed: a selection
+   * pointing at an annotation a visibility change just hid would otherwise
+   * leave the delete button/key acting on something no widget shows.
+   */
+  private dropSelectionIfHidden(): void {
     const selected = this.session.annotations.selected;
     if (selected && selected.persisted && !this.isEntityVisible(selected.entityId)) {
       this.session.annotations.select(null);
     }
-  }
-
-  /** Reveal every entity's annotations (the "Show all" control). */
-  showAllEntities(): void {
-    this.session.visibleEntityIds = null;
   }
 
   // ─── Pending annotation (entity assignment) ───────────────────────────────

--- a/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
@@ -5,6 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import { AnnotationCollection } from "$lib/annotations/annotationCollection.svelte.js";
+import type { LiveAnnotationDraft } from "$lib/annotations/scene/sceneContext.js";
 import type { EntityRow } from "$lib/api/annotations.js";
 import type { FieldInfo } from "$lib/types/dataset.js";
 
@@ -39,6 +40,13 @@ export class WorkspaceSession {
    * shared state so every widget viewing the record filters identically.
    */
   visibleEntityIds = $state<Set<string> | null>(null);
+  /**
+   * In-progress geometry the active editing gesture broadcasts on every pointer
+   * move, so widgets in other mediums can preview it live (e.g. re-projecting a
+   * 3D box onto images while it is dragged). Committed truth stays in
+   * `annotations`; this slot is null whenever no gesture is running.
+   */
+  liveDraft = $state<LiveAnnotationDraft | null>(null);
 
   /** Reset the selection (e.g. on `clearWorkspace`). */
   reset(): void {
@@ -49,5 +57,6 @@ export class WorkspaceSession {
     this.entitySchemaFields = null;
     this.annotations = new AnnotationCollection();
     this.visibleEntityIds = null;
+    this.liveDraft = null;
   }
 }


### PR DESCRIPTION
## Issue

<!--- No tracking issue; this continues the next-UI annotation tooling work on releases/v1.0-alpha. -->

## Description

Projects a 3D box onto every calibrated image view **while it is being drawn or dragged**, not only after it is saved.

### Why a new seam was needed

A gesture in flight is not in the annotation collection — the store contract covers *committed* annotations (membership, selection, deletion) — so an image widget had nothing to re-project. `docs/ARCHITECTURE_TOOLING.md` previously claimed the 2D projection was "display-only"; that holds for saved edits but not for live ones, and the doc is corrected here.

This adds a `liveDraft` slot on `WorkspaceSession`, exposed through the seam as a read/write `LiveDraftChannel` and to renderers as a read-only `LiveDraftSource` (D4: a renderer still cannot publish).

Two properties are enforced structurally rather than by convention:

- **Ownership.** `buildSeam` stamps the widget id on publish and clears only a draft that widget published, so no tool can wipe a gesture running in another widget — whether or not its author remembered the rule.
- **Capability.** The write side lives on `SeamContext`, not `SceneContextBase`, so publishing is granted deliberately instead of inherited by every tool in every medium. A 2D tool calling `publish` is now a compile error.

### Cost of the pointer-rate path

`AnnotationRenderer2D` grows a required `syncDraft(draft)`. `sync()` is proportional to the collection; `syncDraft` runs on every pointer move and stays proportional to the draft, so dragging one box no longer rewrites every shape on the record. It is required rather than optional so a renamed or mistyped implementation is a compile error rather than a silent opt-out; kinds with no cross-widget preview implement a documented no-op.

### Hardening of the projection it runs on

- Three.js scratch objects are pre-allocated as class fields — the projection no longer allocates ~53 objects per box per sync, per `CODING_STANDARDS`.
- Rotations are typed as a precise `Rotation3x3` tuple, validated once in the seed loader where server rows enter, and the projection guard becomes `!(z > 0)`. The previous `z <= 0` waved NaN through — every comparison with NaN is false — so a malformed rotation reached Konva as NaN line points while rendering fine in 3D.
- Wireframes are `listening: false`: they carry no click handler, so a listening line could only swallow the select tool's click-empty-canvas-to-deselect.
- Removes an unreachable `Konva.Transformer` from the bbox3d renderer (keyed by bbox3d id against a `selectedId` that only ever holds 2D bbox ids).

### Tests

Adds renderer, seam and seed-loader suites, plus coverage for the previously untested `deleteBox()` / `changeEntity()` commit paths. Each new guard was mutation-checked — reverting it turns the suite red.

Frontend suite: 338 passing (28 files). `pnpm run check` holds at its pre-existing 41-error baseline with no errors in changed files.

### Docs

`docs/ARCHITECTURE_TOOLING.md`: corrects the worked example, records that cross-widget *live* feedback is a seam feature rather than a renderer feature, marks DEBT-3 largely resolved for 2D (the Konva mock harness it was blocked on now exists), narrows DEBT-4 (delete shipped in #662; residual is UX only), and adds DEBT-7 for selecting a 3D box from an image view.

### Also included

A second, independent commit adds a show/hide-all toggle to the entities panel. `visibleEntityIds` already meant "null shows everything, a set isolates its members", so an empty set encodes "hide everything" with no new state.

---

Commits are split by concern and each was verified to stand alone, so the branch is bisectable.