### PR TITLE
feat(web): remember and replay a dataset's widget arrangement

### DIFF
--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -148,8 +148,44 @@ WorkspaceManager
 Representative API: `selectRecordInDataset`, `flushSave`, `queueMutation`,
 `upsertUpdateMutation`, `deleteAnnotation`, `beginPendingAnnotation` /
 `confirmPendingAnnotation` / `cancelPendingAnnotation`, `isEntityVisible` /
-`toggleEntityVisible` / `showAllEntities`. Getters forward to the session/queue
-(`annotations`, `entities`, `pendingCount`, `saving`, …).
+`toggleEntityVisible` / `showAllEntities`, `saveDatasetLayout` /
+`restoreOpeningLayout` / `fitLayoutToViewport`. Getters forward to the
+session/queue (`annotations`, `entities`, `pendingCount`, `saving`, …).
+
+**Per-dataset layout preference.** Every record of a dataset declares the same
+views, so the arrangement the user builds on one is replayed on the others
+(`workspace/datasetLayout.ts` for the rules, `datasetLayoutRepository.ts` for
+storage). Widgets are keyed by `viewName` — the only identifier that survives a
+record switch. Three invariants hold this together:
+
+- **Only gestures persist.** The grid also writes layouts back when *it* places
+  widgets (mount, clamping, compaction after a hide); persisting those would
+  freeze an automatic placement, computed for one record's widget count, as if
+  the user had chosen it. `GridWorkspace` calls `saveDatasetLayout()` at the
+  points where an arrangement has settled after a user action, and nowhere else.
+- **A position is never stored before the grid has resolved it.** Hiding compacts
+  the neighbours and showing re-places a widget wherever a slot is now free, so
+  the save waits for GridStack to react (behind the deferred mount's microtask
+  for a show). The one deliberate exception is a fully hidden workspace, which is
+  never written at all — see `snapshotDatasetLayout`.
+- **A programmatic arrangement is authoritative.** `restoreOpeningLayout` /
+  `fitLayoutToViewport` decide every position themselves, so the reconciliation
+  effect skips the gap-fill meant for a user hide while applying one; otherwise
+  compaction would overwrite the very positions being restored.
+
+`layoutRevision` is the reverse channel: bumped when the manager rewrites layouts
+itself, it tells `GridWorkspace` to push the new positions — and their lowered
+`minW`/`minH` — into GridStack. It is watched *alone*: depending on the layouts
+themselves would re-run that effect mid-drag and fight the user's gesture.
+
+**The workspace lock covers every control that can move a widget.** `editMode`
+off puts GridStack in static mode, and the inspector disables the layout actions
+*and* the per-widget visibility toggles alongside it. Visibility belongs in that
+set rather than being display-only: hiding a widget compacts its neighbours and
+the grid stores the result, so an ungated toggle would write the very arrangement
+the lock exists to protect.
+
+See `docs/OPEN_QUESTIONS.md` for the limitations accepted in this first version.
 
 ### `WorkspaceSession` (`workspace/workspaceSession.svelte.ts`)
 The record-scoped truth, replaced on every load:
@@ -170,7 +206,11 @@ on the whole manager.
 3. For each declared view, ask each registered **extension** `addRecordSeed(...)`;
    run the per-kind **`SEED_LOADERS`** to fetch that record's annotation rows and
    map them into the shared `AnnotationCollection`.
-4. Create one widget per claimed view (layout via `layoutPlanner`).
+4. Create one widget per claimed view, keyed by `viewName`. Placement comes from
+   `resolveRecordLayouts`: the dataset's remembered arrangement where the user
+   has arranged that view, `layoutPlanner`'s automatic placement otherwise. The
+   resolved state is kept on `session.openingLayout` so "Reset layout" can undo
+   the moves made on this record.
 
 `reloadEntities()` refetches just the entity list after a save (token-guarded) so
 the panel/picker reflect created/pruned entities.
@@ -349,7 +389,10 @@ ui/apps/web/src/lib/
 │  ├─ workspaceSession.svelte.ts           record-scoped shared state
 │  ├─ recordLoader.ts                       (dataset,record) → widgets + data
 │  ├─ mutationQueue.svelte.ts               pending writes + flush
-│  └─ datasetGateway.ts                     I/O seam (interface + http impl)
+│  ├─ datasetGateway.ts                     I/O seam (interface + http impl)
+│  ├─ datasetLayout.ts                      per-dataset layout rules (snapshot/
+│  │                                         resolve/parse) — no storage access
+│  └─ datasetLayoutRepository.ts            layout storage seam (+ localStorage impl)
 ├─ annotations/
 │  ├─ annotationCollection.svelte.ts        LocalAnnotation, AnnotationStore,
 │  │                                         AnnotationCollection, ViewScopedAnnotations
@@ -377,6 +420,7 @@ ui/apps/web/src/lib/
 | Contract | Defined in | Implemented / consumed by |
 |---|---|---|
 | `DatasetGateway` | `workspace/datasetGateway.ts` | `httpDatasetGateway`; consumed by loader + queue |
+| `DatasetLayoutRepository` | `workspace/datasetLayoutRepository.ts` | `localStorageDatasetLayoutRepository`; consumed by loader + manager |
 | `AnnotationStore` | `annotations/annotationCollection.svelte.ts` | `AnnotationCollection`, `ViewScopedAnnotations` |
 | `MutationSink` | `scene/sceneContext.ts` | `MutationQueue`; consumed by tools/widgets |
 | `Scene2DContext` | `scene/sceneContext.ts` | built by `ImageWidget`; consumed by tools/editors (renderers get the read-only `Scene2DReadContext`) |

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -4,6 +4,44 @@
 > when a decision is deferred; remove it (and record the outcome in the relevant
 > doc or code) once resolved.
 
+## Per-dataset layout preference — accepted limitations
+
+**Status:** open (deliberate trade-offs, shipped knowingly).
+
+The workspace remembers how a user arranges a dataset's widgets and replays it on
+the dataset's other records (`ui/apps/web/src/lib/workspace/datasetLayout.ts`,
+`datasetLayoutRepository.ts`; see FRONTEND_ARCHITECTURE.md §4). These limits were
+accepted to keep the first version small — each is a decision, not an oversight.
+
+- **Storage is browser-local.** The arrangement never follows a user across
+  machines or browsers. `DatasetLayoutRepository` exists precisely so this can
+  move to a user-scoped preference endpoint by swapping the implementation
+  injected into `WorkspaceManager`, with no call-site changes.
+- **No way to forget an arrangement.** `clear()` was dropped from the port when
+  "Reset layout" was redefined as "restore what this record opened with", leaving
+  no caller. Consequences: a dataset can never go back to purely automatic
+  placement once arranged, and entries for deleted datasets linger in
+  `localStorage`. Re-adding `clear()` plus a "Forget arrangement" action is the
+  fix if either becomes a real complaint.
+- **Only view-backed widgets are remembered.** A widget dragged in from the
+  palette has no counterpart in the next record's views, so nothing would restore
+  it onto. "Fit layout" does re-tile them on screen; they just are not persisted.
+- **Concurrent tabs: last writer wins.** No `storage` event listener, so two tabs
+  on the same dataset overwrite each other's arrangement.
+- **UI strings are literals.** `ui/apps/web` has no i18n infrastructure at all
+  (no translation module, no `labelKey` usage), so the layout controls follow the
+  app's existing convention and violate CODING_STANDARDS.md's translation-key
+  rule along with every other component. Introducing i18n is its own piece of
+  work, tracked here rather than silently accepted.
+- **The arrangement no longer adapts to the viewport.** Before this feature every
+  record opened with a placement recomputed for the current screen. Once a
+  dataset has been arranged, its records replay cell coordinates captured on
+  whatever screen the user arranged them on, and nothing re-fits automatically —
+  an arrangement built on a large display can extend past the fold on a laptop.
+  "Fit layout" is the manual escape hatch; re-fitting on viewport change (or
+  storing the viewport alongside the arrangement and re-planning when it differs
+  markedly) is the fix if this bites.
+
 ## How should `tri3d` be declared for `uv`?
 
 **Status:** open.

--- a/ui/apps/web/src/lib/components/grid/GridWorkspace.svelte
+++ b/ui/apps/web/src/lib/components/grid/GridWorkspace.svelte
@@ -8,8 +8,9 @@ License: CECILL-C
   import "gridstack/dist/gridstack.min.css";
 
   import { GridStack, type GridStackNode } from "gridstack";
-  import { mount, onDestroy, onMount, unmount } from "svelte";
+  import { mount, onDestroy, onMount, unmount, untrack } from "svelte";
 
+  import { DEFAULT_MIN_CELL, GESTURE_CHANGE_WINDOW_MS } from "./gridConstants.js";
   import { fillGapAndSync, placeWidget } from "./gridReflow.js";
   import WidgetFrame from "./WidgetFrame.svelte";
   import type { WidgetInstance } from "$lib/extensions/types.js";
@@ -28,6 +29,32 @@ License: CECILL-C
   // still pending (see mountWidget).
   let mountedWidgets: Map<string, Record<string, unknown> | null> = new Map();
   let lastManipulationEvent = 0;
