### PR TITLE
chore(ui): apply Prettier to the whole workspace

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,3 +1,10 @@
 pnpm-lock.yaml
 **/.svelte-kit/**
 dist
+# Generated output: SvelteKit's adapter-static build and vitest's coverage
+# report. Both are gitignored, so CI's fresh checkout never sees them — but
+# locally, running `pnpm build` or `pnpm test:coverage` before
+# `pnpm format_check` would otherwise report hundreds of generated files as
+# unformatted.
+**/build/**
+**/coverage/**

--- a/ui/apps/pixano/src/routes/+layout.svelte
+++ b/ui/apps/pixano/src/routes/+layout.svelte
@@ -6,6 +6,7 @@ License: CECILL-C
 
 <script lang="ts">
   import { Tooltip } from "bits-ui";
+  import { ArrowsLeftRight } from "phosphor-svelte";
   import { fade } from "svelte/transition";
 
   import pixanoFavicon from "../assets/favicon.ico";
@@ -17,8 +18,6 @@ License: CECILL-C
   import { page } from "$app/state";
   import { pixanoLogo } from "$lib/assets";
   import { datasetsStore, themeMode, toggleTheme } from "$lib/stores/appStores.svelte";
-  import { ArrowsLeftRight } from "phosphor-svelte";
-
   import { getEffectProbeSnapshot, IconButton, ThemeToggle } from "$lib/ui";
 
   import "./styles.css";

--- a/ui/apps/pixano/svelte.config.js
+++ b/ui/apps/pixano/svelte.config.js
@@ -1,5 +1,6 @@
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
 import { pixanoAliases } from "./pixano-aliases.js";
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/ui/apps/web/src/lib/annotations/__tests__/annotationCollection.svelte.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/annotationCollection.svelte.test.ts
@@ -14,7 +14,14 @@ import {
 } from "../annotationCollection.svelte.js";
 
 function makeBBox(id: string, persisted = false): LocalBBox {
-  return { id, entityId: `e-${id}`, kind: "bbox", viewId: "view-1", geometry: [0.1, 0.1, 0.2, 0.2], persisted };
+  return {
+    id,
+    entityId: `e-${id}`,
+    kind: "bbox",
+    viewId: "view-1",
+    geometry: [0.1, 0.1, 0.2, 0.2],
+    persisted,
+  };
 }
 
 function makeBBox3D(id: string): LocalAnnotation {
@@ -77,7 +84,6 @@ describe("AnnotationCollection", () => {
     collection.setGeometry("a", [0.5, 0.5, 0.1, 0.1]);
     expect(collection.find("a")?.geometry).toEqual([0.5, 0.5, 0.1, 0.1]);
   });
-
 });
 
 describe("ViewScopedAnnotations", () => {
@@ -100,7 +106,9 @@ describe("ViewScopedAnnotations", () => {
     const { shared, view1 } = makeShared();
 
     view1.setGeometry("box3d", { coords: [9, 9, 9, 1, 1, 1], format: "xyzwhd" });
-    expect((shared.find("box3d")?.geometry as { coords: number[] }).coords).toEqual([9, 9, 9, 1, 1, 1]);
+    expect((shared.find("box3d")?.geometry as { coords: number[] }).coords).toEqual([
+      9, 9, 9, 1, 1, 1,
+    ]);
 
     view1.add({ ...makeBBox("new"), viewId: "view-1" });
     expect(shared.find("new")).toBeDefined();

--- a/ui/apps/web/src/lib/annotations/__tests__/commit.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/commit.test.ts
@@ -11,11 +11,7 @@ import {
   type BBox3DGeometry,
   type BBoxGeometry,
 } from "../annotationCollection.svelte.js";
-import {
-  commitGeometryEdit,
-  commitNewAnnotation,
-  type CommitContext,
-} from "../payloadBuilders.js";
+import { commitGeometryEdit, commitNewAnnotation, type CommitContext } from "../payloadBuilders.js";
 import type { ResourceMutation } from "../types.js";
 
 const BUILD_CTX = { datasetId: "ds-1", recordId: "rec-1", viewId: "view-1" };

--- a/ui/apps/web/src/lib/annotations/__tests__/payloadBuilders.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/payloadBuilders.test.ts
@@ -86,14 +86,26 @@ describe("buildDeleteMutations", () => {
   it("deletes only the annotation row; the orphan entity is pruned server-side", () => {
     const mutations = buildDeleteMutations(BBOX, "w1");
     expect(mutations).toEqual([
-      expect.objectContaining({ op: "delete", resource: "bboxes", id: "ann-1", localAnnotationId: "ann-1" }),
+      expect.objectContaining({
+        op: "delete",
+        resource: "bboxes",
+        id: "ann-1",
+        localAnnotationId: "ann-1",
+      }),
     ]);
   });
 });
 
 describe("commitDraftWithEntity (shared draft-commit)", () => {
   function makeDraft(): LocalBBox {
-    return { id: "d1", entityId: "", kind: "bbox", viewId: "view", geometry: [0, 0, 1, 1], persisted: false };
+    return {
+      id: "d1",
+      entityId: "",
+      kind: "bbox",
+      viewId: "view",
+      geometry: [0, 0, 1, 1],
+      persisted: false,
+    };
   }
 
   function makeCtx(collection: AnnotationCollection, findEntity = vi.fn()): DraftCommitContext {
@@ -111,7 +123,11 @@ describe("commitDraftWithEntity (shared draft-commit)", () => {
     const collection = new AnnotationCollection([makeDraft()]);
     const ctx = makeCtx(collection);
 
-    commitDraftWithEntity(collection.find("d1")!, { mode: "new", entityFields: { category: "car" } }, ctx);
+    commitDraftWithEntity(
+      collection.find("d1")!,
+      { mode: "new", entityFields: { category: "car" } },
+      ctx,
+    );
 
     const draft = collection.find("d1")!;
     expect(draft.entityId).not.toBe("");
@@ -171,14 +187,20 @@ describe("reassignEntity (change a persisted annotation's entity)", () => {
     expect(ctx.mutations.upsertUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ op: "update", resource: "bbox3ds", id: "box-1" }),
     );
-    expect(vi.mocked(ctx.mutations.upsertUpdate).mock.calls[0][0].body).toMatchObject({ entity_id: "new-ent" });
+    expect(vi.mocked(ctx.mutations.upsertUpdate).mock.calls[0][0].body).toMatchObject({
+      entity_id: "new-ent",
+    });
   });
 
   it("new entity: queues an entity create + the box update with the generated id", () => {
     const collection = new AnnotationCollection([makePersisted()]);
     const ctx = makeCtx(collection);
 
-    reassignEntity(collection.find("box-1")!, { mode: "new", entityFields: { category: "car" } }, ctx);
+    reassignEntity(
+      collection.find("box-1")!,
+      { mode: "new", entityFields: { category: "car" } },
+      ctx,
+    );
 
     const box = collection.find("box-1")!;
     expect(box.entityId).not.toBe("old-ent");

--- a/ui/apps/web/src/lib/annotations/__tests__/pointCloudParser.test.ts
+++ b/ui/apps/web/src/lib/annotations/__tests__/pointCloudParser.test.ts
@@ -58,19 +58,34 @@ describe("parsePointCloud — Lance→Three.js coordinate transform", () => {
 describe("parsePointCloud — elevation colors", () => {
   it("assigns R=0 to the lowest Lance Z point", () => {
     // Point A at Lance Z=0 (minimum elevation): t=0, R=0
-    const { colors } = parsePointCloud(buildBuffer([[0, 0, 0], [0, 0, 10]]));
+    const { colors } = parsePointCloud(
+      buildBuffer([
+        [0, 0, 0],
+        [0, 0, 10],
+      ]),
+    );
     expect(colors[0]).toBeCloseTo(0); // R of point A
   });
 
   it("assigns R=1 to the highest Lance Z point", () => {
     // Point B at Lance Z=10 (maximum elevation): t=1, R=1
-    const { colors } = parsePointCloud(buildBuffer([[0, 0, 0], [0, 0, 10]]));
+    const { colors } = parsePointCloud(
+      buildBuffer([
+        [0, 0, 0],
+        [0, 0, 10],
+      ]),
+    );
     expect(colors[3]).toBeCloseTo(1); // R of point B
   });
 
   it("assigns stable colors when all points share the same elevation", () => {
     // Single elevation: lanceZRange falls back to 1, t=0 for all points
-    const { colors } = parsePointCloud(buildBuffer([[0, 0, 5], [1, 0, 5]]));
+    const { colors } = parsePointCloud(
+      buildBuffer([
+        [0, 0, 5],
+        [1, 0, 5],
+      ]),
+    );
     expect(colors[0]).toBeCloseTo(0); // R: t=0
     expect(colors[1]).toBeCloseTo(0.4); // G: GREEN_MIN + 0 * GREEN_RANGE = 0.4
     expect(colors[2]).toBeCloseTo(1.0); // B: 1 - 0 * BLUE_DECAY = 1
@@ -78,7 +93,13 @@ describe("parsePointCloud — elevation colors", () => {
 
   it("colors are interpolated for a mid-elevation point", () => {
     // Three points: Z=0, Z=5, Z=10 → t=0, 0.5, 1
-    const { colors } = parsePointCloud(buildBuffer([[0, 0, 0], [0, 0, 5], [0, 0, 10]]));
+    const { colors } = parsePointCloud(
+      buildBuffer([
+        [0, 0, 0],
+        [0, 0, 5],
+        [0, 0, 10],
+      ]),
+    );
     expect(colors[3]).toBeCloseTo(0.5); // R of mid point
     expect(colors[4]).toBeCloseTo(0.4 + 0.5 * 0.4); // G
     expect(colors[5]).toBeCloseTo(1 - 0.5 * 0.5); // B
@@ -91,7 +112,12 @@ describe("parsePointCloud — Three.js bounding box", () => {
   it("computes the correct bounds from two opposite points", () => {
     // Lance (-1,-2,-3) → Three.js (-1,-3, 2)
     // Lance ( 1, 2, 3) → Three.js ( 1, 3,-2)
-    const { bounds } = parsePointCloud(buildBuffer([[-1, -2, -3], [1, 2, 3]]));
+    const { bounds } = parsePointCloud(
+      buildBuffer([
+        [-1, -2, -3],
+        [1, 2, 3],
+      ]),
+    );
     expect(bounds.minX).toBeCloseTo(-1);
     expect(bounds.maxX).toBeCloseTo(1);
     expect(bounds.minY).toBeCloseTo(-3);

--- a/ui/apps/web/src/lib/annotations/buildPayloads.ts
+++ b/ui/apps/web/src/lib/annotations/buildPayloads.ts
@@ -4,9 +4,8 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { BBOX3D_RESOURCE, BBOX_RESOURCE, ENTITY_RESOURCE } from "$lib/api/resourceNames.js";
-
 import type { CoordsNorm, ResourceMutation, Rotation3x3 } from "./types.js";
+import { BBOX_RESOURCE, BBOX3D_RESOURCE, ENTITY_RESOURCE } from "$lib/api/resourceNames.js";
 
 const ID_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -142,7 +141,15 @@ export function buildBBoxCreate(
     // entity-create is skipped (the chosen entityId is supplied in opts).
     ...(opts.linkExisting
       ? []
-      : [buildEntityCreateMutation(ctx, entityId, opts.entityFields, opts.widgetId, opts.localAnnotationId)]),
+      : [
+          buildEntityCreateMutation(
+            ctx,
+            entityId,
+            opts.entityFields,
+            opts.widgetId,
+            opts.localAnnotationId,
+          ),
+        ]),
     {
       op: "create",
       resource: BBOX_RESOURCE,
@@ -226,7 +233,15 @@ export function buildBBox3DCreate(
   const mutations: ResourceMutation[] = [
     ...(opts.linkExisting
       ? []
-      : [buildEntityCreateMutation(ctx, entityId, opts.entityFields, opts.widgetId, opts.localAnnotationId)]),
+      : [
+          buildEntityCreateMutation(
+            ctx,
+            entityId,
+            opts.entityFields,
+            opts.widgetId,
+            opts.localAnnotationId,
+          ),
+        ]),
     {
       op: "create",
       resource: BBOX3D_RESOURCE,

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/bboxEditor2D.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/bboxEditor2D.test.ts
@@ -7,6 +7,13 @@ License: CECILL-C
 import type Konva from "konva";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createBBoxEditor2D } from "../bboxEditor2D.js";
+import {
+  AnnotationCollection,
+  type BBoxGeometry,
+} from "$lib/annotations/annotationCollection.svelte.js";
+import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
+
 // The editor only constructs a Konva.Transformer; the layer + nodes are fakes
 // supplied by the harness, so we mock just the Transformer.
 vi.mock("konva", () => {
@@ -19,11 +26,6 @@ vi.mock("konva", () => {
   }
   return { default: { Transformer } };
 });
-
-import { AnnotationCollection, type BBoxGeometry } from "$lib/annotations/annotationCollection.svelte.js";
-import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
-
-import { createBBoxEditor2D } from "../bboxEditor2D.js";
 
 function fakeImage(w = 100, h = 100): Konva.Image {
   return { x: () => 0, y: () => 0, width: () => w, height: () => h } as unknown as Konva.Image;
@@ -102,7 +104,9 @@ describe("bboxEditor2D", () => {
       persisted: true,
     });
 
-    harness.handlers["dragend.bbox-edit"]({ target: fakeRect({ id: "a1", x: 10, y: 20, w: 30, h: 40 }) });
+    harness.handlers["dragend.bbox-edit"]({
+      target: fakeRect({ id: "a1", x: 10, y: 20, w: 30, h: 40 }),
+    });
 
     // pixel (10,20,30,40) over a 100×100 frame → normalized [0.1,0.2,0.3,0.4].
     expect(harness.collection.find("a1")?.geometry).toEqual([0.1, 0.2, 0.3, 0.4]);

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/bboxSeedLoader.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/bboxSeedLoader.test.ts
@@ -6,13 +6,17 @@ License: CECILL-C
 
 import { describe, expect, it } from "vitest";
 
+import { bboxSeedLoader } from "../bboxSeedLoader.js";
 import type { SeedLoadContext, ViewInfo } from "$lib/annotations/seedLoaders.js";
 import type { CoordsNorm } from "$lib/annotations/types.js";
 import type { BBoxRow, EntityRow } from "$lib/api/annotations.js";
 
-import { bboxSeedLoader } from "../bboxSeedLoader.js";
-
-const CAM_FRONT: ViewInfo = { id: "CAM_FRONT_0_0", logicalName: "CAM_FRONT", width: 1600, height: 900 };
+const CAM_FRONT: ViewInfo = {
+  id: "CAM_FRONT_0_0",
+  logicalName: "CAM_FRONT",
+  width: 1600,
+  height: 900,
+};
 
 function makeContext(bboxes: BBoxRow[], entities: EntityRow[] = []): SeedLoadContext {
   const views = new Map<string, ViewInfo>();
@@ -91,7 +95,9 @@ describe("bboxSeedLoader — view resolution", () => {
   });
 
   it("resolves legacy rows whose view_id is the logical name", async () => {
-    const rows = await bboxSeedLoader.load(makeContext([makeRow({ id: "legacy", view_id: "CAM_FRONT" })]));
+    const rows = await bboxSeedLoader.load(
+      makeContext([makeRow({ id: "legacy", view_id: "CAM_FRONT" })]),
+    );
     expect(rows).toHaveLength(1);
     expect(rows[0].viewId).toBe("CAM_FRONT_0_0");
   });

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/drawBBoxTool.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/__tests__/drawBBoxTool.test.ts
@@ -7,6 +7,14 @@ License: CECILL-C
 import type Konva from "konva";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { drawBBoxTool } from "../drawBBoxTool.js";
+import {
+  AnnotationCollection,
+  type BBoxGeometry,
+} from "$lib/annotations/annotationCollection.svelte.js";
+import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
+import type { CoordsNorm } from "$lib/annotations/types.js";
+
 // Konva needs a native canvas in node; the tool only constructs a Rect and
 // reads/writes its geometry. Mock it with a plain accessor object.
 vi.mock("konva", () => {
@@ -47,12 +55,6 @@ vi.mock("konva", () => {
   return { default: { Rect } };
 });
 
-import { AnnotationCollection, type BBoxGeometry } from "$lib/annotations/annotationCollection.svelte.js";
-import type { CoordsNorm } from "$lib/annotations/types.js";
-
-import { drawBBoxTool } from "../drawBBoxTool.js";
-import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
-
 // ─── Harness ─────────────────────────────────────────────────────────────────
 
 // Image frame at the origin sized 100×100 so pixel == percent in assertions.
@@ -88,7 +90,9 @@ function makeHarness(opts: { image?: Konva.Image | null } = {}) {
   return { ctx, collection, setPointer: (p: { x: number; y: number } | null) => (pointer = p) };
 }
 
-type PointerEvt = Parameters<NonNullable<ReturnType<typeof drawBBoxTool.createHandler>["onPointerDown"]>>[0];
+type PointerEvt = Parameters<
+  NonNullable<ReturnType<typeof drawBBoxTool.createHandler>["onPointerDown"]>
+>[0];
 const pointerEvent = () => ({ cancelBubble: false }) as PointerEvt;
 
 /** Drive a full down→move→up gesture between two stage points. */

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxEditor2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxEditor2D.ts
@@ -6,16 +6,15 @@ License: CECILL-C
 
 import Konva from "konva";
 
