### PR TITLE
ci: run frontend test and build across every workspace

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -50,6 +50,10 @@ jobs:
         run: |
           cd ui
           pnpm i --frozen-lockfile
+      # `turbo lint` only runs workspaces that define a `lint` script, so this
+      # currently covers apps/pixano alone. Adding one to apps/web would pin the
+      # job red (134 eslint errors, mostly no-unsafe-call / unbound-method in
+      # test files); add it once those are cleared.
       - name: Lint frontend code with eslint
         run: |
           cd ui
@@ -104,6 +108,10 @@ jobs:
           cd ui
           pnpm i --frozen-lockfile
 
+      # Deliberately scoped to apps/pixano, not `pnpm check` (turbo, all
+      # workspaces): apps/web currently reports 41 svelte-check errors, so
+      # widening this would pin the job red. Widen it once those are cleared —
+      # apps/web is already covered by Test and Build above.
       - name: Type-check frontend code with svelte-check
         run: |
           cd ui
@@ -131,10 +139,11 @@ jobs:
           cd ui
           pnpm i --frozen-lockfile
 
+      # Turbo runs every workspace's `test` script, so this covers apps/web too.
       - name: Test frontend code with vitest
         run: |
           cd ui
-          pnpm -C apps/pixano test
+          pnpm test
   build_front:
     name: Build
     runs-on: ubuntu-latest
@@ -158,7 +167,8 @@ jobs:
           cd ui
           pnpm i --frozen-lockfile
 
+      # Turbo runs every workspace's `build` script, so this covers apps/web too.
       - name: Build frontend
         run: |
           cd ui
-          pnpm -C apps/pixano run build
+          pnpm build


### PR DESCRIPTION
## Issue

<!--- No tracking issue. Closes a gap found while reviewing #726. -->

## Description

`apps/web` was effectively unguarded by CI.

The Frontend workflow scopes Test, Check and Build to `apps/pixano`, and `turbo lint` only runs workspaces that define a `lint` script — which `apps/web` does not:

```yaml
check_front:  pnpm -C apps/pixano run check
test_front:   pnpm -C apps/pixano test
build_front:  pnpm -C apps/pixano run build
lint_front:   pnpm lint   # turbo lint — apps/web has no lint script
```

Format was the only job that touched `apps/web`, and it has been failing on pre-existing formatting (see #727). So a regression anywhere in the next-UI workspace could not turn CI red. Three eslint errors reached the branch unnoticed that way.

### What this does

Switches Test and Build to the turbo-level scripts, which run every workspace. This brings `apps/web`'s **286 tests** and its production build under CI, with no other change. Verified at this PR's base: `pnpm test` and `pnpm build` both pass for both apps.

### What it deliberately does not do

Check and Lint stay scoped, with a comment on each recording why and what unblocks it:

| Job | If widened to `apps/web` today |
|---|---|
| Check | 41 svelte-check errors |
| Lint | 134 eslint errors (mostly `no-unsafe-call` / `unbound-method` in test files) |

Widening either would pin the job red rather than protect anything — the same trap #727 is fixing. The comments live at the call site so the gap is visible to the next reader instead of silently absent, and so the numbers can be checked against reality later.

### Suggested follow-up

Clear those two backlogs, then widen Check and Lint the same way. The eslint count is dominated by a handful of test-file rules, so a targeted override plus a few fixes would likely cover most of it.