+  // The widget ids the manager held at the previous reconciliation (hidden
+  // widgets included — hiding keeps a widget owned), so a mount can be told
+  // apart: a known id coming back is the user re-showing a widget (an
+  // arrangement change worth remembering), an unknown one is a record load or
+  // a palette add.
+  let knownWidgetIds: Set<string> = new Set();
+  // Last programmatic arrangement pushed into the grid. Lets the reconciliation
+  // effect tell "the manager just rearranged everything" from "the user hid one
+  // widget", which need opposite handling of the freed space.
+  let appliedRevision = 0;
+
+  /**
+   * The size constraints to hand GridStack for a widget.
+   *
+   * Capped by the widget's own size so a computed layout below the extension's
+   * declared minimum is honoured rather than silently inflated — which is what
+   * "Fit layout" produces when a record has more views than the viewport can
+   * show comfortably, and what breaks the alignment of a whole tiled grid.
+   */
+  function minCellFor(widget: WidgetInstance) {
+    const config = registry.get(widget.extensionName);
+    return {
+      minW: Math.min(widget.layout.w, config?.defaultLayout.minW ?? DEFAULT_MIN_CELL),
+      minH: Math.min(widget.layout.h, config?.defaultLayout.minH ?? DEFAULT_MIN_CELL),
+    };
+  }
 
   function mountWidget(widget: WidgetInstance) {
     const config = registry.get(widget.extensionName);
@@ -70,8 +97,7 @@ License: CECILL-C
       // Honor the computed layout even when it is below the extension's default
       // minW/minH; otherwise GridStack silently enlarges the widget and breaks
       // the alignment of programmatically computed grids.
-      const minW = Math.min(widget.layout.w, config.defaultLayout.minW ?? 2);
-      const minH = Math.min(widget.layout.h, config.defaultLayout.minH ?? 2);
+      const { minW, minH } = minCellFor(widget);
 
       // Keep the stored spot when free, else drop into the next free spot (used
       // when a re-shown widget's original slot was filled by a prior compaction).
@@ -116,7 +142,7 @@ License: CECILL-C
   }
 
   function onGridItemsChange(_: Event, items: GridStackNode[]) {
-    if (Date.now() - lastManipulationEvent > 10) return;
+    if (Date.now() - lastManipulationEvent > GESTURE_CHANGE_WINDOW_MS) return;
 
     for (const item of items) {
       const element = item.el;
@@ -128,6 +154,11 @@ License: CECILL-C
       const layout = parseLayoutFromElement(element);
       manager.updateLayout(widgetId, layout);
     }
+
+    // The guard above means we only get here for a drag/resize the user just
+    // finished, which is exactly when the arrangement is worth remembering for
+    // the dataset's other records.
+    manager.saveDatasetLayout();
   }
 
   function onGridItemAdded(_: Event, items: GridStackNode[]) {
@@ -187,6 +218,12 @@ License: CECILL-C
     const visibleWidgets = manager.widgets.filter((w) => !w.hidden);
     const visibleIds = new Set(visibleWidgets.map((w) => w.id));
 
+    // A programmatic arrangement ("Reset layout" / "Fit layout") has already
+    // decided where every widget goes, including the ones it hides. The gap-fill
+    // below exists for a *user* hide and would reshuffle those chosen positions,
+    // so it is skipped here; the revision effect applies them instead.
+    const authoritative = manager.layoutRevision !== appliedRevision;
+
     // Remove widgets no longer visible. Distinguish a *hide* (widget still owned
     // by the manager, just toggled off) from a *removal* (record switch / delete):
     // only a hide should reflow the remaining widgets to fill the freed space.
@@ -201,17 +238,60 @@ License: CECILL-C
     // Fill the hole left by a hidden widget without resizing anything, then
     // persist the shifted positions (compact() moves items programmatically, so
     // GridStack's user-drag persistence path never sees them).
-    if (didHide) {
+    if (didHide && !authoritative) {
       fillGapAndSync(grid, manager);
+      // Compaction moved the remaining widgets, so the arrangement the user
+      // now sees differs from the one stored when they clicked "hide".
+      manager.saveDatasetLayout();
     }
 
     // Add newly visible widgets. mountWidget places a re-shown widget in the next
     // free spot when its original position is now taken.
+    let didShow = false;
     for (const widget of visibleWidgets) {
       if (!currentIds.has(widget.id)) {
+        if (knownWidgetIds.has(widget.id)) didShow = true;
         mountWidget(widget);
       }
     }
+
+    // A re-shown widget only has its final position once its deferred mount has
+    // run and GridStack has resolved a free slot for it, so persist behind those
+    // microtasks — ours is queued last and therefore runs after them. Widgets a
+    // record load brought in are unknown ids and never reach this.
+    if (didShow) queueMicrotask(() => manager.saveDatasetLayout());
+
+    knownWidgetIds = new Set(managerIds);
+  });
+
+  // Push layouts the manager rewrote programmatically ("Reset layout" / "Fit
+  // layout") into GridStack. It deliberately depends on the revision counter
+  // alone: reading the widget layouts here would re-run this on every drag and
+  // fight the gesture. Widgets this arrangement re-shows are not on the grid yet
+  // — their deferred mount places them from the same (already updated) layout.
+  //
+  // ORDER MATTERS: this effect must stay declared after the reconciliation
+  // effect above. Effects run in declaration order, so the reconciliation pass
+  // still sees `layoutRevision !== appliedRevision` and skips its gap-fill;
+  // declared the other way round, `appliedRevision` would already be caught up
+  // and a restore that hides a widget would get compacted like a user hide.
+  $effect(() => {
+    const revision = manager.layoutRevision;
+
+    untrack(() => {
+      if (grid) {
+        for (const element of grid.getGridItems()) {
+          const widget = manager.widgets.find((w) => w.id === element.dataset.widgetId);
+          // The constraints go with the size: a node keeps the minH it was
+          // mounted with, which would clamp a smaller fitted cell straight back
+          // up and push the grid past the fold again.
+          if (widget) grid.update(element, { ...widget.layout, ...minCellFor(widget) });
+        }
+      }
+      // Marks this arrangement as applied, so the next reconciliation treats a
+      // hide as the user's again rather than as part of it.
+      appliedRevision = revision;
+    });
   });
 
   onDestroy(() => {

--- a/ui/apps/web/src/lib/components/grid/__tests__/GridWorkspace.svelte.test.ts
+++ b/ui/apps/web/src/lib/components/grid/__tests__/GridWorkspace.svelte.test.ts
@@ -6,13 +6,16 @@ License: CECILL-C
 
 import { cleanup, render } from "@testing-library/svelte";
 import { flushSync, tick } from "svelte";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import GridWorkspace from "../GridWorkspace.svelte";
 import StubReactiveWidget from "./StubReactiveWidget.svelte";
 import type { WidgetExtensionConfig } from "$lib/extensions/types.js";
 import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
+import { DatasetInfo, type Dataset } from "$lib/types/dataset.js";
+import { makeLayoutRepository } from "$lib/workspace/__tests__/fakeDatasetLayoutRepository.js";
 import type { DatasetGateway } from "$lib/workspace/datasetGateway.js";
+import { DATASET_LAYOUT_VERSION, type DatasetLayout } from "$lib/workspace/datasetLayout.js";
 import { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
 // Exercises the GridWorkspace $effect glue (hide → compact, show → free spot)
@@ -31,6 +34,65 @@ const registry = {
   get: () => stubConfig,
   getAll: () => [stubConfig],
 } as unknown as WidgetRegistry;
+
+/**
+ * Minimal record-loading setup so a test can drive the *real*
+ * `restoreOpeningLayout` / `fitLayoutToViewport` instead of imitating what they
+ * do to the manager. One dataset, two image views, one widget each.
+ */
+function makeRecordSetup(storedLayout?: DatasetLayout, viewCount = 2) {
+  const views = Object.fromEntries(
+    Array.from({ length: viewCount }, (_, i) => [`cam_${i + 1}`, { base: "Image" }]),
+  );
+  const info = new DatasetInfo({
+    id: "ds-1",
+    name: "Test Dataset",
+    description: "",
+    num_items: 1,
+    size: "",
+    preview: "",
+    workspace: "image",
+  });
+  info.views = views;
+  const dataset = { info, schema: { schemas: {} } } as unknown as Dataset;
+
+  const gateway = {
+    getDataset: () => Promise.resolve(dataset),
+    listEntities: () => Promise.resolve([]),
+    loadImageByLogicalName: (_d: string, _r: string, name: string) =>
+      Promise.resolve({ id: `img-${name}`, src: "/i.png", width: 100, height: 50 }),
+    listBBoxes: () => Promise.resolve([]),
+    loadPointCloudByLogicalName: () => Promise.resolve(null),
+    listBBox3Ds: () => Promise.resolve([]),
+    createEntity: () => Promise.resolve({}),
+    deleteEntity: () => Promise.resolve(),
+    createAnnotation: () => Promise.resolve({}),
+    updateAnnotation: () => Promise.resolve({}),
+    deleteAnnotation: () => Promise.resolve(),
+  } as unknown as DatasetGateway;
+
+  const seedingConfig = {
+    ...stubConfig,
+    // Mirrors the real image/point-cloud extensions, whose minimum is 3 cells.
+    // A stub with minW/minH of 1 would never exercise GridStack clamping a
+    // fitted cell back up, which is half of what these tests guard.
+    defaultLayout: { x: 0, y: 0, w: 6, h: 6, minW: 3, minH: 3 },
+    addRecordSeed: ({ viewName, viewDef }: { viewName: string; viewDef: { base: string } }) =>
+      viewDef.base === "Image"
+        ? Promise.resolve({ title: viewName, view: { logicalName: viewName } })
+        : Promise.resolve(null),
+  } as unknown as WidgetExtensionConfig;
+
+  const seedingRegistry = {
+    get: () => seedingConfig,
+    getAll: () => [seedingConfig],
+  } as unknown as WidgetRegistry;
+
+  const layouts = makeLayoutRepository(storedLayout ? { "ds-1": storedLayout } : {});
+  const manager = new WorkspaceManager(seedingRegistry, gateway, layouts);
+
+  return { manager, registry: seedingRegistry, layouts };
+}
 
 function mountedIds(container: HTMLElement): string[] {
   return [...container.querySelectorAll<HTMLElement>("[data-widget-id]")]
@@ -161,6 +223,222 @@ describe("GridWorkspace — hide/show reflow", () => {
 
     expect(container.querySelectorAll("[data-widget-id]")).toHaveLength(0);
     expect(container.querySelectorAll("[data-testid='preset-name']")).toHaveLength(0);
+  });
+
+  it("does not remember an arrangement the user never made", async () => {
+    // Mounting writes each widget's resolved position back to the manager
+    // (GridStack may clamp it). Persisting that would freeze an automatic
+    // placement — computed for this record's widget count — as the dataset's
+    // preferred arrangement, so only real gestures may reach the store.
+    const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+    manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } });
+    manager.addWidget("stub", { layout: { x: 0, y: 6, w: 6, h: 6 } });
+    const save = vi.spyOn(manager, "saveDatasetLayout");
+
+    render(GridWorkspace, { props: { manager, registry } });
+    await tick();
+    await Promise.resolve(); // let the deferred widget mounts run
+    await tick();
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("remembers the arrangement only once the hide-driven compaction has landed", async () => {
+    const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+    const top = manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } })!;
+    const bottom = manager.addWidget("stub", { layout: { x: 0, y: 6, w: 6, h: 6 } })!;
+    const layoutOf = (id: string) => manager.widgets.find((w) => w.id === id)!.layout;
+
+    // What the manager would have stored at each save, so we can assert the
+    // arrangement finally remembered is the one on screen — not the pre-compaction
+    // snapshot taken when the visibility toggle itself saved.
+    const persistedTops: Array<number | undefined> = [];
+    const save = vi
+      .spyOn(manager, "saveDatasetLayout")
+      .mockImplementation(() => void persistedTops.push(layoutOf(bottom.id).y));
+
+    render(GridWorkspace, { props: { manager, registry } });
+    await tick();
+
+    manager.toggleWidgetVisibility(top.id);
+    flushSync();
+    await tick();
+
+    expect(save).toHaveBeenCalled();
+    expect(persistedTops.at(-1)).toBe(0);
+  });
+
+  it("remembers a re-shown widget's settled spot, not its pre-hide one", async () => {
+    // Regression: showing a widget used to persist the position it had before
+    // being hidden — a slot compaction may since have given to a neighbour.
+    // GridStack then re-placed it on screen without that landing in storage, so
+    // the remembered arrangement disagreed with what the user saw.
+    const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+    const top = manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } })!;
+    manager.addWidget("stub", { layout: { x: 0, y: 6, w: 6, h: 6 } })!;
+    const layoutOf = (id: string) => manager.widgets.find((w) => w.id === id)!.layout;
+
+    // Snapshot what would have been written at each save, to compare the last
+    // one against where the widget actually ends up.
+    const persisted: Array<{ x: number; y: number }> = [];
+    vi.spyOn(manager, "saveDatasetLayout").mockImplementation(() => {
+      const { x, y } = layoutOf(top.id);
+      persisted.push({ x, y });
+    });
+
+    const { container } = render(GridWorkspace, { props: { manager, registry } });
+    await tick();
+
+    manager.toggleWidgetVisibility(top.id); // hide → the other widget compacts up
+    flushSync();
+    await tick();
+
+    manager.toggleWidgetVisibility(top.id); // show again
+    flushSync();
+    await tick();
+    await Promise.resolve(); // deferred mount places it
+    await Promise.resolve(); // our save microtask, queued behind it
+
+    const element = container.querySelector<HTMLElement>(`[data-widget-id="${top.id}"]`)!;
+    const onScreen = {
+      x: parseInt(element.getAttribute("gs-x") ?? "-1"),
+      y: parseInt(element.getAttribute("gs-y") ?? "-1"),
+    };
+    expect(persisted.at(-1)).toEqual(onScreen);
+  });
+
+  it("pushes programmatically restored layouts back into the grid", async () => {
+    const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+    const widget = manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } })!;
+
+    const { container } = render(GridWorkspace, { props: { manager, registry } });
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    // What "Reset layout" does: rewrite the layout, then bump the revision.
+    manager.updateLayout(widget.id, { x: 6, y: 0, w: 6, h: 6 });
+    manager.layoutRevision++;
+    flushSync();
+    await tick();
+
+    const element = container.querySelector<HTMLElement>(`[data-widget-id="${widget.id}"]`)!;
+    expect(element.getAttribute("gs-x")).toBe("6");
+  });
+
+  it("lets a programmatic arrangement hide a widget without compacting the rest", async () => {
+    // Regression: "Reset layout" sets every position *and* hides a widget in one
+    // go. The reconciliation effect used to treat that hide as the user's, run
+    // the gap-fill, and overwrite the positions the restore had just chosen —
+    // so the restore silently produced a compacted layout instead.
+    const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+    const top = manager.addWidget("stub", { layout: { x: 0, y: 0, w: 6, h: 6 } })!;
+    const bottom = manager.addWidget("stub", { layout: { x: 0, y: 6, w: 6, h: 6 } })!;
+    const layoutOf = (id: string) => manager.widgets.find((w) => w.id === id)!.layout;
+
+    render(GridWorkspace, { props: { manager, registry } });
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    // Exactly what restoreOpeningLayout/fitLayoutToViewport do: rewrite the
+    // layouts, flip visibility, then bump the revision as one arrangement.
+    manager.widgets.find((w) => w.id === top.id)!.hidden = true;
+    manager.updateLayout(bottom.id, { x: 0, y: 6, w: 6, h: 6 });
+    manager.layoutRevision++;
+    flushSync();
+    await tick();
+
+    // Compaction would have pulled it to y=0; the chosen position must survive.
+    expect(layoutOf(bottom.id).y).toBe(6);
+  });
+
+  it("restores the opening arrangement through the real manager call", async () => {
+    // End-to-end over the seam the earlier test only imitated: a genuine
+    // restoreOpeningLayout() must survive the reconciliation effect and land on
+    // screen, hidden view included.
+    // The opening arrangement deliberately leaves a gap *above* the visible
+    // widget: the hidden one sits on top. Compaction would pull the visible one
+    // up into that gap, so y=3 surviving is what proves the restore won.
+    const { manager, registry: seedingRegistry } = makeRecordSetup({
+      version: DATASET_LAYOUT_VERSION,
+      views: {
+        cam_1: { layout: { x: 0, y: 0, w: 12, h: 3 }, hidden: true },
+        cam_2: { layout: { x: 0, y: 3, w: 12, h: 3 }, hidden: false },
+      },
+    });
+
+    const { container } = render(GridWorkspace, {
+      props: { manager, registry: seedingRegistry },
+    });
+    await manager.selectRecordInDataset("ds-1", "rec-1", { width: 1600, height: 900 });
+    flushSync();
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    // The user reveals the hidden view and drags the other one elsewhere.
+    manager.toggleWidgetVisibility(manager.widgets[0].id);
+    flushSync();
+    await tick();
+    await Promise.resolve();
+    await tick();
+    manager.updateLayout(manager.widgets[1].id, { x: 6, y: 0, w: 6, h: 3 });
+
+    manager.restoreOpeningLayout();
+    flushSync();
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    // cam_1 hidden again, cam_2 back at y=3 — the gap above it left untouched.
+    expect(mountedIds(container)).toEqual([manager.widgets[1].id]);
+    const element = container.querySelector<HTMLElement>(
+      `[data-widget-id="${manager.widgets[1].id}"]`,
+    )!;
+    expect(element.getAttribute("gs-x")).toBe("0");
+    expect(element.getAttribute("gs-y")).toBe("3");
+    expect(element.getAttribute("gs-w")).toBe("12");
+  });
+
+  it("fits every widget on screen through the real manager call", async () => {
+    // Seven views — a 6-camera + lidar rig — is the first count the comfort
+    // floor cannot fit, so it is what makes this assertion meaningful.
+    const VIEWPORT = { width: 1600, height: 900 };
+    const VISIBLE_ROWS = 6; // floor(12 * 900 / 1600)
+    const { manager, registry: seedingRegistry } = makeRecordSetup(undefined, 7);
+
+    const { container } = render(GridWorkspace, {
+      props: { manager, registry: seedingRegistry },
+    });
+    await manager.selectRecordInDataset("ds-1", "rec-1", VIEWPORT);
+    flushSync();
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    manager.toggleWidgetVisibility(manager.widgets[0].id);
+    flushSync();
+    await tick();
+
+    manager.fitLayoutToViewport(VIEWPORT);
+    flushSync();
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    expect(manager.widgets.every((w) => w.hidden === false)).toBe(true);
+
+    // Asserted on the DOM, not on the manager: GridStack keeps the minH a node
+    // was mounted with, so a fitted cell that the grid clamped back up would
+    // still look correct in the manager while overflowing on screen.
+    const elements = [...container.querySelectorAll<HTMLElement>("[data-widget-id]")];
+    expect(elements).toHaveLength(7);
+    for (const element of elements) {
+      const y = parseInt(element.getAttribute("gs-y") ?? "0");
+      const h = parseInt(element.getAttribute("gs-h") ?? "0");
+      expect(y + h).toBeLessThanOrEqual(VISIBLE_ROWS);
+    }
   });
 
   it("does not compact when a widget is removed (not hidden)", async () => {

--- a/ui/apps/web/src/lib/components/grid/gridConstants.ts
+++ b/ui/apps/web/src/lib/components/grid/gridConstants.ts
@@ -1,0 +1,26 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+/**
+ * How long after a `dragstop` / `resizestop` a `change` event is still attributed
+ * to that gesture.
+ *
+ * GridStack emits `change` for programmatic moves too (mounting, clamping,
+ * compaction), and those must not be read as user intent — they would otherwise
+ * be persisted as the dataset's preferred arrangement. The observed contract is
+ * that a gesture's `change` arrives immediately after its `*stop` event, while
+ * programmatic ones arrive outside any gesture; this window is the margin that
+ * separates the two, not a measured latency.
+ */
+export const GESTURE_CHANGE_WINDOW_MS = 10;
+
+/**
+ * Fallback minimum cell used when a widget extension declares no `minW`/`minH`.
+ * Only a floor for the *constraint*: the actual minimum handed to GridStack is
+ * capped by the widget's own size so a deliberately small widget is never
+ * inflated (see `minCellFor` in `GridWorkspace.svelte`).
+ */
+export const DEFAULT_MIN_CELL = 2;

--- a/ui/apps/web/src/lib/components/shell/RightPanel.svelte
+++ b/ui/apps/web/src/lib/components/shell/RightPanel.svelte
@@ -5,10 +5,21 @@ License: CECILL-C
 -------------------------------------->
 
 <script lang="ts">
-  import { Eye, EyeOff, Layers, MessageSquare, ScanSearch } from "lucide-svelte";
+  import {
+    Eye,
+    EyeOff,
+    Layers,
+    LayoutGrid,
+    MessageSquare,
+    RotateCcw,
+    ScanSearch,
+  } from "lucide-svelte";
 
   import EntitiesPanel from "./EntitiesPanel.svelte";
   import SaveAnnotationForm from "./SaveAnnotationForm.svelte";
+  // Measured here, next to the grid, so the manager stays environment-agnostic
+  // — the same split `LeftPanel` uses when it opens a record.
+  import { measureGridViewport } from "$lib/workspace/layoutPlanner.js";
   import type { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
 
   interface Props {
@@ -18,6 +29,20 @@ License: CECILL-C
   let { manager }: Props = $props();
 
   let activeTab = $state<"inspector" | "entities" | "agent">("inspector");
+
+  // Locking the workspace means "don't rearrange my widgets while I annotate",
+  // so it covers every control that can move a widget — not just dragging.
+  // Visibility is one of them: hiding a widget compacts its neighbours and the
+  // grid then stores the result as the dataset's arrangement, which is exactly
+  // what the lock exists to prevent.
+  const locked = $derived(!manager.editMode);
+  const LOCKED_HINT = "Unlock the workspace to rearrange the widgets";
+
+  const LAYOUT_ACTION_CLASS =
+    "flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] " +
+    "text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground " +
+    "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent " +
+    "disabled:hover:text-muted-foreground";
 
   // Surface the entity form as soon as a drawn box is awaiting its entity.
   $effect(() => {
@@ -62,11 +87,32 @@ License: CECILL-C
       {/if}
     {:else if activeTab === "inspector"}
       <div class="p-3">
-        <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <h4 class="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Properties
         </h4>
 
         {#if manager.widgetCount > 0}
+          <div class="mb-3 flex flex-wrap items-center gap-1.5">
+            <button
+              onclick={() => manager.restoreOpeningLayout()}
+              disabled={locked || !manager.hasOpeningLayout}
+              title={locked ? LOCKED_HINT : "Put the widgets back where this record opened them"}
+              class={LAYOUT_ACTION_CLASS}
+            >
+              <RotateCcw class="h-3 w-3" />
+              Reset layout
+            </button>
+            <button
+              onclick={() => manager.fitLayoutToViewport(measureGridViewport())}
+              disabled={locked}
+              title={locked ? LOCKED_HINT : "Show every widget and tile them to fit the screen"}
+              class={LAYOUT_ACTION_CLASS}
+            >
+              <LayoutGrid class="h-3 w-3" />
+              Fit layout
+            </button>
+          </div>
+
           <div class="space-y-2">
             {#each manager.widgets as widget (widget.id)}
               <div
@@ -77,8 +123,10 @@ License: CECILL-C
                 <div class="flex items-center gap-2">
                   <button
                     onclick={() => manager.toggleWidgetVisibility(widget.id)}
-                    title={widget.hidden ? "Show widget" : "Hide widget"}
-                    class="shrink-0 text-muted-foreground hover:text-foreground"
+                    disabled={locked}
+                    title={locked ? LOCKED_HINT : widget.hidden ? "Show widget" : "Hide widget"}
+                    class="shrink-0 text-muted-foreground transition-colors hover:text-foreground
+                      disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-muted-foreground"
                   >
                     {#if widget.hidden}
                       <EyeOff class="h-3.5 w-3.5" />

--- a/ui/apps/web/src/lib/components/shell/__tests__/RightPanel.svelte.test.ts
+++ b/ui/apps/web/src/lib/components/shell/__tests__/RightPanel.svelte.test.ts
@@ -1,0 +1,115 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import RightPanel from "../RightPanel.svelte";
+import type { WidgetExtensionConfig } from "$lib/extensions/types.js";
+import type { WidgetRegistry } from "$lib/extensions/WidgetRegistry.js";
+import type { DatasetGateway } from "$lib/workspace/datasetGateway.js";
+import { WorkspaceManager } from "$lib/workspace/workspaceManager.svelte.js";
+
+// The inspector tab owns every control that can move a widget: the two layout
+// actions and the per-widget visibility toggles. They must agree on the
+// workspace lock — a hide compacts the neighbours and the grid stores the
+// result, so an ungated eye toggle would write the very arrangement the lock
+// exists to protect.
+
+const stubConfig = {
+  name: "stub",
+  label: "Stub",
+  icon: "square",
+  defaultLayout: { x: 0, y: 0, w: 6, h: 6, minW: 1, minH: 1 },
+  component: undefined,
+} as unknown as WidgetExtensionConfig;
+
+const registry = {
+  get: () => stubConfig,
+  getAll: () => [stubConfig],
+} as unknown as WidgetRegistry;
+
+function makeManagerWithWidgets() {
+  const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+  manager.addWidget("stub", { title: "Front camera" });
+  manager.addWidget("stub", { title: "Lidar" });
+  return manager;
+}
+
+// jest-dom's `toBeDisabled` is not typed in this workspace (the same gap the
+// LeftPanel suite hits with `toBeInTheDocument`), so assert on the DOM property.
+const isDisabled = (element: HTMLElement) => (element as HTMLButtonElement).disabled;
+
+/** The layout actions plus every per-widget visibility toggle. */
+function widgetControls(): HTMLElement[] {
+  return [
+    screen.getByRole("button", { name: /reset layout/i }),
+    screen.getByRole("button", { name: /fit layout/i }),
+    ...screen.getAllByTitle(/show widget|hide widget|unlock the workspace/i),
+  ];
+}
+
+afterEach(() => cleanup());
+
+describe("RightPanel — workspace lock", () => {
+  it("disables every control that can move a widget while locked", () => {
+    const manager = makeManagerWithWidgets();
+    manager.editMode = false;
+
+    render(RightPanel, { props: { manager } });
+    flushSync();
+
+    for (const control of widgetControls()) {
+      expect(isDisabled(control)).toBe(true);
+    }
+  });
+
+  it("explains why the controls are inert", () => {
+    const manager = makeManagerWithWidgets();
+    manager.editMode = false;
+
+    render(RightPanel, { props: { manager } });
+    flushSync();
+
+    expect(screen.getAllByTitle(/unlock the workspace/i).length).toBeGreaterThan(0);
+  });
+
+  it("re-enables the visibility toggles once unlocked", () => {
+    const manager = makeManagerWithWidgets();
+    manager.editMode = true;
+
+    render(RightPanel, { props: { manager } });
+    flushSync();
+
+    for (const toggle of screen.getAllByTitle(/hide widget/i)) {
+      expect(isDisabled(toggle)).toBe(false);
+    }
+    expect(isDisabled(screen.getByRole("button", { name: /fit layout/i }))).toBe(false);
+  });
+
+  it("keeps Reset disabled until a record has been opened", () => {
+    // Widgets exist (added from the palette) but no record has loaded, so there
+    // is no opening arrangement to go back to.
+    const manager = makeManagerWithWidgets();
+
+    render(RightPanel, { props: { manager } });
+    flushSync();
+
+    expect(manager.hasOpeningLayout).toBe(false);
+    expect(isDisabled(screen.getByRole("button", { name: /reset layout/i }))).toBe(true);
+  });
+
+  it("offers no layout controls on an empty workspace", () => {
+    const manager = new WorkspaceManager(registry, {} as DatasetGateway);
+
+    render(RightPanel, { props: { manager } });
+    flushSync();
+
+    expect(screen.queryByRole("button", { name: /reset layout/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /fit layout/i })).toBeNull();
+  });
+});

--- a/ui/apps/web/src/lib/extensions/types.ts
+++ b/ui/apps/web/src/lib/extensions/types.ts
@@ -104,6 +104,13 @@ export interface WidgetInstance {
   options: Record<string, unknown>;
   data?: Record<string, unknown>;
   hidden?: boolean;
+  /**
+   * Dataset view this widget renders, set by `RecordLoader` for record-seeded
+   * widgets and absent for ones added from the palette. It is the widget's only
+   * identifier that survives a record switch, so it keys the per-dataset layout
+   * preference (see `workspace/datasetLayout.ts`).
+   */
+  viewName?: string;
 }
 
 /** A workspace preset (named layout configuration) */

--- a/ui/apps/web/src/lib/workspace/__tests__/datasetLayout.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/datasetLayout.test.ts
@@ -1,0 +1,262 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DATASET_LAYOUT_VERSION,
+  parseDatasetLayout,
+  resolveRecordLayouts,
+  snapshotDatasetLayout,
+  toDatasetLayout,
+  type DatasetLayout,
+} from "../datasetLayout.js";
+import { planViewportLayouts } from "../layoutPlanner.js";
+import type { WidgetInstance } from "$lib/extensions/types.js";
+
+const VIEWPORT = { width: 1600, height: 900 };
+
+function makeWidget(overrides: Partial<WidgetInstance>): WidgetInstance {
+  return {
+    id: "w-1",
+    extensionName: "image",
+    title: "Widget",
+    layout: { x: 0, y: 0, w: 6, h: 4 },
+    options: {},
+    ...overrides,
+  };
+}
+
+function makeStoredLayout(views: DatasetLayout["views"]): DatasetLayout {
+  return { version: DATASET_LAYOUT_VERSION, views };
+}
+
+// ─── snapshotDatasetLayout ───────────────────────────────────────────────────
+
+describe("snapshotDatasetLayout", () => {
+  it("captures view-backed widgets keyed by their view name", () => {
+    const snapshot = snapshotDatasetLayout([
+      makeWidget({ id: "w-1", viewName: "cam", layout: { x: 0, y: 0, w: 6, h: 4 } }),
+      makeWidget({ id: "w-2", viewName: "lidar", layout: { x: 6, y: 0, w: 6, h: 4 } }),
+    ]);
+
+    expect(snapshot).toEqual({
+      version: DATASET_LAYOUT_VERSION,
+      views: {
+        cam: { layout: { x: 0, y: 0, w: 6, h: 4 }, hidden: false },
+        lidar: { layout: { x: 6, y: 0, w: 6, h: 4 }, hidden: false },
+      },
+    });
+  });
+
+  it("records the hidden flag so a hidden view stays hidden on the next record", () => {
+    const snapshot = snapshotDatasetLayout([
+      makeWidget({ id: "w-1", viewName: "cam", hidden: true }),
+      makeWidget({ id: "w-2", viewName: "lidar" }),
+    ]);
+
+    expect(snapshot?.views.cam.hidden).toBe(true);
+    expect(snapshot?.views.lidar.hidden).toBe(false);
+  });
+
+  it("refuses to remember a fully hidden workspace, which would open blank", () => {
+    const snapshot = snapshotDatasetLayout([
+      makeWidget({ id: "w-1", viewName: "cam", hidden: true }),
+      makeWidget({ id: "w-2", viewName: "lidar", hidden: true }),
+    ]);
+
+    expect(snapshot).toBeNull();
+  });
+
+  it("copies the layout so later widget moves do not mutate the snapshot", () => {
+    const widget = makeWidget({ viewName: "cam" });
+    const snapshot = snapshotDatasetLayout([widget]);
+
+    widget.layout.x = 9;
+
+    expect(snapshot?.views.cam.layout.x).toBe(0);
+  });
+
+  it("skips palette widgets, which no other record has a counterpart for", () => {
+    const snapshot = snapshotDatasetLayout([
+      makeWidget({ id: "w-1", viewName: "cam" }),
+      makeWidget({ id: "w-2", extensionName: "text" }),
+    ]);
+
+    expect(Object.keys(snapshot?.views ?? {})).toEqual(["cam"]);
+  });
+
+  it("returns null when nothing is capturable, so callers do not erase what is stored", () => {
+    expect(snapshotDatasetLayout([])).toBeNull();
+    expect(snapshotDatasetLayout([makeWidget({ extensionName: "text" })])).toBeNull();
+  });
+});
+
+// ─── resolveRecordLayouts ────────────────────────────────────────────────────
+
+describe("resolveRecordLayouts", () => {
+  it("replays the stored arrangement for views the user arranged", () => {
+    const saved = makeStoredLayout({
+      cam: { layout: { x: 3, y: 6, w: 9, h: 5 }, hidden: false },
+      lidar: { layout: { x: 0, y: 0, w: 3, h: 5 }, hidden: true },
+    });
+
+    expect(resolveRecordLayouts(["cam", "lidar"], VIEWPORT, saved)).toEqual([
+      { layout: { x: 3, y: 6, w: 9, h: 5 }, hidden: false },
+      { layout: { x: 0, y: 0, w: 3, h: 5 }, hidden: true },
+    ]);
+  });
+
+  it("falls back to automatic placement when nothing is stored", () => {
+    const planned = planViewportLayouts(3, VIEWPORT);
+
+    expect(resolveRecordLayouts(["a", "b", "c"], VIEWPORT, null)).toEqual(
+      planned.map((layout) => ({ layout, hidden: false })),
+    );
+  });
+
+  it("mixes stored and automatic placement when a record has an unarranged view", () => {
+    const saved = makeStoredLayout({ cam: { layout: { x: 3, y: 6, w: 9, h: 5 }, hidden: false } });
+    const planned = planViewportLayouts(2, VIEWPORT);
+
+    expect(resolveRecordLayouts(["cam", "lidar"], VIEWPORT, saved)).toEqual([
+      { layout: { x: 3, y: 6, w: 9, h: 5 }, hidden: false },
+      { layout: planned[1], hidden: false },
+    ]);
+  });
+
+  it("ignores stored views the record does not have", () => {
+    const saved = makeStoredLayout({
+      cam: { layout: { x: 3, y: 6, w: 9, h: 5 }, hidden: false },
+      gone: { layout: { x: 0, y: 0, w: 1, h: 1 }, hidden: false },
+    });
+
+    expect(resolveRecordLayouts(["cam"], VIEWPORT, saved)).toHaveLength(1);
+  });
+
+  it("copies stored layouts so moving a widget does not rewrite the preference", () => {
+    const saved = makeStoredLayout({ cam: { layout: { x: 3, y: 6, w: 9, h: 5 }, hidden: false } });
+
+    const [resolved] = resolveRecordLayouts(["cam"], VIEWPORT, saved);
+    resolved.layout.x = 0;
+
+    expect(saved.views.cam.layout.x).toBe(3);
+  });
+
+  it("returns nothing for a record with no renderable view", () => {
+    expect(resolveRecordLayouts([], VIEWPORT, null)).toEqual([]);
+  });
+});
+
+// ─── toDatasetLayout ─────────────────────────────────────────────────────────
+
+describe("toDatasetLayout", () => {
+  it("expresses a record's resolved placement as a replayable arrangement", () => {
+    const layout = toDatasetLayout(
+      ["cam", "lidar"],
+      [
+        { layout: { x: 0, y: 0, w: 6, h: 4 }, hidden: false },
+        { layout: { x: 6, y: 0, w: 6, h: 4 }, hidden: true },
+      ],
+    );
+
+    expect(layout).toEqual({
+      version: DATASET_LAYOUT_VERSION,
+      views: {
+        cam: { layout: { x: 0, y: 0, w: 6, h: 4 }, hidden: false },
+        lidar: { layout: { x: 6, y: 0, w: 6, h: 4 }, hidden: true },
+      },
+    });
+  });
+
+  it("copies layouts so later moves cannot rewrite the opening arrangement", () => {
+    const resolved = [{ layout: { x: 0, y: 0, w: 6, h: 4 }, hidden: false }];
+    const layout = toDatasetLayout(["cam"], resolved);
+
+    resolved[0].layout.x = 9;
+
+    expect(layout.views.cam.layout.x).toBe(0);
+  });
+
+  it("round-trips through resolveRecordLayouts", () => {
+    const resolved = resolveRecordLayouts(["cam", "lidar"], VIEWPORT, null);
+
+    expect(
+      resolveRecordLayouts(["cam", "lidar"], VIEWPORT, toDatasetLayout(["cam", "lidar"], resolved)),
+    ).toEqual(resolved);
+  });
+});
+
+// ─── parseDatasetLayout ──────────────────────────────────────────────────────
+
+describe("parseDatasetLayout", () => {
+  it("accepts a well-formed payload", () => {
+    const stored = makeStoredLayout({ cam: { layout: { x: 1, y: 2, w: 3, h: 4 }, hidden: true } });
+
+    expect(parseDatasetLayout(JSON.parse(JSON.stringify(stored)))).toEqual(stored);
+  });
+
+  it("defaults a missing hidden flag to visible", () => {
+    const parsed = parseDatasetLayout({
+      version: DATASET_LAYOUT_VERSION,
+      views: { cam: { layout: { x: 1, y: 2, w: 3, h: 4 } } },
+    });
+
+    expect(parsed?.views.cam.hidden).toBe(false);
+  });
+
+  it("discards a payload written by another shape version", () => {
+    expect(
+      parseDatasetLayout({
+        version: DATASET_LAYOUT_VERSION + 1,
+        views: { cam: { layout: { x: 1, y: 2, w: 3, h: 4 }, hidden: false } },
+      }),
+    ).toBeNull();
+  });
+
+  it("drops only the unreadable views, keeping the usable ones", () => {
+    const parsed = parseDatasetLayout({
+      version: DATASET_LAYOUT_VERSION,
+      views: {
+        cam: { layout: { x: 1, y: 2, w: 3, h: 4 }, hidden: false },
+        broken: { layout: { x: "1", y: 2, w: 3, h: 4 } },
+        missing: {},
+      },
+    });
+
+    expect(Object.keys(parsed?.views ?? {})).toEqual(["cam"]);
+  });
+
+  it.each([
+    ["non-finite", { x: Number.NaN, y: 0, w: 3, h: 4 }],
+    ["fractional", { x: 0.5, y: 0, w: 3, h: 4 }],
+    ["fractional span", { x: 0, y: 0, w: 2.5, h: 4 }],
+    ["negative offset", { x: -1, y: 0, w: 3, h: 4 }],
+    ["zero-width", { x: 0, y: 0, w: 0, h: 4 }],
+    ["past the last column", { x: 10, y: 0, w: 4, h: 4 }],
+  ])("rejects a %s cell, which GridStack could not honour", (_label, layout) => {
+    expect(
+      parseDatasetLayout({ version: DATASET_LAYOUT_VERSION, views: { cam: { layout } } }),
+    ).toBeNull();
+  });
+
+  it("keeps a widget taller than the grid is wide (rows are unbounded)", () => {
+    const parsed = parseDatasetLayout({
+      version: DATASET_LAYOUT_VERSION,
+      views: { cam: { layout: { x: 0, y: 0, w: 12, h: 20 } } },
+    });
+
+    expect(parsed?.views.cam.layout.h).toBe(20);
+  });
+
+  it("rejects payloads that are not a layout at all", () => {
+    expect(parseDatasetLayout(null)).toBeNull();
+    expect(parseDatasetLayout("nope")).toBeNull();
+    expect(parseDatasetLayout([])).toBeNull();
+    expect(parseDatasetLayout({ version: DATASET_LAYOUT_VERSION })).toBeNull();
+    expect(parseDatasetLayout({ version: DATASET_LAYOUT_VERSION, views: {} })).toBeNull();
+  });
+});

--- a/ui/apps/web/src/lib/workspace/__tests__/datasetLayoutRepository.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/datasetLayoutRepository.test.ts
@@ -1,0 +1,70 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DATASET_LAYOUT_VERSION, type DatasetLayout } from "../datasetLayout.js";
+import {
+  DATASET_LAYOUT_KEY_PREFIX,
+  localStorageDatasetLayoutRepository as repository,
+} from "../datasetLayoutRepository.js";
+
+const LAYOUT: DatasetLayout = {
+  version: DATASET_LAYOUT_VERSION,
+  views: { cam: { layout: { x: 1, y: 2, w: 3, h: 4 }, hidden: false } },
+};
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("localStorageDatasetLayoutRepository", () => {
+  it("round-trips an arrangement", () => {
+    repository.save("ds-1", LAYOUT);
+
+    expect(repository.load("ds-1")).toEqual(LAYOUT);
+  });
+
+  it("namespaces datasets so one arrangement never shadows another", () => {
+    repository.save("ds-1", LAYOUT);
+
+    expect(repository.load("ds-2")).toBeNull();
+    expect(localStorage.getItem(`${DATASET_LAYOUT_KEY_PREFIX}ds-1`)).not.toBeNull();
+  });
+
+  it("reports no arrangement for a dataset that has none", () => {
+    expect(repository.load("unknown")).toBeNull();
+  });
+
+  it("treats an unparsable entry as no arrangement rather than throwing", () => {
+    localStorage.setItem(`${DATASET_LAYOUT_KEY_PREFIX}ds-1`, "{not json");
+
+    expect(repository.load("ds-1")).toBeNull();
+  });
+
+  it("treats a structurally invalid entry as no arrangement", () => {
+    localStorage.setItem(`${DATASET_LAYOUT_KEY_PREFIX}ds-1`, JSON.stringify({ views: "nope" }));
+
+    expect(repository.load("ds-1")).toBeNull();
+  });
+
+  it("stays silent when storage is blocked, so a workspace never fails over a preference", () => {
+    // Spy on the live `localStorage` object rather than `Storage.prototype`:
+    // happy-dom exposes these as own properties, so a prototype spy is never
+    // consulted and the test would pass without exercising anything.
+    const blocked = new Error("storage disabled");
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw blocked;
+    });
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+      throw blocked;
+    });
+
+    expect(() => repository.save("ds-1", LAYOUT)).not.toThrow();
+    expect(repository.load("ds-1")).toBeNull();
+  });
+});

--- a/ui/apps/web/src/lib/workspace/__tests__/fakeDatasetLayoutRepository.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/fakeDatasetLayoutRepository.ts
@@ -1,0 +1,35 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import type { DatasetLayout } from "../datasetLayout.js";
+import type { DatasetLayoutRepository } from "../datasetLayoutRepository.js";
+
+/**
+ * In-memory `DatasetLayoutRepository` for tests: same contract as the
+ * localStorage one, but with per-instance state so suites never leak stored
+ * arrangements into each other, and a `saved` log so a test can assert *what*
+ * was written rather than only that something was.
+ */
+export interface FakeDatasetLayoutRepository extends DatasetLayoutRepository {
+  /** Every `save` call, in order. */
+  saved: Array<{ datasetId: string; layout: DatasetLayout }>;
+}
+
+export function makeLayoutRepository(
+  initial: Record<string, DatasetLayout> = {},
+): FakeDatasetLayoutRepository {
+  const store = new Map(Object.entries(initial));
+  const saved: FakeDatasetLayoutRepository["saved"] = [];
+
+  return {
+    saved,
+    load: (datasetId) => store.get(datasetId) ?? null,
+    save: (datasetId, layout) => {
+      store.set(datasetId, layout);
+      saved.push({ datasetId, layout });
+    },
+  };
+}

--- a/ui/apps/web/src/lib/workspace/__tests__/layoutPlanner.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/layoutPlanner.test.ts
@@ -7,11 +7,13 @@ License: CECILL-C
 import { describe, expect, it } from "vitest";
 
 import {
+  GRID_ABSOLUTE_MIN_CELL,
   GRID_MAX_COLS,
   GRID_MIN_CELL,
   GRID_TOTAL_COLS,
   measureGridViewport,
   pickRenderableViews,
+  planFittedLayouts,
   planViewportLayouts,
 } from "../layoutPlanner.js";
 
@@ -115,6 +117,56 @@ describe("planViewportLayouts", () => {
     const layouts = planViewportLayouts(1, { width: 1, height: 1 });
     expect(layouts[0].w).toBeGreaterThanOrEqual(GRID_MIN_CELL);
     expect(layouts[0].h).toBeGreaterThanOrEqual(GRID_MIN_CELL);
+  });
+});
+
+// ─── planFittedLayouts ───────────────────────────────────────────────────────
+
+describe("planFittedLayouts", () => {
+  const VIEWPORT = { width: 1600, height: 900 };
+  // Rows the viewport actually shows, by the planner's own definition.
+  const visibleRows = Math.floor((GRID_TOTAL_COLS * VIEWPORT.height) / VIEWPORT.width);
+
+  it.each([1, 2, 3, 4, 6, 7, 9, 12, 16])(
+    "keeps all %i widgets inside the visible rows",
+    (count) => {
+      for (const layout of planFittedLayouts(count, VIEWPORT)) {
+        expect(layout.y + layout.h).toBeLessThanOrEqual(visibleRows);
+      }
+    },
+  );
+
+  it("fits counts the comfort-floored planner cannot", () => {
+    // The reason this variant exists: a 6-camera + lidar rig is 7 views.
+    const overflowing = planViewportLayouts(7, VIEWPORT);
+    expect(Math.max(...overflowing.map((l) => l.y + l.h))).toBeGreaterThan(visibleRows);
+
+    const fitted = planFittedLayouts(7, VIEWPORT);
+    expect(Math.max(...fitted.map((l) => l.y + l.h))).toBeLessThanOrEqual(visibleRows);
+  });
+
+  it("matches the default planner while the comfort floor is not binding", () => {
+    for (const count of [1, 2, 4, 6]) {
+      expect(planFittedLayouts(count, VIEWPORT)).toEqual(planViewportLayouts(count, VIEWPORT));
+    }
+  });
+
+  it("never plans a cell below what the grid can express", () => {
+    for (const layout of planFittedLayouts(16, VIEWPORT)) {
+      expect(layout.h).toBeGreaterThanOrEqual(GRID_ABSOLUTE_MIN_CELL);
+      expect(layout.w).toBeGreaterThanOrEqual(GRID_MIN_CELL);
+    }
+  });
+
+  it("keeps every row within the column count", () => {
+    for (const layout of planFittedLayouts(9, VIEWPORT)) {
+      expect(layout.x + layout.w).toBeLessThanOrEqual(GRID_TOTAL_COLS);
+    }
+  });
+
+  it("returns nothing for a non-positive count", () => {
+    expect(planFittedLayouts(0, VIEWPORT)).toEqual([]);
+    expect(planFittedLayouts(-1, VIEWPORT)).toEqual([]);
   });
 });
 

--- a/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/recordLoader.test.ts
@@ -11,6 +11,7 @@ import type { DatasetGateway } from "../datasetGateway.js";
 import { RecordLoader } from "../recordLoader.js";
 import type { WidgetSink } from "../recordLoader.js";
 import { WorkspaceSession } from "../workspaceSession.svelte.js";
+import { makeLayoutRepository } from "./fakeDatasetLayoutRepository.js";
 import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
 import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
 import type { WidgetComponentProps, WidgetExtensionConfig } from "$lib/extensions/types.js";
@@ -149,6 +150,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(ext),
       gateway: { ...makeGateway({ dataset }), listBBoxes },
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -176,6 +178,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway: makeGateway({ dataset }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -211,6 +214,7 @@ describe("RecordLoader.load", () => {
         ]),
       }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -231,6 +235,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway: makeGateway({ dataset }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -252,6 +257,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway: makeGateway({ dataset }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -268,6 +274,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway: makeGateway({ dataset }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await expect(loader.load("ds-1", "rec-1", VIEWPORT)).rejects.toThrow("No renderable views");
@@ -285,6 +292,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway,
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -313,6 +321,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(highPriority, lowPriority),
       gateway: makeGateway({ dataset }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -334,6 +343,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway: makeGateway({ dataset, entities }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -361,6 +371,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway,
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     const loadPromise = loader.load("ds-1", "rec-1", VIEWPORT);
@@ -382,6 +393,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway,
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -412,6 +424,7 @@ describe("RecordLoader.load", () => {
       registry: makeRegistry(ext),
       gateway: makeGateway({ dataset, entities: [entity] }),
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -437,6 +450,7 @@ describe("RecordLoader.reloadEntities", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway,
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-1", VIEWPORT);
@@ -466,6 +480,7 @@ describe("RecordLoader.reloadEntities", () => {
       registry: makeRegistry(makeImageExtension()),
       gateway,
       session,
+      layoutRepository: makeLayoutRepository(),
     });
 
     await loader.load("ds-1", "rec-A", VIEWPORT);

--- a/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
+++ b/ui/apps/web/src/lib/workspace/__tests__/workspaceManager.svelte.test.ts
@@ -8,7 +8,10 @@ import type { Component } from "svelte";
 import { describe, expect, it } from "vitest";
 
 import type { DatasetGateway } from "../datasetGateway.js";
+import { DATASET_LAYOUT_VERSION } from "../datasetLayout.js";
+import { planViewportLayouts } from "../layoutPlanner.js";
 import { WorkspaceManager } from "../workspaceManager.svelte.js";
+import { makeLayoutRepository } from "./fakeDatasetLayoutRepository.js";
 import type { BBox3DRow, BBoxRow, EntityRow } from "$lib/api/annotations.js";
 import type { CalibratedImageResponse, PointCloudResponse } from "$lib/api/restTypes.js";
 import type { WidgetComponentProps, WidgetExtensionConfig } from "$lib/extensions/types.js";
@@ -623,5 +626,274 @@ describe("WorkspaceManager.selectRecordInDataset", () => {
     resolveDataset(dataset);
     resolveEntities([]);
     await done;
+  });
+});
+
+// ─── Per-dataset layout preference ───────────────────────────────────────────
+// End-to-end through the manager: an arrangement made on one record is stored
+// against the dataset and replayed when another of its records is opened.
+
+describe("WorkspaceManager dataset layout preference", () => {
+  function makeTwoViewGateway() {
+    return makeGateway({
+      dataset: makeDataset({ cam_front: { base: "Image" }, lidar_top: { base: "PointCloud" } }),
+      entities: [],
+      imagesByLogicalName: new Map([
+        [
+          "cam_front",
+          { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse,
+        ],
+      ]),
+      pointCloudsByLogicalName: new Map([
+        ["lidar_top", { id: "pc-top", src: "/lidar.pcd" } as PointCloudResponse],
+      ]),
+      bboxes: [],
+      bboxes3d: [],
+    });
+  }
+
+  it("keys record-seeded widgets by their dataset view", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, makeLayoutRepository());
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+
+    expect(manager.widgets.map((w) => w.viewName)).toEqual(["cam_front", "lidar_top"]);
+  });
+
+  it("reuses on a later record the arrangement saved on an earlier one", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    // The user drags the lidar widget across the grid; the grid component then
+    // asks the manager to remember the arrangement.
+    manager.updateLayout(manager.widgets[1].id, { x: 0, y: 7, w: 12, h: 3 });
+    manager.saveDatasetLayout();
+
+    manager.clearWorkspace();
+    await manager.selectRecordInDataset("ds-1", "rec-2", FIXED_VIEWPORT);
+
+    expect(manager.widgets[1].layout).toEqual({ x: 0, y: 7, w: 12, h: 3 });
+  });
+
+  it("replays a hidden view as hidden on the next record", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    manager.toggleWidgetVisibility(manager.widgets[1].id);
+    // The grid persists once its reflow has settled; stand in for it here.
+    manager.saveDatasetLayout();
+
+    manager.clearWorkspace();
+    await manager.selectRecordInDataset("ds-1", "rec-2", FIXED_VIEWPORT);
+
+    expect(manager.widgets.map((w) => w.hidden)).toEqual([false, true]);
+  });
+
+  it("keeps each dataset's arrangement to itself", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    const arranged = { x: 0, y: 7, w: 12, h: 3 };
+    manager.updateLayout(manager.widgets[1].id, arranged);
+    manager.saveDatasetLayout();
+
+    manager.clearWorkspace();
+    await manager.selectRecordInDataset("ds-2", "rec-1", FIXED_VIEWPORT);
+
+    expect(manager.widgets[1].layout).not.toEqual(arranged);
+  });
+
+  it("does not save when no record is open, so clearing keeps the arrangement", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    manager.saveDatasetLayout();
+
+    expect(layouts.saved).toHaveLength(0);
+  });
+
+  it("does not overwrite the arrangement with an empty workspace", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    manager.saveDatasetLayout();
+    // `clearWorkspace` keeps the session's dataset selection, so a save
+    // triggered afterwards must not erase what was stored.
+    manager.clearWorkspace();
+    manager.saveDatasetLayout();
+
+    expect(layouts.load("ds-1")?.views.cam_front).toBeDefined();
+  });
+
+  it("puts the widgets back where the record opened them", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    const opening = manager.widgets.map((w) => ({ ...w.layout }));
+
+    manager.updateLayout(manager.widgets[1].id, { x: 0, y: 7, w: 12, h: 3 });
+    manager.toggleWidgetVisibility(manager.widgets[0].id);
+    manager.restoreOpeningLayout();
+
+    expect(manager.widgets.map((w) => w.layout)).toEqual(opening);
+    expect(manager.widgets.map((w) => w.hidden)).toEqual([false, false]);
+  });
+
+  it("tells the grid to re-apply the restored positions", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, makeLayoutRepository());
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    const before = manager.layoutRevision;
+    manager.restoreOpeningLayout();
+
+    expect(manager.layoutRevision).toBe(before + 1);
+  });
+
+  it("stores the restored arrangement, so screen and storage never disagree", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    const opening = { ...manager.widgets[1].layout };
+    manager.updateLayout(manager.widgets[1].id, { x: 0, y: 7, w: 12, h: 3 });
+    manager.saveDatasetLayout();
+
+    manager.restoreOpeningLayout();
+
+    expect(layouts.load("ds-1")?.views.lidar_top.layout).toEqual(opening);
+  });
+
+  it("does nothing before a record has loaded", () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    expect(() => manager.restoreOpeningLayout()).not.toThrow();
+    expect(layouts.saved).toHaveLength(0);
+  });
+
+  it("restores a view that was hidden when the record opened", async () => {
+    const { gateway } = makeTwoViewGateway();
+    // The dataset's stored arrangement hides the lidar, so the record opens with
+    // it hidden — the state "Reset layout" has to be able to get back to.
+    const layouts = makeLayoutRepository({
+      "ds-1": {
+        version: DATASET_LAYOUT_VERSION,
+        views: {
+          cam_front: { layout: { x: 0, y: 0, w: 12, h: 6 }, hidden: false },
+          lidar_top: { layout: { x: 0, y: 6, w: 12, h: 6 }, hidden: true },
+        },
+      },
+    });
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    expect(manager.widgets.map((w) => w.hidden)).toEqual([false, true]);
+
+    manager.toggleWidgetVisibility(manager.widgets[1].id);
+    manager.updateLayout(manager.widgets[0].id, { x: 3, y: 3, w: 6, h: 3 });
+    manager.restoreOpeningLayout();
+
+    expect(manager.widgets.map((w) => w.hidden)).toEqual([false, true]);
+    expect(manager.widgets[0].layout).toMatchObject({ x: 0, y: 0, w: 12, h: 6 });
+  });
+
+  it("drops the opening arrangement when the workspace is cleared", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, makeLayoutRepository());
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    manager.clearWorkspace();
+
+    // Nothing to restore onto, and nothing stale left describing the old record.
+    const before = manager.layoutRevision;
+    manager.restoreOpeningLayout();
+    expect(manager.layoutRevision).toBe(before);
+  });
+});
+
+// ─── Fit layout ──────────────────────────────────────────────────────────────
+
+describe("WorkspaceManager.fitLayoutToViewport", () => {
+  function makeTwoViewGateway() {
+    return makeGateway({
+      dataset: makeDataset({ cam_front: { base: "Image" }, lidar_top: { base: "PointCloud" } }),
+      entities: [],
+      imagesByLogicalName: new Map([
+        [
+          "cam_front",
+          { id: "img-front", src: "/f.png", width: 100, height: 50 } as CalibratedImageResponse,
+        ],
+      ]),
+      pointCloudsByLogicalName: new Map([
+        ["lidar_top", { id: "pc-top", src: "/lidar.pcd" } as PointCloudResponse],
+      ]),
+      bboxes: [],
+      bboxes3d: [],
+    });
+  }
+
+  it("re-tiles every widget to the automatic placement for the viewport", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, makeLayoutRepository());
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    manager.updateLayout(manager.widgets[0].id, { x: 9, y: 40, w: 3, h: 3 });
+
+    manager.fitLayoutToViewport(FIXED_VIEWPORT);
+
+    expect(manager.widgets.map((w) => w.layout)).toEqual(
+      planViewportLayouts(2, FIXED_VIEWPORT).map((layout) => expect.objectContaining(layout)),
+    );
+  });
+
+  it("reveals hidden widgets, so nothing is left off-screen", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, makeLayoutRepository());
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    manager.toggleWidgetVisibility(manager.widgets[0].id);
+
+    manager.fitLayoutToViewport(FIXED_VIEWPORT);
+
+    expect(manager.widgets.every((w) => w.hidden === false)).toBe(true);
+  });
+
+  it("tells the grid to re-apply, and remembers the result", async () => {
+    const { gateway } = makeTwoViewGateway();
+    const layouts = makeLayoutRepository();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, layouts);
+
+    await manager.selectRecordInDataset("ds-1", "rec-1", FIXED_VIEWPORT);
+    const before = manager.layoutRevision;
+
+    manager.fitLayoutToViewport(FIXED_VIEWPORT);
+
+    expect(manager.layoutRevision).toBe(before + 1);
+    expect(layouts.load("ds-1")?.views.cam_front.layout).toEqual(
+      planViewportLayouts(2, FIXED_VIEWPORT)[0],
+    );
+  });
+
+  it("does nothing on an empty workspace", () => {
+    const { gateway } = makeTwoViewGateway();
+    const manager = new WorkspaceManager(makeRegistry(), gateway, makeLayoutRepository());
+
+    expect(() => manager.fitLayoutToViewport(FIXED_VIEWPORT)).not.toThrow();
+    expect(manager.layoutRevision).toBe(0);
   });
 });