+import { BBOX_ID_ATTR, BBOX_NODE_NAME } from "./bbox2dNodes.js";
 import { commitGeometryEdit } from "$lib/annotations/payloadBuilders.js";
 import type { AnnotationEditor2D } from "$lib/annotations/scene/renderer.js";
-import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
 import {
   BBOX_COLOR_PERSISTED,
   getPixelFrame,
   pixelToNormalized,
 } from "$lib/annotations/scene/scene2dGeometry.js";
-
-import { BBOX_ID_ATTR, BBOX_NODE_NAME } from "./bbox2dNodes.js";
+import type { Scene2DContext } from "$lib/annotations/scene/sceneContext.js";
 
 const MIN_BBOX_PIXELS = 1;
 

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxPayloadBuilder.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxPayloadBuilder.ts
@@ -4,7 +4,10 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { BBoxGeometry, LocalAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
+import type {
+  BBoxGeometry,
+  LocalAnnotation,
+} from "$lib/annotations/annotationCollection.svelte.js";
 import {
   buildBBoxCreate,
   buildBBoxUpdate,
@@ -41,7 +44,10 @@ export const bboxPayloadBuilder = {
     }).mutations;
   },
 
-  buildUpdate(ctx: BuildContext, annotation: LocalAnnotation<BBoxGeometry>): Record<string, unknown> {
+  buildUpdate(
+    ctx: BuildContext,
+    annotation: LocalAnnotation<BBoxGeometry>,
+  ): Record<string, unknown> {
     return buildBBoxUpdate(ctx, annotation.id, annotation.entityId, annotation.geometry);
   },
 };

--- a/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxRenderer2D.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/2d/bbox/bboxRenderer2D.ts
@@ -6,12 +6,13 @@ License: CECILL-C
 
 import Konva from "konva";
 
+import { BBOX_ID_ATTR, BBOX_NODE_NAME } from "./bbox2dNodes.js";
+import { createBBoxEditor2D } from "./bboxEditor2D.js";
 import type { LocalBBox } from "$lib/annotations/annotationCollection.svelte.js";
 import type {
   AnnotationRenderer2D,
   AnnotationRenderer2DFactory,
 } from "$lib/annotations/scene/renderer.js";