--- a/ui/apps/web/src/lib/workspace/datasetLayout.ts
+++ b/ui/apps/web/src/lib/workspace/datasetLayout.ts
@@ -1,0 +1,177 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { GRID_TOTAL_COLS, planViewportLayouts, type Viewport } from "./layoutPlanner.js";
+import type { WidgetInstance, WidgetLayout } from "$lib/extensions/types.js";
+
+/**
+ * Domain of the "remember how I arranged this dataset" feature.
+ *
+ * A dataset's records all expose the *same* declared views (`camera_front`,
+ * `lidar`, …), so the arrangement a user builds on one record is meaningful
+ * for every other record of that dataset. This module owns the value object
+ * describing that arrangement plus the two pure transforms around it:
+ *
+ *   - `snapshotDatasetLayout` — current widgets → storable preference,
+ *   - `resolveRecordLayouts`  — stored preference + the views a record
+ *                               actually has → the layout for each widget.
+ *
+ * Persistence itself lives in `datasetLayoutRepository.ts`; nothing here
+ * touches storage, so the rules stay testable without a DOM.
+ *
+ * The view name is the key because it is the only widget identifier stable
+ * across records: instance ids are minted per load, and titles are display
+ * text an extension may localize or rewrite.
+ */
+
+/**
+ * Shape version of a stored preference. Bump it whenever the persisted
+ * structure changes; payloads carrying any other version are discarded on
+ * read rather than migrated, so a stale entry degrades to "no preference"
+ * instead of corrupting a workspace.
+ */
+export const DATASET_LAYOUT_VERSION = 1;
+
+/** The arrangement remembered for a single dataset view. */
+export interface StoredViewLayout {
+  layout: WidgetLayout;
+  hidden: boolean;
+}
+
+/** Everything remembered for one dataset, keyed by view name. */
+export interface DatasetLayout {
+  version: number;
+  views: Record<string, StoredViewLayout>;
+}
+
+/** A widget's placement for the record being opened. */
+export interface ResolvedLayout {
+  layout: WidgetLayout;
+  hidden: boolean;
+}
+
+/**
+ * Capture the user's current arrangement as a storable preference.
+ *
+ * Only view-backed widgets are captured: a widget dragged in from the
+ * palette has no counterpart in the next record's views, so there would be
+ * nothing to restore it onto. Returns `null` when there is nothing worth
+ * remembering, which callers treat as "no preference to write" rather than
+ * "erase what is stored".
+ */
+export function snapshotDatasetLayout(widgets: readonly WidgetInstance[]): DatasetLayout | null {
+  const views: Record<string, StoredViewLayout> = {};
+  let captured = 0;
+  let visible = 0;
+
+  for (const widget of widgets) {
+    if (!widget.viewName) continue;
+    const hidden = widget.hidden === true;
+    views[widget.viewName] = { layout: { ...widget.layout }, hidden };
+    captured++;
+    if (!hidden) visible++;
+  }
+
+  // A workspace with every view hidden is a transient state, not an arrangement
+  // worth replaying: remembering it would open every other record of the
+  // dataset on an empty grid, which reads as a failed load. The previously
+  // stored arrangement stays instead.
+  if (captured === 0 || visible === 0) return null;
+
+  return { version: DATASET_LAYOUT_VERSION, views };
+}
+
+/**
+ * Express a record's resolved placement as a replayable arrangement, so the
+ * state a record opened in can be restored after the user rearranges it.
+ */
+export function toDatasetLayout(
+  viewNames: readonly string[],
+  layouts: readonly ResolvedLayout[],
+): DatasetLayout {
+  const views: Record<string, StoredViewLayout> = {};
+
+  viewNames.forEach((viewName, index) => {
+    views[viewName] = { layout: { ...layouts[index].layout }, hidden: layouts[index].hidden };
+  });
+
+  return { version: DATASET_LAYOUT_VERSION, views };
+}
+
+/**
+ * Decide where each of a record's widgets goes.
+ *
+ * A view the user has arranged keeps that arrangement; any other view falls
+ * back to the automatic placement computed for the record's widget count. A
+ * fallback slot can collide with a remembered one (the stored arrangement was
+ * built from a different set of views) — that is left to GridStack, which drops
+ * a colliding widget into the next free spot at the requested size.
+ */
+export function resolveRecordLayouts(
+  viewNames: readonly string[],
+  viewport: Viewport,
+  saved: DatasetLayout | null,
+): ResolvedLayout[] {
+  const planned = planViewportLayouts(viewNames.length, viewport);
+
+  return viewNames.map((viewName, index) => {
+    const stored = saved?.views[viewName];
+    if (stored) return { layout: { ...stored.layout }, hidden: stored.hidden };
+    return { layout: planned[index], hidden: false };
+  });
+}
+
+/**
+ * Validate an untrusted payload (hand-edited storage, an entry written by an
+ * older build) into a `DatasetLayout`, or `null` when it cannot be trusted.
+ * Unreadable views are dropped individually so one bad entry does not throw
+ * away an otherwise usable arrangement.
+ */
+export function parseDatasetLayout(raw: unknown): DatasetLayout | null {
+  if (!isRecord(raw)) return null;
+  if (raw.version !== DATASET_LAYOUT_VERSION) return null;
+  if (!isRecord(raw.views)) return null;
+
+  const views: Record<string, StoredViewLayout> = {};
+  for (const [viewName, entry] of Object.entries(raw.views)) {
+    const parsed = parseStoredViewLayout(entry);
+    if (parsed) views[viewName] = parsed;
+  }
+
+  return Object.keys(views).length > 0 ? { version: DATASET_LAYOUT_VERSION, views } : null;
+}
+
+/**
+ * Accept only geometry the grid can actually honour. Storage is user-editable,
+ * so a fractional, negative or over-wide cell would otherwise reach GridStack
+ * and break the whole grid rather than just its own widget.
+ */
+function parseStoredViewLayout(entry: unknown): StoredViewLayout | null {
+  if (!isRecord(entry) || !isRecord(entry.layout)) return null;
+
+  const { x, y, w, h } = entry.layout;
+  if (!isCellOffset(x) || !isCellOffset(y)) return null;
+  // Rows are unbounded (a tall viewport plans widgets taller than the grid is
+  // wide), so only the horizontal span is checked against the column count.
+  if (!isCellSpan(w) || !isCellSpan(h)) return null;
+  if (x + w > GRID_TOTAL_COLS) return null;
+
+  return { layout: { x, y, w, h }, hidden: entry.hidden === true };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Grid coordinates are whole, non-negative cell offsets. */
+function isCellOffset(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/** A span covers at least one whole cell. */
+function isCellSpan(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1;
+}

--- a/ui/apps/web/src/lib/workspace/datasetLayoutRepository.ts
+++ b/ui/apps/web/src/lib/workspace/datasetLayoutRepository.ts
@@ -1,0 +1,59 @@
+/*-------------------------------------
+Copyright: CEA-LIST/DIASI/SIALV/LVA
+Author : pixano@cea.fr
+License: CECILL-C
+-------------------------------------*/
+
+import { parseDatasetLayout, type DatasetLayout } from "./datasetLayout.js";
+
+/**
+ * Storage seam for per-dataset layout preferences.
+ *
+ * The workspace depends on this interface, never on `localStorage`, so the
+ * arrangement can later be moved server-side (a user-scoped preference
+ * endpoint) by swapping the implementation injected into `WorkspaceManager` —
+ * no call site changes. Tests inject an in-memory double for the same reason.
+ */
+export interface DatasetLayoutRepository {
+  /** The arrangement remembered for this dataset, or `null` if there is none. */
+  load(datasetId: string): DatasetLayout | null;
+  /** Remember `layout` as this dataset's arrangement, replacing any previous one. */
+  save(datasetId: string, layout: DatasetLayout): void;
+}
+
+/** Namespace for the per-dataset keys, so one dataset's entry never shadows another's. */
+export const DATASET_LAYOUT_KEY_PREFIX = "pixano-dataset-layout:";
+
+function storageKey(datasetId: string): string {
+  return `${DATASET_LAYOUT_KEY_PREFIX}${datasetId}`;
+}
+
+/**
+ * Browser-local implementation. A layout preference is a per-user comfort
+ * setting, not dataset content, so it stays on the machine that set it and is
+ * never worth failing a workspace over: every access is guarded because
+ * `localStorage` throws outright when storage is disabled (private modes,
+ * hardened browsers) or the quota is exhausted. It is also inert under SSR,
+ * where `window` does not exist.
+ */
+export const localStorageDatasetLayoutRepository: DatasetLayoutRepository = {
+  load(datasetId: string): DatasetLayout | null {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = localStorage.getItem(storageKey(datasetId));
+      return raw === null ? null : parseDatasetLayout(JSON.parse(raw));
+    } catch {
+      // Storage blocked, or a malformed entry that JSON.parse rejected.
+      return null;
+    }
+  },
+
+  save(datasetId: string, layout: DatasetLayout): void {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem(storageKey(datasetId), JSON.stringify(layout));
+    } catch {
+      // Storage blocked or full — the arrangement stays live for this session.
+    }
+  },
+};

--- a/ui/apps/web/src/lib/workspace/layoutPlanner.ts
+++ b/ui/apps/web/src/lib/workspace/layoutPlanner.ts
@@ -24,6 +24,13 @@ export const GRID_TOTAL_COLS = 12;
 export const GRID_MIN_CELL = 3;
 export const GRID_MAX_COLS = Math.floor(GRID_TOTAL_COLS / GRID_MIN_CELL); // 4
 
+/**
+ * Smallest cell GridStack can express. `GRID_MIN_CELL` is the *comfortable*
+ * minimum widget extensions ask for; this is the floor used when fitting every
+ * widget on screen matters more than comfort (see `planFittedLayouts`).
+ */
+export const GRID_ABSOLUTE_MIN_CELL = 1;
+
 export interface Viewport {
   width: number;
   height: number;
@@ -56,19 +63,39 @@ export function pickRenderableViews(
  * fills the full width.
  */
 export function planViewportLayouts(count: number, viewport: Viewport): WidgetLayout[] {
+  return planTiledLayouts(count, viewport, GRID_MIN_CELL);
+}
+
+/**
+ * Same tiling, but guaranteeing the whole set is on screen.
+ *
+ * `planViewportLayouts` keeps every widget at least `GRID_MIN_CELL` tall, which
+ * beyond six widgets needs more rows than the viewport shows — a 6-camera +
+ * lidar rig would tile past the fold. This variant trades that comfort floor for
+ * the guarantee the "Fit layout" action promises: rows × cell height never
+ * exceeds the visible rows. Widths are unaffected (`cols × w ≤ GRID_TOTAL_COLS`
+ * already holds), and consumers must lower each widget's `minH`/`minW`
+ * accordingly or GridStack will inflate the result back past the fold.
+ */
+export function planFittedLayouts(count: number, viewport: Viewport): WidgetLayout[] {
+  return planTiledLayouts(count, viewport, GRID_ABSOLUTE_MIN_CELL);
+}
+
+/**
+ * Shared tiling: square-ish grid of `count` cells across `GRID_TOTAL_COLS`,
+ * with `minCell` as the floor on cell height.
+ */
+function planTiledLayouts(count: number, viewport: Viewport, minCell: number): WidgetLayout[] {
   if (count <= 0) return [];
 
   const containerW = Math.max(1, viewport.width);
   const containerH = Math.max(1, viewport.height);
-  const visibleRows = Math.max(
-    GRID_MIN_CELL,
-    Math.floor((GRID_TOTAL_COLS * containerH) / containerW),
-  );
+  const visibleRows = Math.max(minCell, Math.floor((GRID_TOTAL_COLS * containerH) / containerW));
 
   const cols = Math.max(1, Math.min(GRID_MAX_COLS, Math.ceil(Math.sqrt(count))));
   const rows = Math.ceil(count / cols);
   const w = Math.max(GRID_MIN_CELL, Math.floor(GRID_TOTAL_COLS / cols));
-  const h = Math.max(GRID_MIN_CELL, Math.floor(visibleRows / rows));
+  const h = Math.max(minCell, Math.floor(visibleRows / rows));
 
   const layouts: WidgetLayout[] = [];
   for (let i = 0; i < count; i++) {

--- a/ui/apps/web/src/lib/workspace/recordLoader.ts
+++ b/ui/apps/web/src/lib/workspace/recordLoader.ts
@@ -5,7 +5,9 @@ License: CECILL-C
 -------------------------------------*/
 
 import type { DatasetGateway, RecordReadGateway } from "./datasetGateway.js";
-import { measureGridViewport, planViewportLayouts, type Viewport } from "./layoutPlanner.js";
+import { resolveRecordLayouts, toDatasetLayout } from "./datasetLayout.js";
+import type { DatasetLayoutRepository } from "./datasetLayoutRepository.js";
+import { measureGridViewport, type Viewport } from "./layoutPlanner.js";
 import type { RecordWidgetSeed } from "./recordSeed.js";
 import type { WorkspaceSession } from "./workspaceSession.svelte.js";
 import { AnnotationCollection } from "$lib/annotations/annotationCollection.svelte.js";
@@ -37,6 +39,11 @@ export interface RecordLoaderDeps {
    */
   gateway: DatasetGateway;
   session: WorkspaceSession;
+  /**
+   * Source of the dataset's remembered widget arrangement. Read once per load
+   * so a record opens laid out the way the user arranged an earlier one.
+   */
+  layoutRepository: DatasetLayoutRepository;
 }
 
 /**
@@ -49,6 +56,7 @@ export class RecordLoader {
   private gateway: DatasetGateway;
   private readGateway: RecordReadGateway;
   private session: WorkspaceSession;
+  private layoutRepository: DatasetLayoutRepository;
   // Incremented on every load() call. Each async continuation checks that it
   // still holds the current token before mutating workspace state, so a
   // rapid record-switch never lets a stale load overwrite the newer one.
@@ -60,6 +68,7 @@ export class RecordLoader {
     this.gateway = deps.gateway;
     this.readGateway = deps.gateway;
     this.session = deps.session;
+    this.layoutRepository = deps.layoutRepository;
   }
 
   /**
@@ -194,7 +203,18 @@ export class RecordLoader {
     if (token !== this.loadToken) return;
     this.session.annotations = new AnnotationCollection(loaded.flat());
 
-    const layouts = planViewportLayouts(claimed.length, viewport);
+    // Replay the arrangement the user built on an earlier record of this
+    // dataset; views they never arranged fall back to automatic placement.
+    const viewNames = claimed.map(({ viewName }) => viewName);
+    const layouts = resolveRecordLayouts(
+      viewNames,
+      viewport,
+      this.layoutRepository.load(datasetId),
+    );
+
+    // Remember the state the record opens in so the user can undo the moves
+    // they make on it (`WorkspaceManager.restoreOpeningLayout`).
+    this.session.openingLayout = toDatasetLayout(viewNames, layouts);
 
     // Materialize widgets in the dataset's declared view order so on-screen
     // placement matches the schema (e.g. cameras left-to-right, lidar
@@ -207,7 +227,11 @@ export class RecordLoader {
         {
           extensionName,
           title: seed.title ?? viewName,
-          layout: layouts[i],
+          // Keys this widget to its dataset view so a later arrangement of it
+          // is remembered under a name the next record also has.
+          viewName,
+          layout: layouts[i].layout,
+          hidden: layouts[i].hidden,
           options: seed.options,
           data: seed.data,
         },

--- a/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceManager.svelte.ts
@@ -5,7 +5,12 @@ License: CECILL-C
 -------------------------------------*/
 
 import { httpDatasetGateway, type DatasetGateway } from "./datasetGateway.js";
-import type { Viewport } from "./layoutPlanner.js";
+import { snapshotDatasetLayout } from "./datasetLayout.js";
+import {
+  localStorageDatasetLayoutRepository,
+  type DatasetLayoutRepository,
+} from "./datasetLayoutRepository.js";
+import { planFittedLayouts, type Viewport } from "./layoutPlanner.js";
 import { MutationQueue } from "./mutationQueue.svelte.js";
 import { RecordLoader } from "./recordLoader.js";
 import { WorkspaceSession } from "./workspaceSession.svelte.js";
@@ -53,6 +58,14 @@ export class WorkspaceManager {
   widgetCount = $derived(this.widgets.length);
 
   /**
+   * Bumped whenever widget layouts are rewritten programmatically rather than
+   * by a grid gesture. `GridWorkspace` watches this counter alone to push the
+   * new positions into GridStack — watching the layouts themselves would make
+   * it re-apply on every drag and fight the user's own gesture.
+   */
+  layoutRevision = $state(0);
+
+  /**
    * A box drawn but awaiting its entity choice in the Inspector. `null` when no
    * box is pending. Set by widgets via `beginPendingAnnotation`.
    */
@@ -64,10 +77,16 @@ export class WorkspaceManager {
   private session: WorkspaceSession;
   private mutations: MutationQueue;
   private loader: RecordLoader;
+  private layoutRepository: DatasetLayoutRepository;
 
-  constructor(registry: WidgetRegistry, gateway: DatasetGateway = httpDatasetGateway) {
+  constructor(
+    registry: WidgetRegistry,
+    gateway: DatasetGateway = httpDatasetGateway,
+    layoutRepository: DatasetLayoutRepository = localStorageDatasetLayoutRepository,
+  ) {
     this.registry = registry;
     this.session = new WorkspaceSession();
+    this.layoutRepository = layoutRepository;
 
     // Annotations are record-scoped: the queue flips `persisted` directly on
     // the session's shared collection, no per-widget storage lookup needed.
@@ -80,6 +99,7 @@ export class WorkspaceManager {
       registry,
       gateway,
       session: this.session,
+      layoutRepository,
     });
   }
 
@@ -304,6 +324,8 @@ export class WorkspaceManager {
       layout: overrides?.layout ?? { ...config.defaultLayout },
       options: { ...options, ...overrides?.options },
       data: overrides?.data,
+      hidden: overrides?.hidden,
+      viewName: overrides?.viewName,
     };
 
     this.storageMap.set(widget.id, storage);
@@ -325,12 +347,97 @@ export class WorkspaceManager {
     }
   }
 
-  /** Toggle the visibility of a widget in the workspace. */
+  /**
+   * Toggle the visibility of a widget in the workspace.
+   *
+   * Persisting is left to the grid: hiding compacts the neighbours and showing
+   * re-places the widget in whatever slot is now free, so the arrangement the
+   * user ends up seeing is only settled once GridStack has reacted.
+   */
   toggleWidgetVisibility(id: string): void {
     const widget = this.widgets.find((w) => w.id === id);
     if (widget) {
       widget.hidden = !widget.hidden;
     }
+  }
+
+  // ─── Per-dataset layout preference ────────────────────────────────────────
+  // Arranging the widgets on one record states how the user wants *this
+  // dataset* laid out, so the arrangement is remembered and replayed when they
+  // open the dataset's other records.
+  //
+  // Saving is deliberately explicit rather than a side effect of
+  // `updateLayout`: the grid also writes layouts back when it places widgets
+  // programmatically (mount, clamping, gap compaction after a hide), and
+  // persisting those would freeze an automatic placement — computed for one
+  // record's widget count — as if the user had chosen it. Only the call sites
+  // that know a gesture happened save.
+
+  /**
+   * Remember how the user arranged the current dataset. No-op when no dataset
+   * is open or no widget is view-backed, so clearing the workspace or moving a
+   * palette widget never erases a stored arrangement.
+   */
+  saveDatasetLayout(): void {
+    const datasetId = this.session.datasetId;
+    if (!datasetId) return;
+
+    const layout = snapshotDatasetLayout(this.widgets);
+    if (layout) this.layoutRepository.save(datasetId, layout);
+  }
+
+  /**
+   * Whether there is an opening arrangement to go back to. False until a record
+   * has loaded, so the UI can disable the action instead of offering a no-op.
+   */
+  get hasOpeningLayout(): boolean {
+    return this.session.openingLayout !== null;
+  }
+
+  /**
+   * Put every widget back where the current record opened it, undoing the moves
+   * made since, and remember that as the dataset's arrangement so what is shown
+   * and what is stored never disagree.
+   *
+   * No-op before a record has loaded.
+   */
+  restoreOpeningLayout(): void {
+    const opening = this.session.openingLayout;
+    if (!opening) return;
+
+    for (const widget of this.widgets) {
+      const stored = widget.viewName ? opening.views[widget.viewName] : undefined;
+      if (!stored) continue;
+      // Spread over the current layout so the extension's minW/minH survive.
+      widget.layout = { ...widget.layout, ...stored.layout };
+      widget.hidden = stored.hidden;
+    }
+
+    this.layoutRevision++;
+    this.saveDatasetLayout();
+  }
+
+  /**
+   * Re-tile every widget so the whole set is visible and fits the viewport,
+   * revealing any that were hidden. The escape hatch for a workspace that has
+   * been arranged into a corner — or whose stored arrangement was built for a
+   * screen the user no longer has.
+   *
+   * The viewport is passed in (rather than measured here) so the manager stays
+   * environment-agnostic and unit-testable; callers read it from the live grid.
+   */
+  fitLayoutToViewport(viewport: Viewport): void {
+    if (this.widgets.length === 0) return;
+
+    const layouts = planFittedLayouts(this.widgets.length, viewport);
+    this.widgets.forEach((widget, index) => {
+      // Spread over the current layout so the extension's minW/minH survive.
+      widget.layout = { ...widget.layout, ...layouts[index] };
+      widget.hidden = false;
+    });
+
+    this.layoutRevision++;
+    this.saveDatasetLayout();
   }
 
   /** Get the mutable storage for a widget instance. */
@@ -348,6 +455,9 @@ export class WorkspaceManager {
     this.storageMap.clear();
     this.widgets = [];
     this.mutations.reset();
+    // The widgets it described are gone, so the arrangement they opened in no
+    // longer means anything; the next load writes the new record's.
+    this.session.openingLayout = null;
   }
 
   /** Apply a workspace preset, replacing all current widgets. */

--- a/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
+++ b/ui/apps/web/src/lib/workspace/workspaceSession.svelte.ts
@@ -4,6 +4,7 @@ Author : pixano@cea.fr
 License: CECILL-C
 -------------------------------------*/
 
+import type { DatasetLayout } from "./datasetLayout.js";
 import { AnnotationCollection } from "$lib/annotations/annotationCollection.svelte.js";
 import type { LiveAnnotationDraft } from "$lib/annotations/scene/sceneContext.js";
 import type { EntityRow } from "$lib/api/annotations.js";
@@ -47,6 +48,11 @@ export class WorkspaceSession {
    * `annotations`; this slot is null whenever no gesture is running.
    */
   liveDraft = $state<LiveAnnotationDraft | null>(null);
+  /**
+   * The arrangement this record opened with, so "Reset layout" can undo the
+   * moves made since. Written by `RecordLoader` at the end of each load.
+   */
+  openingLayout = $state<DatasetLayout | null>(null);
 
   /** Reset the selection (e.g. on `clearWorkspace`). */
   reset(): void {
@@ -58,5 +64,6 @@ export class WorkspaceSession {
     this.annotations = new AnnotationCollection();
     this.visibleEntityIds = null;
     this.liveDraft = null;
+    this.openingLayout = null;
   }
 }


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

No tracking issue — this implements a layout-persistence request made directly.

## Description

Widgets rearranged on one record now stay that way when the dataset's other records are opened.

Every record of a dataset declares the same views, so the arrangement a user builds on one is meaningful for all of them. Widgets are keyed by **view name** — the only identifier that survives a record switch, since instance ids are minted per load and titles are display text. Views the user never arranged fall back to the existing automatic placement, so a record with a different set of views still opens sensibly.

### What is added

- `workspace/datasetLayout.ts` — the rules (snapshot / resolve / validate). No storage access, so they are testable without a DOM.
- `workspace/datasetLayoutRepository.ts` — the storage seam, with a `localStorage` implementation. The workspace depends on the interface, never on `localStorage`, so this can later move to a user-scoped preference endpoint by swapping the injected implementation, with no call-site changes.
- Two inspector actions: **Reset layout** puts the widgets back where the current record opened them; **Fit layout** reveals every widget and re-tiles it to fit the viewport.

### Design notes worth reviewing

**Only gestures persist.** The grid writes layouts back whenever *it* places widgets (mount, clamping, compaction after a hide). Persisting those would freeze an automatic placement — computed for one record's widget count — as if the user had chosen it, which breaks datasets whose records expose different numbers of views. `GridWorkspace` saves only where an arrangement has settled after a user action.

**Screen and storage must agree.** Hiding compacts the neighbours and showing re-places a widget wherever a slot is now free, so the save waits for GridStack to react — for a re-shown widget, behind the deferred mount's microtask, once the slot it actually lands in is resolved.

**Programmatic arrangements are authoritative.** `restoreOpeningLayout` / `fitLayoutToViewport` choose every position themselves, so the reconciliation effect skips the gap-fill meant for a user hide while applying one; otherwise compaction overwrites the positions being restored. `layoutRevision` is the reverse channel that pushes those positions — and their lowered `minW`/`minH`, which GridStack would otherwise clamp back up — into the DOM. It is watched alone: depending on the layouts themselves would re-run that effect mid-drag and fight the gesture.

**`planFittedLayouts`** is a new sibling of `planViewportLayouts` rather than a change to it: the default planner keeps a comfort floor on cell height that cannot fit more than six widgets, which a 6-camera + lidar rig exceeds. Record opening is deliberately left untouched.

**The workspace lock** now covers every control that can move a widget, visibility toggles included — hiding compacts the neighbours and the grid stores the result, so an ungated toggle wrote the very arrangement the lock exists to protect.

### Accepted limitations

Listed in `docs/OPEN_QUESTIONS.md` with the way out for each: browser-local storage, no way to forget an arrangement, palette widgets not remembered, last-writer-wins across tabs, literal UI strings, and the loss of automatic viewport adaptation.

### Verification

413 frontend tests pass (+42). `pnpm run check` stays at its baseline (41 errors, 1 warning — all pre-existing and unrelated). Prettier, pre-commit and the production build are clean. Each fix in here was checked to be load-bearing by disabling it and confirming the matching test fails.