-import type { Scene2DReadContext } from "$lib/annotations/scene/sceneContext.js";
 import {
   BBOX_COLOR_DRAFT,
   BBOX_COLOR_PERSISTED,
@@ -20,10 +21,8 @@ import {
   normalizedToPixel,
   type PixelFrame,
 } from "$lib/annotations/scene/scene2dGeometry.js";
+import type { Scene2DReadContext } from "$lib/annotations/scene/sceneContext.js";
 import { pickEntityLabel } from "$lib/annotations/types.js";
-
-import { BBOX_ID_ATTR, BBOX_NODE_NAME } from "./bbox2dNodes.js";
-import { createBBoxEditor2D } from "./bboxEditor2D.js";
 
 /**
  * Displays the "bbox" kind on the Konva scene: one rect (+ optional entity
@@ -77,10 +76,16 @@ class BBoxRenderer2D implements AnnotationRenderer2D {
     }
 
     for (const [id, rect] of this.rectByBBoxId) {
-      if (!activeIds.has(id)) { rect.destroy(); this.rectByBBoxId.delete(id); }
+      if (!activeIds.has(id)) {
+        rect.destroy();
+        this.rectByBBoxId.delete(id);
+      }
     }
     for (const [id, label] of this.labelByBBoxId) {
-      if (!activeIds.has(id)) { label.destroy(); this.labelByBBoxId.delete(id); }
+      if (!activeIds.has(id)) {
+        label.destroy();
+        this.labelByBBoxId.delete(id);
+      }
     }
 
     this.ctx.annotationLayer.batchDraw();
@@ -127,19 +132,33 @@ class BBoxRenderer2D implements AnnotationRenderer2D {
     });
     rect.setAttr(BBOX_ID_ATTR, bbox.id);
     // Selection is display state, not a queue mutation, so it stays in the renderer.
-    rect.on("click tap", (e) => { e.cancelBubble = true; this.ctx.collection.select(bbox.id); });
+    rect.on("click tap", (e) => {
+      e.cancelBubble = true;
+      this.ctx.collection.select(bbox.id);
+    });
     // Keep the label glued to the box while the editor drags/transforms it.
     rect.on("dragmove transform", () => this._followLabel(bbox.id, rect));
     return rect;
   }
 
-  private _makeLabel(persisted: boolean, entity: Record<string, unknown> | undefined): Konva.Label | null {
+  private _makeLabel(
+    persisted: boolean,
+    entity: Record<string, unknown> | undefined,
+  ): Konva.Label | null {
     const text = pickEntityLabel(entity);
     if (!text) return null;
     const stroke = persisted ? BBOX_COLOR_PERSISTED : BBOX_COLOR_DRAFT;
     const label = new Konva.Label({ listening: false });
     label.add(new Konva.Tag({ fill: stroke, cornerRadius: 3 }));
-    label.add(new Konva.Text({ text, fontSize: 12, fontFamily: "system-ui, sans-serif", fill: "#0f172a", padding: 3 }));
+    label.add(
+      new Konva.Text({
+        text,
+        fontSize: 12,
+        fontFamily: "system-ui, sans-serif",
+        fill: "#0f172a",
+        padding: 3,
+      }),
+    );
     return label;
   }
 }

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DTool.svelte
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/BBox3DTool.svelte
@@ -9,6 +9,9 @@ License: CECILL-C
   import { HTML } from "@threlte/extras";
   import { onDestroy, onMount } from "svelte";
 
+  import type { BBox3DSession } from "./bbox3dSession.svelte.js";
+  import { DRAW_BBOX3D_TOOL_ID, type BBoxRenderData } from "./bbox3dTypes.js";
+  import { BoxEditor } from "./boxEditor.svelte.js";
   import {
     bboxTransform,
     threeBoxToLanceXYZWHD,
@@ -17,10 +20,6 @@ License: CECILL-C
   import type { Scene3DContext } from "$lib/annotations/scene/sceneContext.js";
   import type { ToolHandle3D } from "$lib/annotations/scene/tool.js";
   import { pickEntityLabel } from "$lib/annotations/types";
-
-  import { BoxEditor } from "./boxEditor.svelte.js";
-  import type { BBox3DSession } from "./bbox3dSession.svelte.js";
-  import { DRAW_BBOX3D_TOOL_ID, type BBoxRenderData } from "./bbox3dTypes.js";
 
   interface Props {
     ctx: Scene3DContext;
@@ -140,10 +139,17 @@ License: CECILL-C
   {/each}
 {/if}
 
-{#snippet arrowGizmo(arrow: { id: string; pos: [number, number, number]; quat: [number, number, number, number]; color: string })}
+{#snippet arrowGizmo(arrow: {
+  id: string;
+  pos: [number, number, number];
+  quat: [number, number, number, number];
+  color: string;
+})}
   <T.Group position={arrow.pos} quaternion={arrow.quat}>
     <T.Mesh position={[0, editor.arrowShaftOffsetY, 0]}>
-      <T.CylinderGeometry args={[editor.arrowShaftRadius, editor.arrowShaftRadius, editor.arrowShaftLength, 8]} />
+      <T.CylinderGeometry
+        args={[editor.arrowShaftRadius, editor.arrowShaftRadius, editor.arrowShaftLength, 8]}
+      />
       <T.MeshBasicMaterial color={arrow.color} transparent opacity={0.85} />
     </T.Mesh>
     <T.Mesh position={[0, editor.arrowHeadOffsetY, 0]}>
@@ -175,7 +181,9 @@ License: CECILL-C
       style="transform: translate(-50%, calc(-50% - 60px));"
     >
       {#if editor.drawPhase === "moving"}
-        {editor.moveMode === "axis" ? "Drag to translate · Release to lock" : "Drag to reposition · Release to lock"}
+        {editor.moveMode === "axis"
+          ? "Drag to translate · Release to lock"
+          : "Drag to reposition · Release to lock"}
       {:else if editor.drawPhase === "resizing-face"}
         Drag to resize · Release to lock
       {:else if editor.drawPhase === "rotating"}

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSeedLoader.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSeedLoader.test.ts
@@ -6,11 +6,10 @@ License: CECILL-C
 
 import { describe, expect, it } from "vitest";
 
+import { bbox3dSeedLoader } from "../bbox3dSeedLoader.js";
 import type { BBox3DGeometry } from "$lib/annotations/annotationCollection.svelte.js";
 import type { SeedLoadContext } from "$lib/annotations/seedLoaders.js";
 import type { BBox3DRow, EntityRow } from "$lib/api/annotations.js";
-
-import { bbox3dSeedLoader } from "../bbox3dSeedLoader.js";
 
 function makeContext(rows: BBox3DRow[], entities: EntityRow[] = []): SeedLoadContext {
   return {
@@ -53,7 +52,9 @@ describe("bbox3dSeedLoader", () => {
   });
 
   it("carries the row's view_id through (often empty for scene-level boxes)", async () => {
-    expect((await bbox3dSeedLoader.load(makeContext([makeRow({ view_id: "" })])))[0].viewId).toBe("");
+    expect((await bbox3dSeedLoader.load(makeContext([makeRow({ view_id: "" })])))[0].viewId).toBe(
+      "",
+    );
     expect(
       (await bbox3dSeedLoader.load(makeContext([makeRow({ view_id: "lidar-top" })])))[0].viewId,
     ).toBe("lidar-top");

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSession.test.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/__tests__/bbox3dSession.test.ts
@@ -11,10 +11,7 @@ import {
   AnnotationCollection,
   type BBox3DGeometry,
 } from "$lib/annotations/annotationCollection.svelte.js";
-import type {
-  LiveAnnotationDraft,
-  SeamContext,
-} from "$lib/annotations/scene/sceneContext.js";
+import type { LiveAnnotationDraft, SeamContext } from "$lib/annotations/scene/sceneContext.js";
 import type { PendingAnnotation, ResourceMutation, Rotation3x3 } from "$lib/annotations/types.js";
 
 const COORDS: [number, number, number, number, number, number] = [1, 2, 3, 4, 5, 6];

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dPayloadBuilder.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/bbox3dPayloadBuilder.ts
@@ -4,7 +4,10 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { BBox3DGeometry, LocalAnnotation } from "$lib/annotations/annotationCollection.svelte.js";
+import type {
+  BBox3DGeometry,
+  LocalAnnotation,
+} from "$lib/annotations/annotationCollection.svelte.js";
 import {
   buildBBox3DCreate,
   buildBBox3DUpdate,

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/boxEditor.svelte.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/boxEditor.svelte.ts
@@ -7,9 +7,7 @@ License: CECILL-C
 import * as THREE from "three";
 import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
-import { threeBoxToLanceXYZWHD, threeQuaternionToLanceRotation } from "$lib/annotations/coordinateTransforms";
-import type { Rotation3x3 } from "$lib/annotations/types";
-
+import type { BBoxRenderData, GizmoVisibility } from "./bbox3dTypes.js";
 import {
   ARROW_DEFS,
   ARROW_UP,
@@ -28,7 +26,11 @@ import {
   RING_LOCAL_QUATS,
   TRANSLATE_ARROW_DEFS,
 } from "./boxEditorConstants.js";
-import type { BBoxRenderData, GizmoVisibility } from "./bbox3dTypes.js";
+import {
+  threeBoxToLanceXYZWHD,
+  threeQuaternionToLanceRotation,
+} from "$lib/annotations/coordinateTransforms";
+import type { Rotation3x3 } from "$lib/annotations/types";
 
 type DrawPhase = "idle" | "confirming" | "moving" | "resizing-face" | "rotating";
 
@@ -46,8 +48,8 @@ export class BoxEditor {
 
   activeDragging = $derived(
     this.drawPhase === "moving" ||
-    this.drawPhase === "resizing-face" ||
-    this.drawPhase === "rotating",
+      this.drawPhase === "resizing-face" ||
+      this.drawPhase === "rotating",
   );
 
   // Geometry caches
@@ -58,7 +60,8 @@ export class BoxEditor {
 
   // Gizmo derived sizes
   gizmoRingRadius = $derived(
-    Math.hypot(this.previewSize[0], this.previewSize[1], this.previewSize[2]) / 2 * GIZMO_RING_PADDING,
+    (Math.hypot(this.previewSize[0], this.previewSize[1], this.previewSize[2]) / 2) *
+      GIZMO_RING_PADDING,
   );
   gizmoTubeRadius = $derived(this.gizmoRingRadius * GIZMO_TUBE_FRACTION);
   arrowHeight = $derived(this.gizmoRingRadius * GIZMO_ARROW_HEIGHT_FRACTION);
@@ -66,8 +69,8 @@ export class BoxEditor {
   arrowHeadLength = $derived(this.arrowHeight * GIZMO_ARROW_HEAD_FRACTION);
   arrowShaftLength = $derived(this.arrowHeight * (1 - GIZMO_ARROW_HEAD_FRACTION));
   arrowShaftRadius = $derived(this.arrowRadius * GIZMO_ARROW_SHAFT_RADIUS_FRACTION);
-  arrowShaftOffsetY = $derived(-this.arrowHeight * GIZMO_ARROW_HEAD_FRACTION / 2);
-  arrowHeadOffsetY = $derived(this.arrowHeight * (1 - GIZMO_ARROW_HEAD_FRACTION) / 2);
+  arrowShaftOffsetY = $derived((-this.arrowHeight * GIZMO_ARROW_HEAD_FRACTION) / 2);
+  arrowHeadOffsetY = $derived((this.arrowHeight * (1 - GIZMO_ARROW_HEAD_FRACTION)) / 2);
 
   // Gizmo derived world-space positions / orientations
   private readonly _ringWorldQuat = new THREE.Quaternion();
@@ -84,7 +87,12 @@ export class BoxEditor {
       this._ringWorldQuat.multiplyQuaternions(this.previewQuaternion, RING_LOCAL_QUATS[i]);
       return {
         color: ring.color,
-        quat: [this._ringWorldQuat.x, this._ringWorldQuat.y, this._ringWorldQuat.z, this._ringWorldQuat.w] as [number, number, number, number],
+        quat: [
+          this._ringWorldQuat.x,
+          this._ringWorldQuat.y,
+          this._ringWorldQuat.z,
+          this._ringWorldQuat.w,
+        ] as [number, number, number, number],
       };
     }),
   );
@@ -96,13 +104,20 @@ export class BoxEditor {
       return ARROW_DEFS.map((def) => {
         const halfSize = this.previewSize[def.axis] / 2;
         this._arrowWorldDir.copy(def.localDir).applyQuaternion(this.previewQuaternion).normalize();
-        this._arrowFaceCenter.set(...this.previewCenter).addScaledVector(this._arrowWorldDir, halfSize);
+        this._arrowFaceCenter
+          .set(...this.previewCenter)
+          .addScaledVector(this._arrowWorldDir, halfSize);
         this._arrowPos.copy(this._arrowFaceCenter).addScaledVector(this._arrowWorldDir, hs);
         this._arrowRotQuat.setFromUnitVectors(ARROW_UP, this._arrowWorldDir);
         return {
           id: def.id,
           pos: [this._arrowPos.x, this._arrowPos.y, this._arrowPos.z] as [number, number, number],
-          quat: [this._arrowRotQuat.x, this._arrowRotQuat.y, this._arrowRotQuat.z, this._arrowRotQuat.w] as [number, number, number, number],
+          quat: [
+            this._arrowRotQuat.x,
+            this._arrowRotQuat.y,
+            this._arrowRotQuat.z,
+            this._arrowRotQuat.w,
+          ] as [number, number, number, number],
           color: def.color,
           axis: def.axis,
           sign: def.sign,
@@ -115,13 +130,27 @@ export class BoxEditor {
     (() => {
       const hs = this.arrowHeight / 2;
       return TRANSLATE_ARROW_DEFS.map((def) => {
-        this._translateArrowWorldDir.copy(def.localDir).applyQuaternion(this.previewQuaternion).normalize();
-        this._translateArrowPos.set(...this.previewCenter).addScaledVector(this._translateArrowWorldDir, hs);
+        this._translateArrowWorldDir
+          .copy(def.localDir)
+          .applyQuaternion(this.previewQuaternion)
+          .normalize();
+        this._translateArrowPos
+          .set(...this.previewCenter)
+          .addScaledVector(this._translateArrowWorldDir, hs);
         this._translateArrowRotQuat.setFromUnitVectors(ARROW_UP, this._translateArrowWorldDir);
         return {
           id: def.id,
-          pos: [this._translateArrowPos.x, this._translateArrowPos.y, this._translateArrowPos.z] as [number, number, number],
-          quat: [this._translateArrowRotQuat.x, this._translateArrowRotQuat.y, this._translateArrowRotQuat.z, this._translateArrowRotQuat.w] as [number, number, number, number],
+          pos: [
+            this._translateArrowPos.x,
+            this._translateArrowPos.y,
+            this._translateArrowPos.z,
+          ] as [number, number, number],
+          quat: [
+            this._translateArrowRotQuat.x,
+            this._translateArrowRotQuat.y,
+            this._translateArrowRotQuat.z,
+            this._translateArrowRotQuat.w,
+          ] as [number, number, number, number],
           color: def.color,
           axis: def.axis,
         };
@@ -130,10 +159,14 @@ export class BoxEditor {
   );
 
   rotWorldAngleDeg = $derived(
-    2 * Math.atan2(
-      [this.previewQuaternion.x, this.previewQuaternion.y, this.previewQuaternion.z][this.rotAxis],
-      this.previewQuaternion.w,
-    ) * (180 / Math.PI),
+    2 *
+      Math.atan2(
+        [this.previewQuaternion.x, this.previewQuaternion.y, this.previewQuaternion.z][
+          this.rotAxis
+        ],
+        this.previewQuaternion.w,
+      ) *
+      (180 / Math.PI),
   );
 
   // Pre-allocated raycast meshes
@@ -201,7 +234,10 @@ export class BoxEditor {
       this.previewEdgesGeometry = edges;
       this._raycastBoxGeom = box;
       this._raycastBoxMesh.geometry = box;
-      return () => { edges.dispose(); box.dispose(); };
+      return () => {
+        edges.dispose();
+        box.dispose();
+      };
     });
 
     $effect(() => {
@@ -214,7 +250,12 @@ export class BoxEditor {
     });
 
     $effect(() => {
-      const geom = new THREE.CylinderGeometry(this.arrowRadius, this.arrowRadius, this.arrowHeight, 8);
+      const geom = new THREE.CylinderGeometry(
+        this.arrowRadius,
+        this.arrowRadius,
+        this.arrowHeight,
+        8,
+      );
       this._raycastArrowGeom = geom;
       this._raycastArrowMesh.geometry = geom;
       return () => geom.dispose();
@@ -255,7 +296,8 @@ export class BoxEditor {
       };
 
       const raycastRings = (clientX: number, clientY: number): { axis: 0 | 1 | 2 } | null => {
-        if (!this.previewVisible || !this.getGizmoVisibility().rings || !this._raycastRingGeoms) return null;
+        if (!this.previewVisible || !this.getGizmoVisibility().rings || !this._raycastRingGeoms)
+          return null;
         setupRay(clientX, clientY);
         for (let axis = 0; axis < 3; axis++) {
           const mesh = this._raycastRingMeshes[axis];
@@ -289,9 +331,15 @@ export class BoxEditor {
         return closestBox;
       };
 
-      const computeRingAngle = (clientX: number, clientY: number, axis: 0 | 1 | 2): number | null => {
+      const computeRingAngle = (
+        clientX: number,
+        clientY: number,
+        axis: 0 | 1 | 2,
+      ): number | null => {
         setupRay(clientX, clientY);
-        const normal = this._ringNormal.copy(AXIS_UNIT_VECS[axis]).applyQuaternion(this.rotStartQuaternion);
+        const normal = this._ringNormal
+          .copy(AXIS_UNIT_VECS[axis])
+          .applyQuaternion(this.rotStartQuaternion);
         this._ringCenter.set(...this.previewCenter);
         this._ringPlane.set(normal, -this._ringCenter.dot(normal));
         if (!this._raycastRay.ray.intersectPlane(this._ringPlane, this._ringHit)) return null;
@@ -301,7 +349,12 @@ export class BoxEditor {
       };
 
       const raycastArrows = (clientX: number, clientY: number) => {
-        if (!this.previewVisible || !this.getGizmoVisibility().resizeArrows || !this._raycastArrowGeom) return null;
+        if (
+          !this.previewVisible ||
+          !this.getGizmoVisibility().resizeArrows ||
+          !this._raycastArrowGeom
+        )
+          return null;
         setupRay(clientX, clientY);
         for (const arrow of this.arrowGizmos) {
           this._raycastArrowMesh.position.set(...arrow.pos);
@@ -313,7 +366,12 @@ export class BoxEditor {
       };
 
       const raycastTranslateArrows = (clientX: number, clientY: number) => {
-        if (!this.previewVisible || !this.getGizmoVisibility().translateArrows || !this._raycastArrowGeom) return null;
+        if (
+          !this.previewVisible ||
+          !this.getGizmoVisibility().translateArrows ||
+          !this._raycastArrowGeom
+        )
+          return null;
         setupRay(clientX, clientY);
         for (const arrow of this.translateArrowGizmos) {
           this._raycastArrowMesh.position.set(...arrow.pos);
@@ -333,7 +391,8 @@ export class BoxEditor {
         this._screenRay.setFromCamera(this._screenNdc, this.camera.current);
         this._groundPlane.constant = -this.getFloorY();
         return this._screenRay.ray.intersectPlane(this._groundPlane, this._screenGroundHit)
-          ? this._screenGroundHit : null;
+          ? this._screenGroundHit
+          : null;
       };
 
       const onPointerDown = (e: PointerEvent) => {
@@ -341,9 +400,13 @@ export class BoxEditor {
 
         if (this.drawPhase === "idle") {
           if (!this.getDrawMode()) return;
-          e.stopPropagation(); e.preventDefault();
+          e.stopPropagation();
+          e.preventDefault();
           const existing = raycastExistingBoxes(e.clientX, e.clientY);
-          if (existing) { this._startEditingBox(existing); return; }
+          if (existing) {
+            this._startEditingBox(existing);
+            return;
+          }
           const side = this.getOrbitCenterDist() * DEFAULT_BOX_SIZE_FRACTION;
           this.previewCenter = [...this.getCameraTarget()];
           this.previewSize = [side, side, side];
@@ -352,43 +415,54 @@ export class BoxEditor {
           this.editingBoxId = null;
           this._fireReadyToConfirm();
           this.drawPhase = "confirming";
-
         } else if (this.drawPhase === "confirming") {
           const ringHit = raycastRings(e.clientX, e.clientY);
           if (ringHit) {
-            e.stopPropagation(); e.preventDefault();
+            e.stopPropagation();
+            e.preventDefault();
             this.rotAxis = ringHit.axis;
             this.rotStartQuaternion = this.previewQuaternion.clone();
             this._invRotStartQuat.copy(this.rotStartQuaternion).invert();
-            this._rotAxisWorld.copy(AXIS_UNIT_VECS[this.rotAxis]).applyQuaternion(this.rotStartQuaternion);
+            this._rotAxisWorld
+              .copy(AXIS_UNIT_VECS[this.rotAxis])
+              .applyQuaternion(this.rotStartQuaternion);
             this.rotStartAngle = computeRingAngle(e.clientX, e.clientY, ringHit.axis) ?? 0;
             this.drawPhase = "rotating";
             return;
           }
           const translateHit = raycastTranslateArrows(e.clientX, e.clientY);
           if (translateHit) {
-            e.stopPropagation(); e.preventDefault();
+            e.stopPropagation();
+            e.preventDefault();
             this.translateAxis = translateHit.axis;
             this.moveMode = "axis";
             this.moveStartCenter = [...this.previewCenter];
-            this._resizeWorldDir.set(0, 0, 0).setComponent(this.translateAxis, 1).applyQuaternion(this.previewQuaternion).normalize();
+            this._resizeWorldDir
+              .set(0, 0, 0)
+              .setComponent(this.translateAxis, 1)
+              .applyQuaternion(this.previewQuaternion)
+              .normalize();
             this.drawPhase = "moving";
             return;
           }
           const arrowHit = raycastArrows(e.clientX, e.clientY);
           if (arrowHit) {
-            e.stopPropagation(); e.preventDefault();
+            e.stopPropagation();
+            e.preventDefault();
             this.resizeAxis = arrowHit.axis as 0 | 1 | 2;
             this.resizeStartCenter = [...this.previewCenter];
             this.resizeStartSize = [...this.previewSize];
             this._resizeWorldDir.set(0, 0, 0).setComponent(arrowHit.axis, arrowHit.sign);
             this._resizeWorldDir.applyQuaternion(this.previewQuaternion).normalize();
-            this._resizeStartFaceCenter.fromArray(this.previewCenter).addScaledVector(this._resizeWorldDir, this.previewSize[arrowHit.axis] / 2);
+            this._resizeStartFaceCenter
+              .fromArray(this.previewCenter)
+              .addScaledVector(this._resizeWorldDir, this.previewSize[arrowHit.axis] / 2);
             this.drawPhase = "resizing-face";
             return;
           }
           if (!raycastBox(e.clientX, e.clientY)) return;
-          e.stopPropagation(); e.preventDefault();
+          e.stopPropagation();
+          e.preventDefault();
           this.moveMode = "ground";
           const ground = screenToGround(e.clientX, e.clientY);
           if (!ground) return;
@@ -404,8 +478,10 @@ export class BoxEditor {
           const angle = computeRingAngle(e.clientX, e.clientY, this.rotAxis);
           if (angle === null) return;
           this._rotDeltaQ.setFromAxisAngle(this._rotAxisWorld, angle - this.rotStartAngle);
-          this.previewQuaternion = new THREE.Quaternion().multiplyQuaternions(this._rotDeltaQ, this.rotStartQuaternion);
-
+          this.previewQuaternion = new THREE.Quaternion().multiplyQuaternions(
+            this._rotDeltaQ,
+            this.rotStartQuaternion,
+          );
         } else if (this.drawPhase === "moving") {
           e.stopPropagation();
           if (this.moveMode === "axis") {
@@ -413,13 +489,21 @@ export class BoxEditor {
             this.camera.current.getWorldDirection(this._resizeF);
             this._resizePlaneNormal.copy(this._resizeF).addScaledVector(C, -this._resizeF.dot(C));
             if (this._resizePlaneNormal.lengthSq() < 1e-6) {
-              this._resizePlaneNormal.set(Math.abs(C.y) > 0.99 ? 1 : 0, Math.abs(C.y) > 0.99 ? 0 : 1, 0);
+              this._resizePlaneNormal.set(
+                Math.abs(C.y) > 0.99 ? 1 : 0,
+                Math.abs(C.y) > 0.99 ? 0 : 1,
+                0,
+              );
             }
             this._resizePlaneNormal.normalize();
             this._ringCenter.set(...this.moveStartCenter);
-            this._resizeDragPlane.setFromNormalAndCoplanarPoint(this._resizePlaneNormal, this._ringCenter);
+            this._resizeDragPlane.setFromNormalAndCoplanarPoint(
+              this._resizePlaneNormal,
+              this._ringCenter,
+            );
             setupRay(e.clientX, e.clientY);
-            if (!this._raycastRay.ray.intersectPlane(this._resizeDragPlane, this._resizeHitPt)) return;
+            if (!this._raycastRay.ray.intersectPlane(this._resizeDragPlane, this._resizeHitPt))
+              return;
             const drag = this._resizeHitPt.sub(this._ringCenter).dot(C);
             this.previewCenter = [
               this.moveStartCenter[0] + C.x * drag,
@@ -436,29 +520,38 @@ export class BoxEditor {
               ];
             }
           }
-
         } else if (this.drawPhase === "resizing-face") {
           e.stopPropagation();
           const C = this._resizeWorldDir;
           this.camera.current.getWorldDirection(this._resizeF);
           this._resizePlaneNormal.copy(this._resizeF).addScaledVector(C, -this._resizeF.dot(C));
           if (this._resizePlaneNormal.lengthSq() < 1e-6) {
-            this._resizePlaneNormal.set(Math.abs(C.y) > 0.99 ? 1 : 0, Math.abs(C.y) > 0.99 ? 0 : 1, 0);
+            this._resizePlaneNormal.set(
+              Math.abs(C.y) > 0.99 ? 1 : 0,
+              Math.abs(C.y) > 0.99 ? 0 : 1,
+              0,
+            );
           }
           this._resizePlaneNormal.normalize();
-          this._resizeDragPlane.setFromNormalAndCoplanarPoint(this._resizePlaneNormal, this._resizeStartFaceCenter);
+          this._resizeDragPlane.setFromNormalAndCoplanarPoint(
+            this._resizePlaneNormal,
+            this._resizeStartFaceCenter,
+          );
           setupRay(e.clientX, e.clientY);
-          if (!this._raycastRay.ray.intersectPlane(this._resizeDragPlane, this._resizeHitPt)) return;
+          if (!this._raycastRay.ray.intersectPlane(this._resizeDragPlane, this._resizeHitPt))
+            return;
           const drag = this._resizeHitPt.sub(this._resizeStartFaceCenter).dot(C);
           const newSize = [...this.resizeStartSize] as [number, number, number];
           const newCenter = [...this.resizeStartCenter] as [number, number, number];
-          newSize[this.resizeAxis] = Math.max(MIN_GEOMETRY_SIZE, this.resizeStartSize[this.resizeAxis] + drag);
-          newCenter[0] = this.resizeStartCenter[0] + C.x * drag / 2;
-          newCenter[1] = this.resizeStartCenter[1] + C.y * drag / 2;
-          newCenter[2] = this.resizeStartCenter[2] + C.z * drag / 2;
+          newSize[this.resizeAxis] = Math.max(
+            MIN_GEOMETRY_SIZE,
+            this.resizeStartSize[this.resizeAxis] + drag,
+          );
+          newCenter[0] = this.resizeStartCenter[0] + (C.x * drag) / 2;
+          newCenter[1] = this.resizeStartCenter[1] + (C.y * drag) / 2;
+          newCenter[2] = this.resizeStartCenter[2] + (C.z * drag) / 2;
           this.previewSize = newSize;
           this.previewCenter = newCenter;
-
         } else if (this.drawPhase === "confirming") {
           if (raycastRings(e.clientX, e.clientY)) {
             el.style.cursor = "grab";
@@ -467,9 +560,14 @@ export class BoxEditor {
           } else {
             const ah = raycastArrows(e.clientX, e.clientY);
             if (ah) {
-              el.style.cursor = ah.axis === 1 ? "ns-resize" : ah.axis === 0 ? "ew-resize" : "nesw-resize";
+              el.style.cursor =
+                ah.axis === 1 ? "ns-resize" : ah.axis === 0 ? "ew-resize" : "nesw-resize";
             } else {
-              el.style.cursor = raycastBox(e.clientX, e.clientY) ? "grab" : this.getDrawMode() ? "crosshair" : "default";
+              el.style.cursor = raycastBox(e.clientX, e.clientY)
+                ? "grab"
+                : this.getDrawMode()
+                  ? "crosshair"
+                  : "default";
             }
           }
         } else {
@@ -508,7 +606,10 @@ export class BoxEditor {
       const onKeyDown = (e: KeyboardEvent) => {
         const t = e.target as HTMLElement | null;
         if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
-        if (e.key === "Escape") { e.preventDefault(); this.reset(); }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          this.reset();
+        }
       };
       window.addEventListener("keydown", onKeyDown);
       return () => window.removeEventListener("keydown", onKeyDown);

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/boxEditorConstants.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/boxEditorConstants.ts
@@ -10,11 +10,11 @@ import * as THREE from "three";
 
 export const GIZMO_RING_PADDING = 1.2;
 export const GIZMO_TUBE_FRACTION = 0.0225;
-export const GIZMO_ARROW_HEIGHT_FRACTION = 0.50;
+export const GIZMO_ARROW_HEIGHT_FRACTION = 0.5;
 export const GIZMO_ARROW_RADIUS_FRACTION = 0.09;
 export const GIZMO_ARROW_GAP_FRACTION = 0.04;
 export const GIZMO_ARROW_HEAD_FRACTION = 0.42;
-export const GIZMO_ARROW_SHAFT_RADIUS_FRACTION = 0.30;
+export const GIZMO_ARROW_SHAFT_RADIUS_FRACTION = 0.3;
 export const MIN_GEOMETRY_SIZE = 0.01;
 export const DEFAULT_BOX_SIZE_FRACTION = 0.12;
 
@@ -31,21 +31,59 @@ export const RING_DEFS = [
  * Pre-baked local quaternions from RING_DEFS.
  * Avoids recomputing in each BoxEditor constructor.
  */
-export const RING_LOCAL_QUATS = RING_DEFS.map((r) =>
-  new THREE.Quaternion().setFromEuler(r.euler),
-);
+export const RING_LOCAL_QUATS = RING_DEFS.map((r) => new THREE.Quaternion().setFromEuler(r.euler));
 
 /** Component pair [a, b] used in atan2(d[a], d[b]) for each ring axis. */
-export const RING_ATAN_AXES = [[2, 1], [2, 0], [1, 0]] as const;
+export const RING_ATAN_AXES = [
+  [2, 1],
+  [2, 0],
+  [1, 0],
+] as const;
 
 /** Six resize arrows — one for each ±axis face. */
 export const ARROW_DEFS = [
-  { id: "+x", localDir: new THREE.Vector3( 1,  0,  0), color: "#ef4444", axis: 0 as const, sign:  1 as const },
-  { id: "-x", localDir: new THREE.Vector3(-1,  0,  0), color: "#ef4444", axis: 0 as const, sign: -1 as const },
-  { id: "+y", localDir: new THREE.Vector3( 0,  1,  0), color: "#3b82f6", axis: 1 as const, sign:  1 as const },
-  { id: "-y", localDir: new THREE.Vector3( 0, -1,  0), color: "#3b82f6", axis: 1 as const, sign: -1 as const },
-  { id: "+z", localDir: new THREE.Vector3( 0,  0,  1), color: "#22c55e", axis: 2 as const, sign:  1 as const },
-  { id: "-z", localDir: new THREE.Vector3( 0,  0, -1), color: "#22c55e", axis: 2 as const, sign: -1 as const },
+  {
+    id: "+x",
+    localDir: new THREE.Vector3(1, 0, 0),
+    color: "#ef4444",
+    axis: 0 as const,
+    sign: 1 as const,
+  },
+  {
+    id: "-x",
+    localDir: new THREE.Vector3(-1, 0, 0),
+    color: "#ef4444",
+    axis: 0 as const,
+    sign: -1 as const,
+  },
+  {
+    id: "+y",
+    localDir: new THREE.Vector3(0, 1, 0),
+    color: "#3b82f6",
+    axis: 1 as const,
+    sign: 1 as const,
+  },
+  {
+    id: "-y",
+    localDir: new THREE.Vector3(0, -1, 0),
+    color: "#3b82f6",
+    axis: 1 as const,
+    sign: -1 as const,
+  },
+  {
+    id: "+z",
+    localDir: new THREE.Vector3(0, 0, 1),
+    color: "#22c55e",
+    axis: 2 as const,
+    sign: 1 as const,
+  },
+  {
+    id: "-z",
+    localDir: new THREE.Vector3(0, 0, -1),
+    color: "#22c55e",
+    axis: 2 as const,
+    sign: -1 as const,
+  },
 ] as const;
 
 /** Three translate arrows — one per +axis direction from box center. */

--- a/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/drawBBox3DTool.ts
+++ b/ui/apps/web/src/lib/annotations/kinds/3d/bbox3d/drawBBox3DTool.ts
@@ -6,12 +6,11 @@ License: CECILL-C
 
 import { Box } from "lucide-svelte";
 
-import type { Tool3D } from "$lib/annotations/scene/tool.js";
-
 import BBox3DHud from "./BBox3DHud.svelte";
-import BBox3DTool from "./BBox3DTool.svelte";
 import { BBox3DSession } from "./bbox3dSession.svelte.js";
+import BBox3DTool from "./BBox3DTool.svelte";
 import { DRAW_BBOX3D_TOOL_ID } from "./bbox3dTypes.js";
+import type { Tool3D } from "$lib/annotations/scene/tool.js";
 
 /**
  * The complete bbox3d draw/edit tool, all kind-owned (the host names no kind):

--- a/ui/apps/web/src/lib/annotations/scene/registry2d.ts
+++ b/ui/apps/web/src/lib/annotations/scene/registry2d.ts
@@ -5,8 +5,8 @@ License: CECILL-C
 -------------------------------------*/
 
 import { bboxRenderer2DFactory } from "../kinds/2d/bbox/bboxRenderer2D.js";
-import { bbox3dRenderer2DFactory } from "../kinds/2d/bbox3d/bbox3dRenderer2D.js";
 import { drawBBoxTool } from "../kinds/2d/bbox/drawBBoxTool.js";
+import { bbox3dRenderer2DFactory } from "../kinds/2d/bbox3d/bbox3dRenderer2D.js";
 import type { AnnotationRenderer2DFactory } from "./renderer.js";
 import { selectTool2D } from "./selectTool2D.js";
 import type { Tool2D } from "./tool.js";
@@ -19,7 +19,10 @@ import type { Tool2D } from "./tool.js";
 export const TOOLS_2D: readonly Tool2D[] = [selectTool2D, drawBBoxTool];
 
 /** Every 2D renderer factory; widgets instantiate one renderer per kind. */
-export const RENDERER_FACTORIES_2D: readonly AnnotationRenderer2DFactory[] = [bboxRenderer2DFactory, bbox3dRenderer2DFactory];
+export const RENDERER_FACTORIES_2D: readonly AnnotationRenderer2DFactory[] = [
+  bboxRenderer2DFactory,
+  bbox3dRenderer2DFactory,
+];
 
 export { DEFAULT_TOOL_2D } from "./tool.js";
 

--- a/ui/apps/web/src/lib/annotations/scene/tool.ts
+++ b/ui/apps/web/src/lib/annotations/scene/tool.ts
@@ -4,9 +4,8 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { Component } from "svelte";
-
 import type Konva from "konva";
+import type { Component } from "svelte";
 
 import type { Scene2DContext, Scene3DContext, SeamContext } from "./sceneContext.js";
 import type { ToolDefinition } from "./toolDefinition.js";

--- a/ui/apps/web/src/lib/annotations/seedLoaders.ts
+++ b/ui/apps/web/src/lib/annotations/seedLoaders.ts
@@ -4,11 +4,10 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
-
 import type { AnnotationKind, LocalAnnotation } from "./annotationCollection.svelte.js";
 import { bboxSeedLoader } from "./kinds/2d/bbox/bboxSeedLoader.js";
 import { bbox3dSeedLoader } from "./kinds/3d/bbox3d/bbox3dSeedLoader.js";
+import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
 
 /**
  * The data-layer slice seed loaders may touch (a structural subset of
@@ -62,7 +61,4 @@ export interface AnnotationSeedLoader {
 }
 
 /** Every seed loader; adding a kind means adding its import here. */
-export const SEED_LOADERS: readonly AnnotationSeedLoader[] = [
-  bboxSeedLoader,
-  bbox3dSeedLoader,
-];
+export const SEED_LOADERS: readonly AnnotationSeedLoader[] = [bboxSeedLoader, bbox3dSeedLoader];

--- a/ui/apps/web/src/lib/annotations/types.ts
+++ b/ui/apps/web/src/lib/annotations/types.ts
@@ -17,17 +17,7 @@ export type CoordsNorm = [number, number, number, number];
  * array. Server rows are validated into this shape by the bbox3d seed loader,
  * so everything downstream of that boundary can trust the length.
  */
-export type Rotation3x3 = [
-  number,
-  number,
-  number,
-  number,
-  number,
-  number,
-  number,
-  number,
-  number,
-];
+export type Rotation3x3 = [number, number, number, number, number, number, number, number, number];
 
 /**
  * Pick a human-friendly label from an entity row. Returns the first non-empty

--- a/ui/apps/web/src/lib/api/__tests__/annotations.test.ts
+++ b/ui/apps/web/src/lib/api/__tests__/annotations.test.ts
@@ -6,7 +6,6 @@ License: CECILL-C
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError } from "../apiClient";
 import {
   createAnnotation,
   createEntity,
@@ -17,6 +16,7 @@ import {
   listEntities,
   updateAnnotation,
 } from "../annotations";
+import { ApiError } from "../apiClient";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -61,9 +61,7 @@ describe("listEntities", () => {
   });
 
   it("includes record_id and limit in query string", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      okJson({ items: [], total: 0, limit: 50, offset: 0 }),
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(okJson({ items: [], total: 0, limit: 50, offset: 0 }));
 
     await listEntities(DS, { recordId: "rec-1", limit: 50 });
 
@@ -74,9 +72,7 @@ describe("listEntities", () => {
   });
 
   it("defaults limit to 1000 when not specified", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      okJson({ items: [], total: 0, limit: 1000, offset: 0 }),
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(okJson({ items: [], total: 0, limit: 1000, offset: 0 }));
 
     await listEntities(DS);
 
@@ -105,7 +101,15 @@ describe("listEntities", () => {
 describe("listBBoxes", () => {
   it("returns items from paginated response", async () => {
     const bboxes = [
-      { id: "b1", record_id: "r1", entity_id: "e1", view_id: "v1", coords: [0, 0, 1, 1], format: "xywh", is_normalized: true },
+      {
+        id: "b1",
+        record_id: "r1",
+        entity_id: "e1",
+        view_id: "v1",
+        coords: [0, 0, 1, 1],
+        format: "xywh",
+        is_normalized: true,
+      },
     ];
     vi.mocked(fetch).mockResolvedValueOnce(
       okJson({ items: bboxes, total: 1, limit: 1000, offset: 0 }),
@@ -116,9 +120,7 @@ describe("listBBoxes", () => {
   });
 
   it("maps viewId to view_name query param", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      okJson({ items: [], total: 0, limit: 1000, offset: 0 }),
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(okJson({ items: [], total: 0, limit: 1000, offset: 0 }));
 
     await listBBoxes(DS, { viewId: "cam-front" });
 
@@ -127,9 +129,7 @@ describe("listBBoxes", () => {
   });
 
   it("omits view_name when viewId is absent", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      okJson({ items: [], total: 0, limit: 1000, offset: 0 }),
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(okJson({ items: [], total: 0, limit: 1000, offset: 0 }));
 
     await listBBoxes(DS);
 
@@ -149,8 +149,14 @@ describe("listBBox3Ds", () => {
   it("returns items from paginated response", async () => {
     const bboxes3d = [
       {
-        id: "b3d-1", record_id: "r1", entity_id: "e1", view_id: "v1",
-        coords: [0, 0, 0, 1, 1, 1], format: "xyzwhd", rotation: [1,0,0,0,1,0,0,0,1], is_normalized: false,
+        id: "b3d-1",
+        record_id: "r1",
+        entity_id: "e1",
+        view_id: "v1",
+        coords: [0, 0, 0, 1, 1, 1],
+        format: "xyzwhd",
+        rotation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        is_normalized: false,
       },
     ];
     vi.mocked(fetch).mockResolvedValueOnce(
@@ -162,9 +168,7 @@ describe("listBBox3Ds", () => {
   });
 
   it("maps viewId to view_name param", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      okJson({ items: [], total: 0, limit: 1000, offset: 0 }),
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(okJson({ items: [], total: 0, limit: 1000, offset: 0 }));
 
     await listBBox3Ds(DS, { viewId: "lidar" });
 
@@ -261,8 +265,12 @@ describe("deleteAnnotation", () => {
   });
 
   it("throws on unexpected non-404 error", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 500, statusText: "Internal Server Error" }));
-    await expect(deleteAnnotation(DS, "bboxes", "b1")).rejects.toThrow("deleteAnnotation(bboxes) failed with 500");
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "Internal Server Error" }),
+    );
+    await expect(deleteAnnotation(DS, "bboxes", "b1")).rejects.toThrow(
+      "deleteAnnotation(bboxes) failed with 500",
+    );
   });
 });
 
@@ -285,7 +293,9 @@ describe("deleteEntity", () => {
   });
 
   it("throws on unexpected error", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 403, statusText: "Forbidden" }));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 403, statusText: "Forbidden" }),
+    );
     await expect(deleteEntity(DS, "e1")).rejects.toThrow("deleteEntity failed with 403");
   });
 });

--- a/ui/apps/web/src/lib/api/adapters.ts
+++ b/ui/apps/web/src/lib/api/adapters.ts
@@ -177,7 +177,8 @@ export function toDatasetSchema(dto: DatasetResponse): DatasetSchema {
 
     if (normalizedTableName === "records") groups.item.push(normalizedTableName);
     else if (normalizedTableName === "entities") groups.entities.push(normalizedTableName);
-    else if (ANNOTATION_TABLES.has(normalizedTableName)) groups.annotations.push(normalizedTableName);
+    else if (ANNOTATION_TABLES.has(normalizedTableName))
+      groups.annotations.push(normalizedTableName);
     else if (normalizedTableName === "embeddings") groups.embeddings.push(normalizedTableName);
     else groups.views.push(normalizedTableName);
   }
@@ -250,7 +251,9 @@ export function toDatasetBrowser(
 export function toRawRecord(record: RecordResponse, tableName = "records"): RawSchemaData {
   const { id, created_at = "", updated_at = "", ...data } = record;
   return {
-    id, created_at, updated_at,
+    id,
+    created_at,
+    updated_at,
     table_info: tableInfo(normalizeTableName(tableName), "item", BaseSchema.Item),
     data,
   };
@@ -259,7 +262,9 @@ export function toRawRecord(record: RecordResponse, tableName = "records"): RawS
 export function toRawEntity(entity: EntityResponse, tableName = "entities"): RawSchemaData {
   const { id, created_at = "", updated_at = "", record_id = "", parent_id = "", ...data } = entity;
   return {
-    id, created_at, updated_at,
+    id,
+    created_at,
+    updated_at,
     table_info: tableInfo(normalizeTableName(tableName), "entities", BaseSchema.Entity),
     data: { item_id: record_id, parent_id, ...data },
   };
@@ -279,7 +284,9 @@ export function toRawView(view: ImageResponse | SFrameResponse | TextResponse): 
   const isSequenceFrame = typeof frame_index === "number";
 
   return {
-    id, created_at, updated_at,
+    id,
+    created_at,
+    updated_at,
     table_info: tableInfo(
       isText ? "texts" : isSequenceFrame ? "sequence_frames" : "images",
       "views",
@@ -289,7 +296,14 @@ export function toRawView(view: ImageResponse | SFrameResponse | TextResponse): 
       item_id: record_id,
       parent_id: "",
       view_name: logical_name,
-      url: src, content, uri, width, height, format, frame_index, timestamp,
+      url: src,
+      content,
+      uri,
+      width,
+      height,
+      format,
+      frame_index,
+      timestamp,
     },
   };
 }
@@ -315,7 +329,9 @@ export function toRawAnnotation(
   const inferredViewId = typeof frame_id === "string" && frame_id !== "" ? frame_id : view_id;
 
   const result = {
-    id, created_at, updated_at,
+    id,
+    created_at,
+    updated_at,
     table_info: tableInfo(
       normalizedTableName,
       "annotations",
@@ -341,8 +357,14 @@ export function toRawAnnotation(
   // Reverse-map backend field names for tracklets
   if (normalizedTableName === "tracklets") {
     const d = result.data as Record<string, unknown>;
-    if ("start_timestep" in d) { d.start_frame = d.start_timestep; delete d.start_timestep; }
-    if ("end_timestep" in d) { d.end_frame = d.end_timestep; delete d.end_timestep; }
+    if ("start_timestep" in d) {
+      d.start_frame = d.start_timestep;
+      delete d.start_timestep;
+    }
+    if ("end_timestep" in d) {
+      d.end_frame = d.end_timestep;
+      delete d.end_timestep;
+    }
   }
 
   return result;

--- a/ui/apps/web/src/lib/components/shell/Toolbar.svelte
+++ b/ui/apps/web/src/lib/components/shell/Toolbar.svelte
@@ -7,10 +7,11 @@ License: CECILL-C
 <script lang="ts">
   import { ArrowLeftRight, Lock, Moon, PanelRight, Sun, Unlock } from "lucide-svelte";
 
+  import pixanoLogo from "$lib/assets/pixano.png";
   import type { PanelState } from "$lib/components/ui/resizable-panel/PanelState.svelte.js";
   import { themeStore } from "$lib/stores/theme.svelte.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
-  import pixanoLogo from "$lib/assets/pixano.png";
+
   interface Props {
     manager: WorkspaceManager;
     rightPanel: PanelState;

--- a/ui/apps/web/src/lib/components/widgets/AnnotationToolbar.svelte
+++ b/ui/apps/web/src/lib/components/widgets/AnnotationToolbar.svelte
@@ -55,7 +55,10 @@ License: CECILL-C
       type="button"
       onclick={() => onSelectTool(activeToolId === tool.id ? defaultToolId : tool.id)}
       title={tool.label}
-      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {activeToolId === tool.id ? 'bg-accent text-accent-foreground' : ''}"
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {activeToolId ===
+      tool.id
+        ? 'bg-accent text-accent-foreground'
+        : ''}"
     >
       <tool.icon class="h-3.5 w-3.5" />
     </button>
@@ -72,7 +75,9 @@ License: CECILL-C
     <span class="text-[10px] text-muted-foreground">{pendingCount} unsaved</span>
   {/if}
   {#if saveError}
-    <span class="max-w-[200px] truncate text-[10px] text-destructive" title={saveError}>Save failed</span>
+    <span class="max-w-[200px] truncate text-[10px] text-destructive" title={saveError}>
+      Save failed
+    </span>
   {/if}
   <button
     type="button"

--- a/ui/apps/web/src/lib/components/widgets/point-cloud/PointCloudScene.svelte
+++ b/ui/apps/web/src/lib/components/widgets/point-cloud/PointCloudScene.svelte
@@ -9,16 +9,15 @@ License: CECILL-C
   import { OrbitControls } from "@threlte/extras";
   import { onMount } from "svelte";
   import * as THREE from "three";
-
-  import { parsePointCloud } from "$lib/annotations/pointCloudParser";
-  import { RENDERER_FACTORIES_3D, TOOLS_3D } from "$lib/annotations/scene/registry3d.js";
-  import type { SceneContextBase, Scene3DContext } from "$lib/annotations/scene/sceneContext.js";
-  import type { ToolHandle3D } from "$lib/annotations/scene/tool.js";
   import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
+  import { PointCloudCamera } from "./usePointCloudCamera.svelte.js";
   // RING_DEFS is the orbit-indicator's ring geometry (camera UI), not annotation logic.
   import { RING_DEFS } from "$lib/annotations/kinds/3d/bbox3d/boxEditorConstants.js";
-  import { PointCloudCamera } from "./usePointCloudCamera.svelte.js";
+  import { parsePointCloud } from "$lib/annotations/pointCloudParser";
+  import { RENDERER_FACTORIES_3D, TOOLS_3D } from "$lib/annotations/scene/registry3d.js";
+  import type { Scene3DContext, SceneContextBase } from "$lib/annotations/scene/sceneContext.js";
+  import type { ToolHandle3D } from "$lib/annotations/scene/tool.js";
 
   interface Props {
     pointCloudUrl?: string;
@@ -99,7 +98,10 @@ License: CECILL-C
 
   // ─── Point cloud loading ──────────────────────────────────────────────────
   onMount(() => {
-    if (!pointCloudUrl) { loading = false; return; }
+    if (!pointCloudUrl) {
+      loading = false;
+      return;
+    }
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -126,14 +128,19 @@ License: CECILL-C
       }
     })();
 
-    return () => { clearTimeout(timeoutId); controller.abort(); };
+    return () => {
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
   });
 </script>
 
 <T.PerspectiveCamera
   makeDefault
   position={cam.cameraPosition}
-  oncreate={(ref) => { ref.lookAt(...cam.cameraTarget); }}
+  oncreate={(ref) => {
+    ref.lookAt(...cam.cameraTarget);
+  }}
 >
   <OrbitControls
     enableDamping={cameraMode === "orbit"}
@@ -172,7 +179,7 @@ License: CECILL-C
 {#each TOOLS_3D as tool (tool.id)}
   {#if tool.overlay}
     {@const Overlay = tool.overlay}
-    <Overlay {ctx} {...(toolProps[tool.id] ?? {})} reportHandle={(h) => (toolHandles[tool.id] = h)} />
+    <Overlay {ctx} {...toolProps[tool.id] ?? {}} reportHandle={(h) => (toolHandles[tool.id] = h)} />
   {/if}
 {/each}
 
@@ -188,7 +195,13 @@ License: CECILL-C
       renderOrder={999}
     >
       <T.TorusGeometry args={[1, 0.04, 6, 64]} />
-      <T.MeshBasicMaterial color="#ffffff" transparent opacity={0.5} depthTest={false} depthWrite={false} />
+      <T.MeshBasicMaterial
+        color="#ffffff"
+        transparent
+        opacity={0.5}
+        depthTest={false}
+        depthWrite={false}
+      />
     </T.Mesh>
   {/each}
 {/if}

--- a/ui/apps/web/src/lib/components/widgets/point-cloud/PointCloudWidget.svelte
+++ b/ui/apps/web/src/lib/components/widgets/point-cloud/PointCloudWidget.svelte
@@ -9,16 +9,14 @@ License: CECILL-C
   import { getContext, onMount } from "svelte";
   import type { Component } from "svelte";
 
+  import AnnotationToolbar from "../AnnotationToolbar.svelte";
+  import { buildSeam } from "../sceneSeam.js";
   // Type-only import (erased at runtime, so the dynamic import below still
   // code-splits) — gives the scene's exact prop types to the lazy holder.
   import type PointCloudSceneComponent from "./PointCloudScene.svelte";
-
   import { DEFAULT_TOOL_3D, TOOLS_3D } from "$lib/annotations/scene/registry3d.js";
   import type { PointCloudWidgetStorage } from "$lib/annotations/types.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
-
-  import AnnotationToolbar from "../AnnotationToolbar.svelte";
-  import { buildSeam } from "../sceneSeam.js";
 
   interface Props {
     widgetId: string;
@@ -110,7 +108,10 @@ License: CECILL-C
         type="button"
         onclick={() => (cameraMode = "orbit")}
         title="Orbit mode (Left drag to orbit · Right drag to pan · Scroll to zoom)"
-        class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {cameraMode === 'orbit' ? 'bg-accent text-accent-foreground' : ''}"
+        class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {cameraMode ===
+        'orbit'
+          ? 'bg-accent text-accent-foreground'
+          : ''}"
       >
         <Globe class="h-3.5 w-3.5" />
       </button>
@@ -118,7 +119,10 @@ License: CECILL-C
         type="button"
         onclick={() => (cameraMode = "first-person")}
         title="First person mode (Left drag to pan · Right drag to look around · Scroll to move forward/back)"
-        class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {cameraMode === 'first-person' ? 'bg-accent text-accent-foreground' : ''}"
+        class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground {cameraMode ===
+        'first-person'
+          ? 'bg-accent text-accent-foreground'
+          : ''}"
       >
         <Eye class="h-3.5 w-3.5" />
       </button>

--- a/ui/apps/web/src/lib/components/widgets/point-cloud/usePointCloudCamera.svelte.ts
+++ b/ui/apps/web/src/lib/components/widgets/point-cloud/usePointCloudCamera.svelte.ts
@@ -8,9 +8,12 @@ import * as THREE from "three";
 import type { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
 export interface PointCloudBounds {
-  minX: number; maxX: number;
-  minY: number; maxY: number;
-  minZ: number; maxZ: number;
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  minZ: number;
+  maxZ: number;
 }
 
 export class PointCloudCamera {
@@ -116,9 +119,13 @@ export class PointCloudCamera {
         ref.update();
       };
 
-      const onPointerUp = (e: PointerEvent) => { if (e.button === 2) isRightDragging = false; };
+      const onPointerUp = (e: PointerEvent) => {
+        if (e.button === 2) isRightDragging = false;
+      };
 
-      const onChange = () => { this.cameraTarget = [ref.target.x, ref.target.y, ref.target.z]; };
+      const onChange = () => {
+        this.cameraTarget = [ref.target.x, ref.target.y, ref.target.z];
+      };
       ref.addEventListener("change", onChange);
 
       const onWheel = (e: WheelEvent) => {

--- a/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/ImageExtension.ts
@@ -4,6 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import { WidgetExtension } from "../WidgetExtension.js";
 import { DEFAULT_TOOL_2D } from "$lib/annotations/scene/tool.js";
 import type {
   CameraCalibration,
@@ -13,8 +14,6 @@ import type {
 import type { CalibratedImageResponse } from "$lib/api/restTypes.js";
 import ImageWidget from "$lib/components/widgets/image/ImageWidget.svelte";
 
-import { WidgetExtension } from "../WidgetExtension.js";
-
 /**
  * Bases this extension claims. `CalibratedImage` extends `Image` on the
  * backend and now surfaces calibration data via `options.calibration`.
@@ -22,7 +21,13 @@ import { WidgetExtension } from "../WidgetExtension.js";
 const CLAIMED_BASES = new Set(["Image", "CalibratedImage"]);
 
 function _extractCalibration(image: CalibratedImageResponse | null): CameraCalibration | null {
-  if (!image?.extrinsic_matrix || !image.ego_to_world || !image.f || !image.c || !image.distortion) {
+  if (
+    !image?.extrinsic_matrix ||
+    !image.ego_to_world ||
+    !image.f ||
+    !image.c ||
+    !image.distortion
+  ) {
     return null;
   }
   return {

--- a/ui/apps/web/src/lib/extensions/builtin/PointCloudExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/PointCloudExtension.ts
@@ -4,11 +4,10 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import { WidgetExtension } from "../WidgetExtension.js";
 import { DEFAULT_TOOL_3D } from "$lib/annotations/scene/tool.js";
 import type { PointCloudWidgetStorage } from "$lib/annotations/types.js";
 import PointCloudWidget from "$lib/components/widgets/point-cloud/PointCloudWidget.svelte";
-
-import { WidgetExtension } from "../WidgetExtension.js";
 
 /**
  * Bases this extension claims. `CalibratedPointCloud` extends `PointCloud`

--- a/ui/apps/web/src/lib/extensions/builtin/TextExtension.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/TextExtension.ts
@@ -4,9 +4,8 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import TextWidget from "$lib/components/widgets/TextWidget.svelte";
-
 import { WidgetExtension } from "../WidgetExtension.js";
+import TextWidget from "$lib/components/widgets/TextWidget.svelte";
 
 export const TextExtension = WidgetExtension.create({
   name: "text",

--- a/ui/apps/web/src/lib/extensions/builtin/__tests__/ImageExtension.test.ts
+++ b/ui/apps/web/src/lib/extensions/builtin/__tests__/ImageExtension.test.ts
@@ -6,14 +6,13 @@ License: CECILL-C
 
 import { describe, expect, it, vi } from "vitest";
 
+import { ImageExtension } from "../ImageExtension.js";
 import type { CalibratedImageResponse } from "$lib/api/restTypes.js";
 import type { DatasetGateway } from "$lib/workspace/datasetGateway.js";
 
 // ImageExtension references ImageWidget.svelte which imports Konva (requires native canvas).
 // Mock the component so this unit test stays pure JS.
 vi.mock("$lib/components/widgets/image/ImageWidget.svelte", () => ({ default: {} }));
-
-import { ImageExtension } from "../ImageExtension.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/ui/apps/web/src/lib/workspace/__tests__/mutationQueue.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/mutationQueue.svelte.test.ts
@@ -6,12 +6,11 @@ License: CECILL-C
 
 import { describe, expect, it } from "vitest";
 
-import type { ResourceMutation } from "$lib/annotations/types.js";
-import { ApiError } from "$lib/api/apiClient.js";
-
 import type { MutationGateway } from "../datasetGateway.js";
 import { MutationQueue, type LocalAnnotationLocator } from "../mutationQueue.svelte.js";
 import { WorkspaceSession } from "../workspaceSession.svelte.js";
+import type { ResourceMutation } from "$lib/annotations/types.js";
+import { ApiError } from "$lib/api/apiClient.js";
 
 // ─── Test scaffolding ───────────────────────────────────────────────────────
 
@@ -67,7 +66,10 @@ const noopLocator: LocalAnnotationLocator = {
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("MutationQueue.upsertUpdate", () => {
-  function update(id: string, body: Record<string, unknown>): Extract<ResourceMutation, { op: "update" }> {
+  function update(
+    id: string,
+    body: Record<string, unknown>,
+  ): Extract<ResourceMutation, { op: "update" }> {
     return { op: "update", resource: "bboxes", id, body };
   }
 
@@ -78,7 +80,11 @@ describe("MutationQueue.upsertUpdate", () => {
     queue.upsertUpdate(update("b1", { coords: [0, 0, 1, 1] }));
 
     expect(queue.count).toBe(1);
-    expect(queue.pending[0]).toMatchObject({ op: "update", id: "b1", body: { coords: [0, 0, 1, 1] } });
+    expect(queue.pending[0]).toMatchObject({
+      op: "update",
+      id: "b1",
+      body: { coords: [0, 0, 1, 1] },
+    });
   });
 
   it("replaces the body of the pending update instead of adding a second one", () => {
@@ -117,7 +123,10 @@ describe("MutationQueue.patchPendingCreate", () => {
     queue.patchPendingCreate("b1", "bboxes", { coords: [5, 5, 2, 2] });
 
     expect(queue.count).toBe(1);
-    expect(queue.pending[0]).toMatchObject({ op: "create", body: { id: "b1", coords: [5, 5, 2, 2] } });
+    expect(queue.pending[0]).toMatchObject({
+      op: "create",
+      body: { id: "b1", coords: [5, 5, 2, 2] },
+    });
   });
 
   it("is a no-op when no matching pending create exists", () => {
@@ -213,7 +222,11 @@ describe("MutationQueue.flush", () => {
   });
 
   it("surfaces ApiError detail in saveError", async () => {
-    const apiErr = new ApiError("createAnnotation(bboxes) failed with 422 Unprocessable", 422, '{"detail":"bad"}');
+    const apiErr = new ApiError(
+      "createAnnotation(bboxes) failed with 422 Unprocessable",
+      422,
+      '{"detail":"bad"}',
+    );
     const { gateway } = makeGateway({ failOn: "createAnnotation", error: apiErr });
     const queue = new MutationQueue(gateway, makeSession(), noopLocator);
 
@@ -227,7 +240,11 @@ describe("MutationQueue.flush", () => {
   });
 
   it("drops already-applied mutations so a retry does not re-send them", async () => {
-    const apiErr = new ApiError("createAnnotation(bboxes) failed with 422 Unprocessable", 422, '{"detail":"bad"}');
+    const apiErr = new ApiError(
+      "createAnnotation(bboxes) failed with 422 Unprocessable",
+      422,
+      '{"detail":"bad"}',
+    );
     const { gateway, calls } = makeGateway({ failOn: "createAnnotation", error: apiErr });
     const queue = new MutationQueue(gateway, makeSession(), noopLocator);
 

--- a/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
@@ -4,20 +4,19 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { describe, expect, it, vi } from "vitest";
-
-import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
-import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
-import { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
-import type { WidgetComponentProps, WidgetExtensionConfig } from "$lib/extensions/types.js";
-import { DatasetInfo } from "$lib/types/dataset";
-import type { Dataset } from "$lib/types/dataset";
 import type { Component } from "svelte";
+import { describe, expect, it, vi } from "vitest";
 
 import type { DatasetGateway } from "../datasetGateway.js";
 import { RecordLoader } from "../recordLoader.js";
 import type { WidgetSink } from "../recordLoader.js";
 import { WorkspaceSession } from "../workspaceSession.svelte.js";
+import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
+import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
+import type { WidgetComponentProps, WidgetExtensionConfig } from "$lib/extensions/types.js";
+import { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
+import { DatasetInfo } from "$lib/types/dataset";
+import type { Dataset } from "$lib/types/dataset";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -46,19 +45,20 @@ function makeDataset(views: Record<string, { base: string }>): Dataset {
   };
 }
 
-function makeGateway(opts: {
-  dataset?: Dataset;
-  entities?: EntityRow[];
-  images?: Map<string, CalibratedImageResponse>;
-  pointClouds?: Map<string, PointCloudResponse>;
-  bboxes?: BBoxRow[];
-  bboxes3d?: BBox3DRow[];
-} = {}): DatasetGateway {
+function makeGateway(
+  opts: {
+    dataset?: Dataset;
+    entities?: EntityRow[];
+    images?: Map<string, CalibratedImageResponse>;
+    pointClouds?: Map<string, PointCloudResponse>;
+    bboxes?: BBoxRow[];
+    bboxes3d?: BBox3DRow[];
+  } = {},
+): DatasetGateway {
   return {
     getDataset: () => Promise.resolve(opts.dataset ?? makeDataset({})),
     listEntities: () => Promise.resolve(opts.entities ?? []),
-    loadImageByLogicalName: (_, __, name) =>
-      Promise.resolve(opts.images?.get(name) ?? null),
+    loadImageByLogicalName: (_, __, name) => Promise.resolve(opts.images?.get(name) ?? null),
     listBBoxes: () => Promise.resolve(opts.bboxes ?? []),
     loadPointCloudByLogicalName: (_, __, name) =>
       Promise.resolve(opts.pointClouds?.get(name) ?? null),
@@ -190,7 +190,26 @@ describe("RecordLoader.load", () => {
     const loader = new RecordLoader({
       workspace: sink,
       registry: makeRegistry(makeImageExtension()),
-      gateway: makeGateway({ dataset, images: new Map([["cam", { id: "img-1", record_id: "rec-1", src: "/cam.jpg", width: 100, height: 100, f: null, c: null, distortion: null, extrinsic_matrix: null, ego_to_world: null } as CalibratedImageResponse]]) }),
+      gateway: makeGateway({
+        dataset,
+        images: new Map([
+          [
+            "cam",
+            {
+              id: "img-1",
+              record_id: "rec-1",
+              src: "/cam.jpg",
+              width: 100,
+              height: 100,
+              f: null,
+              c: null,
+              distortion: null,
+              extrinsic_matrix: null,
+              ego_to_world: null,
+            } as CalibratedImageResponse,
+          ],
+        ]),
+      }),
       session,
     });
 
@@ -331,7 +350,9 @@ describe("RecordLoader.load", () => {
     session.entities = [{ id: "stale", record_id: "old-rec" }];
 
     let resolveEntities!: (rows: EntityRow[]) => void;
-    const entitiesPromise = new Promise<EntityRow[]>((res) => { resolveEntities = res; });
+    const entitiesPromise = new Promise<EntityRow[]>((res) => {
+      resolveEntities = res;
+    });
 
     const gateway = makeGateway({ dataset });
     gateway.listEntities = () => entitiesPromise;
@@ -436,7 +457,9 @@ describe("RecordLoader.reloadEntities", () => {
       call++;
       // 1: load rec-A, 2: the reload (held in-flight), 3: load rec-B.
       if (call === 2) return new Promise<EntityRow[]>((res) => (resolveReload = res));
-      return Promise.resolve(call === 1 ? [{ id: "e-A", record_id: "rec-A" }] : [{ id: "e-B", record_id: "rec-B" }]);
+      return Promise.resolve(
+        call === 1 ? [{ id: "e-A", record_id: "rec-A" }] : [{ id: "e-B", record_id: "rec-B" }],
+      );
     };
     const loader = new RecordLoader({
       workspace: makeSink().sink,

--- a/ui/apps/web/src/lib/workspace/datasetGateway.ts
+++ b/ui/apps/web/src/lib/workspace/datasetGateway.ts
@@ -5,11 +5,7 @@ License: CECILL-C
 -------------------------------------*/
 
 import * as api from "$lib/api";
-import type {
-  BBox3DRow,
-  BBoxRow,
-  EntityRow,
-} from "$lib/api/annotations.js";
+import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
 import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
 import type { Dataset } from "$lib/types/dataset";
 
@@ -60,10 +56,7 @@ export interface RecordReadGateway {
 }
 
 export interface MutationGateway {
-  createEntity(
-    datasetId: string,
-    body: Record<string, unknown>,
-  ): Promise<Record<string, unknown>>;
+  createEntity(datasetId: string, body: Record<string, unknown>): Promise<Record<string, unknown>>;
 
   deleteEntity(datasetId: string, id: string): Promise<void>;
 
@@ -104,6 +97,7 @@ export const httpDatasetGateway: DatasetGateway = {
   createEntity: (datasetId, body) => api.createEntity(datasetId, body),
   deleteEntity: (datasetId, id) => api.deleteEntity(datasetId, id),
   createAnnotation: (datasetId, resource, body) => api.createAnnotation(datasetId, resource, body),
-  updateAnnotation: (datasetId, resource, id, body) => api.updateAnnotation(datasetId, resource, id, body),
+  updateAnnotation: (datasetId, resource, id, body) =>
+    api.updateAnnotation(datasetId, resource, id, body),
   deleteAnnotation: (datasetId, resource, id) => api.deleteAnnotation(datasetId, resource, id),
 };

--- a/ui/apps/web/src/lib/workspace/mutationQueue.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/mutationQueue.svelte.ts
@@ -4,13 +4,12 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import type { MutationGateway } from "./datasetGateway.js";
+import type { WorkspaceSession } from "./workspaceSession.svelte.js";
 import { sortMutations } from "$lib/annotations/buildPayloads.js";
 import type { ResourceMutation } from "$lib/annotations/types.js";
 import { ApiError } from "$lib/api/apiClient.js";
 import { ENTITY_RESOURCE } from "$lib/api/resourceNames.js";
-
-import type { MutationGateway } from "./datasetGateway.js";
-import type { WorkspaceSession } from "./workspaceSession.svelte.js";
 
 /**
  * Lookup the queue uses to mark a local annotation as persisted after a
@@ -78,7 +77,8 @@ export class MutationQueue {
     patch: Record<string, unknown>,
   ): void {
     const pending = this.pending.find(
-      (m) => m.op === "create" && m.resource === resource && m.localAnnotationId === localAnnotationId,
+      (m) =>
+        m.op === "create" && m.resource === resource && m.localAnnotationId === localAnnotationId,
     );
     if (pending && pending.op === "create") Object.assign(pending.body, patch);
   }

--- a/ui/apps/web/src/lib/workspace/recordLoader.ts
+++ b/ui/apps/web/src/lib/workspace/recordLoader.ts
@@ -4,16 +4,15 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import type { DatasetGateway, RecordReadGateway } from "./datasetGateway.js";
+import { measureGridViewport, planViewportLayouts, type Viewport } from "./layoutPlanner.js";
+import type { RecordWidgetSeed } from "./recordSeed.js";
+import type { WorkspaceSession } from "./workspaceSession.svelte.js";
 import { AnnotationCollection } from "$lib/annotations/annotationCollection.svelte.js";
 import { SEED_LOADERS, type ViewInfo } from "$lib/annotations/seedLoaders.js";
 import type { EntityRow } from "$lib/api/annotations.js";
 import type { WidgetInstance } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
-
-import type { DatasetGateway, RecordReadGateway } from "./datasetGateway.js";
-import { measureGridViewport, planViewportLayouts, type Viewport } from "./layoutPlanner.js";
-import type { RecordWidgetSeed } from "./recordSeed.js";
-import type { WorkspaceSession } from "./workspaceSession.svelte.js";
 
 /**
  * Minimal write surface the loader needs. Defined as an interface so

--- a/ui/apps/web/src/lib/workspace/recordSeed.ts
+++ b/ui/apps/web/src/lib/workspace/recordSeed.ts
@@ -4,11 +4,10 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import type { DatasetGateway } from "./datasetGateway.js";
 import type { ViewInfo } from "$lib/annotations/seedLoaders.js";
 import type { EntityRow } from "$lib/api/annotations.js";
 import type { SchemaDescriptor } from "$lib/types/dataset";
-
-import type { DatasetGateway } from "./datasetGateway.js";
 
 /**
  * Per-extension contract for "seed a widget from a (record, view) pair".

--- a/ui/apps/web/vitest.config.ts
+++ b/ui/apps/web/vitest.config.ts
@@ -4,8 +4,8 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
-import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { fileURLToPath } from "node:url";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Issue

<!--- No tracking issue. Fixes the permanently-red Format job on releases/v1.0-alpha. -->

## Description

The **Format** job has been failing on `releases/v1.0-alpha`: 47 tracked files do not match Prettier's output — 45 in `apps/web`, 2 in `apps/pixano`.

That matters more than a normal red check, because Format is currently the *only* CI job that looks at `apps/web` at all (Test, Check and Build are scoped to `apps/pixano`, and `turbo lint` skips `apps/web` since it defines no lint script). So the single signal covering that workspace was permanently noise. A check that is always red trains reviewers to ignore it.

### What this does

Runs Prettier over those 47 files. Pure formatting — no behaviour change:

- 506 tests pass across both apps (220 `apps/pixano`, 286 `apps/web`)
- Both production builds succeed
- `svelte-check` unchanged: `apps/pixano` 0 errors, `apps/web` at its existing 41
- `pnpm lint` still passes

### Also: two generated directories ignored

`build/` (adapter-static output) and `coverage/` (vitest) are gitignored, so CI's fresh checkout never sees them. But locally, running `pnpm build` or `pnpm test:coverage` before `pnpm format_check` left hundreds of generated files reported as unformatted — a failure a developer cannot act on, and one that hides real ones.

`.prettierignore` already excluded `.svelte-kit` and `dist`; these belong in the same list. After this, `pnpm format_check` passes both from a clean checkout and after a local build.

### Review note

Best reviewed with whitespace changes hidden (`?w=1`). Every hunk is Prettier's output — nothing was hand-edited.

### Ordering

This overlaps #726 on a handful of files in `apps/web`. Whichever merges second needs a re-run of Prettier on the updated base, which is mechanical and deterministic. Merging #726 first is the smoother order, since this branch can then simply be regenerated.