### PR TITLE
docs: realign the developer docs with the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,20 @@ Pixano is an open-source data engine for multi-modal AI development. It provides
 
 ## Project Structure & Module Organization
 
-Pixano is a web application organized as a monorepo with a backend server and a UI frontend. The backend is a Python application following standard `uv` package conventions under `src/pixano/`. The `ui/` directory is a pnpm workspace for frontend code. It contains frontend applications under `ui/apps/` and may contain shared frontend packages under `ui/packages/` as the workspace grows. The documentation website is built with Astro and lives in `docs-astro/`.
+Pixano is a web application organized as a monorepo with a backend server and a UI frontend. The backend is a Python application following standard `uv` package conventions under `src/pixano/`. The `ui/` directory is a pnpm + Turbo workspace holding two frontend applications, both bundled into the wheel by `hatch_build.py`:
+
+- `ui/apps/web` (package `@pixano/web`) — the **new workspace UI**, built on a plugin annotation architecture. This is where current frontend work happens; `docs/FRONTEND_ARCHITECTURE.md`, `docs/ARCHITECTURE_TOOLING.md`, `docs/CODING_STANDARDS.md` and `docs/ADDING_AN_ANNOTATION_KIND.md` all describe this app and only this app.
+- `ui/apps/pixano` — the **legacy app** (`hatch_build.py` calls it the "legacy frontend"), being migrated away from. Do not add features here.
+
+There is no `ui/packages/` directory; the two apps share no code (`restTypes.ts` / `apiClient.ts` are hand-copied between them). The documentation website is built with Astro and lives in `docs-astro/`.
 
 Backend modules are organized as follows:
 
 - `src/pixano/api`: REST API module with FastAPI routers.
 - `src/pixano/cli`: Pixano CLI module.
-- `src/pixano/datasets`: dataset builders, exporters, and Python API.
+- `src/pixano/datasets`: LanceDB dataset engine and Python API. `datasets/io/` holds the 0.8.0 import/export engine (`formats/{pixano_jsonl,coco,lerobot}`); the v1 folder builders were removed in that redesign.
 - `src/pixano/inference`: adapters for AI model inference services.
+- `src/pixano/features`: annotation feature definitions.
 - `src/pixano/schemas`: Pixano database schemas.
 - `src/pixano/utils`: shared utilities.
 - `tests`: unit and e2e test modules.
@@ -22,7 +28,7 @@ Design specifications live in `docs/specs/`. Before planning or implementing cha
 
 ## Tech Stack
 
-The backend uses FastAPI for the server, LanceDB as the dataset engine, Python for implementation, and `uv` for dependency management and builds. The frontend uses SvelteKit 5, Svelte 5, TypeScript, and `pnpm`. Important UI libraries include bits-ui, Tailwind CSS, phosphor-svelte, KonvaJS, ThretleJS, and Tiptap.
+The backend uses FastAPI for the server, LanceDB as the dataset engine, Python for implementation, and `uv` for dependency management and builds. The frontend uses SvelteKit, Svelte 5, TypeScript, and `pnpm`. UI libraries differ per app: `ui/apps/web` uses Tailwind CSS, bits-ui, Konva, Three.js with Threlte, Tiptap and lucide-svelte; the legacy `ui/apps/pixano` uses Tailwind CSS, bits-ui, Konva with svelte-konva, D3/Chart.js, ONNX Runtime Web, Tiptap and phosphor-svelte.
 
 ## Build, Test, and Development Commands
 
@@ -53,27 +59,24 @@ When using an existing initialized Pixano data directory during backend developm
 uv run pixano server run /path/to/data
 ```
 
-For frontend development, start the standalone SvelteKit dev server from the pnpm workspace:
+For frontend development, start the dev server for the app you are working on:
 
 ```sh
 cd ui
 pnpm install
-cd apps/pixano
-pnpm run dev
+pnpm run dev:web      # the new workspace UI (ui/apps/web) — the usual target
+pnpm run dev:pixano   # the legacy app (ui/apps/pixano)
 ```
 
-Run backend tests with `uv run pytest --cov=src/pixano tests/`. Run frontend tests with `pnpm -C ui/apps/pixano test`. For broader checks, use `uv tool run pre-commit run --all-files`, `pnpm -C ui lint`, and `pnpm -C ui format_check`.
+Run backend tests with `uv run pytest --cov=src/pixano tests/`. Run frontend tests with `pnpm -C ui test` (Turbo, both apps) or `pnpm -C ui/apps/web test` for the new UI alone — note `pnpm -C ui/apps/pixano test` covers only the legacy app. Type-check the new UI with `pnpm -C ui/apps/web run check`. For broader checks, use `uv tool run pre-commit run --all-files`, `pnpm -C ui lint`, and `pnpm -C ui format_check`.
 
-For release builds, build the UI first, then build the Python wheel:
+For release builds, just build the Python wheel:
 
 ```sh
-cd ui/apps/pixano
-pnpm run build
-cd ../../..
 uv build
 ```
 
-The UI build copies frontend artifacts into `dist`; `uv build` bundles those artifacts with the backend code in the wheel.
+`hatch_build.py` runs `pnpm install --frozen-lockfile` and then builds **both** frontends (legacy then web) as part of the wheel build, so there is no separate UI step. It is skipped for editable installs — build the app you need by hand there (`pnpm -C ui/apps/web run build`).
 
 ## Coding Style & Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Python uses Ruff for linting and formatting, with a 119-character line limit, do
 
 Frontend code uses TypeScript, Svelte 5, ESLint, and Prettier. Name Svelte components `PascalCase.svelte`, helpers `camelCase.ts`, and Vitest files `*.test.ts` under `src/**/__tests__/`. Preserve the repository copyright header in `.py`, `.ts`, and `.svelte` files.
 
+UI text is written as literal strings. Neither app has an i18n layer and none is planned — there is no translation module, no message catalogue and no key indirection. Write the string where it is displayed.
+
 ## Testing Guidelines
 
 Add or update tests alongside the code you change. Backend tests should use `test_*.py` names under the matching `tests/` area. Frontend tests should stay colocated in `__tests__` directories. Tests marked `e2e` require a live inference server configured with `PIXANO_INFERENCE_URL`.

--- a/docs/ADDING_AN_ANNOTATION_KIND.md
+++ b/docs/ADDING_AN_ANNOTATION_KIND.md
@@ -113,6 +113,10 @@ type + any kind-specific types (mirror `bbox3dTypes.ts`).
 
 ## Adding a whole new *medium* (e.g. text), not just a kind
 
+> Note: the existing `TextWidget.svelte` is a display-only Tiptap host — it has no
+> seam, renderer or tool, so it is not an example of this. Text *annotation* is
+> still unbuilt.
+
 That is a bigger job: build the widget with `buildSeam(manager, …)`, define a
 `Scene<Medium>Context extends SceneContextBase` with the medium's engine handle, and add
 renderer/tool interfaces mirroring the 2D/3D ones. Everything below the seam

--- a/docs/ARCHITECTURE_TOOLING.md
+++ b/docs/ARCHITECTURE_TOOLING.md
@@ -109,9 +109,10 @@ scene/
   sceneContext.ts   SceneContextBase, MutationSink, LiveAnnotationDraft,
                     LiveDraftSource / LiveDraftChannel, Scene2DReadContext,
                     Scene2DContext, Scene3DContext
+  toolDefinition.ts ToolDefinition — the metadata 2D and 3D tools share (D3)
   renderer.ts       AnnotationRenderer2D + AnnotationEditor2D (+Factory),
                     AnnotationRenderer3DFactory
-  tool.ts           ToolDefinition, DEFAULT_TOOL_2D/3D, Tool2D/ToolHandler2D,
+  tool.ts           DEFAULT_TOOL_2D/3D, Tool2D/ToolHandler2D,
                     Tool3D/ToolHandle3D/AnnotationTool3DProps/ToolHudProps
   registry2d.ts     TOOLS_2D, RENDERER_FACTORIES_2D
   registry3d.ts     TOOLS_3D, RENDERER_FACTORIES_3D
@@ -241,9 +242,15 @@ which both `Scene2DContext` and the widgets' seam satisfy.
 
 ### Adding a new medium (e.g. text)
 
-`TextWidget` calls `buildSeam(manager, …)`, defines `SceneTextContext extends
-SceneContextBase` with its own engine handle (the editor/DOM node), and implements
-text renderer/tool interfaces mirroring the 2D/3D ones. Everything below the seam —
+> A `TextWidget.svelte` already exists (registered via `TextExtension`), but it is a
+> **display-only Tiptap host**: it calls no `buildSeam`, defines no scene context and
+> carries no renderer or tool. It is not an instance of what follows — text
+> *annotation* is still unbuilt.
+
+An annotating text widget would call `buildSeam(manager, …)`, define
+`SceneTextContext extends SceneContextBase` with its own engine handle (the
+editor/DOM node), and implement text renderer/tool interfaces mirroring the 2D/3D
+ones. Everything below the seam —
 `AnnotationCollection`, `MutationQueue`, seed loaders, payload builders, the
 `commit*` helpers, `buildSeam`, `<AnnotationToolbar>` — is reused unchanged. Per
 D10, those text interfaces are written against a real feature, not pre-declared.
@@ -348,7 +355,7 @@ check` at baseline error count and `vitest` green:
 - **DEBT-3 — renderer sync tests (partial → mostly resolved for 2D, 2026-07-30).**
   The 2D *editor* has coverage (`bboxEditor2D.test.ts` fires drag/transform → asserts
   the commit). `bbox3dRenderer2D` now has node-level tests too
-  (`bbox3dRenderer2D.test.ts`, 21 cases): projection math against hand-computed
+  (`bbox3dRenderer2D.test.ts`): projection math against hand-computed
   pixels, per-box independence of the shared scratch buffers, create/destroy
   lifecycle, entity-visibility filtering, degraded inputs (no calibration / no loaded
   image), rotation, and the whole `syncDraft` fast path including its gesture

--- a/docs/ARCHITECTURE_TOOLING.md
+++ b/docs/ARCHITECTURE_TOOLING.md
@@ -6,7 +6,7 @@
 > *not* the app's generic frontend architecture (routing, panels, theming, data
 > layer) — for that see `FRONTEND_ARCHITECTURE.md`.
 >
-> **Status.** Implemented on `refactor/annotation-tools`. The original design
+> **Status.** Implemented and in use. The original design
 > (Phases 0–6, agreed 2026-06-11) plus the **2026-06-29 plugin-symmetry refactor**
 > (Stages 1–5) that brought the 3D pipeline to full parity with 2D, unified the
 > commit path, and extracted the shared widget shell. The seams are internal-only

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -55,7 +55,10 @@
 
 ## Process
 
-- Branch from `frontend/next-ui-init`; conventional commit messages; atomic
-  commits; self-review before each commit.
-- Refactoring phases (see ARCHITECTURE_TOOLING.md migration plan) land as separate PRs;
-  never mix a phase with feature work.
+- Branch from the integration branch the workspace app currently lives on
+  (see the repository's contributing guide — do not hardcode it here, the
+  previous name in this file outlived its branch); conventional commit
+  messages; atomic commits; self-review before each commit.
+- Structural refactors land as their own PRs, separate from feature work
+  (see the refactor history in ARCHITECTURE_TOOLING.md for how the earlier
+  phases were sequenced).

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -33,8 +33,10 @@
 - Strict TypeScript: no implicit `any`, no `var`, prefer `const` and
   immutability. Geometry types are precise tuples (e.g.
   `[number, number, number, number]`), not `number[]`.
-- UI text goes through translation keys (`labelKey` on `ToolDefinition`), never
-  string literals in components.
+- **UI text is written as literal strings.** The app has no i18n layer and is
+  not getting one — there is no translation module, no message catalogue, and
+  no `labelKey` indirection. `ToolDefinition.label` is the displayed text.
+  Write the string where it is shown; do not add a key/lookup layer for it.
 - No magic numbers: named constants in a `*Constants.ts` module next to their
   consumer (existing pattern: `boxEditorConstants.ts`).
 - Pre-allocate Three.js scratch objects (vectors, quaternions, meshes) as class

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -6,10 +6,10 @@
 ## Architecture rules
 
 - **New annotation kinds are plugins.** A new kind lives entirely under
-  `lib/annotations/kinds/<kind>/` (geometry type, payload builder, renderer,
-  tools) plus registry registrations. If adding a kind requires editing a widget
-  component, a mode union, or the mutation queue, the change is wrong — fix the
-  seam instead.
+  `lib/annotations/kinds/<2d|3d>/<kind>/` (geometry type, payload builder,
+  seed loader, renderer, editor/tool) plus registry registrations. If adding a
+  kind requires editing a widget component, a mode union, or the mutation
+  queue, the change is wrong — fix the seam instead.
 - **Widgets are hosts, not tools.** Widget components own scene setup (Konva
   stage / Threlte canvas), layout, and delegation. They must not contain
   tool-specific branches (`if (mode === "draw-x")`) or annotation-kind logic.

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -11,8 +11,8 @@ on disk, through the FastAPI backend and the REST gateway, into the reactive
 workspace, and out to the widgets / tools / renderers the user interacts with.
 
 > Companion docs:
-> - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — the *why* (refactor decisions D1–D6,
->   the plugin model, known debts).
+> - [`ARCHITECTURE_TOOLING.md`](./ARCHITECTURE_TOOLING.md) — the *why* (design
+>   decisions D1–D10, the plugin model, known debts).
 > - This file — the *how it connects* (the layers, the contracts, the flows).
 
 ---
@@ -80,8 +80,8 @@ Three ideas hold it together:
 - **LanceDB** tables hold the rows; **DuckDB** is used for analytics. Media is
   served separately via `MEDIA_DIR`.
 - Tables are organised into **`SchemaGroup`s**: `RECORD`, `VIEW`, `ENTITY`,
-  `ANNOTATION`, `ENTITY_DYNAMIC_STATE`, `EMBEDDING`. `dataset.info.groups.get(group)`
-  returns every table in a group — this is how the backend sweeps "all annotation
+  `ANNOTATION`, `ENTITY_DYNAMIC_STATE`, `EMBEDDING`, `TIMESERIES`.
+  `dataset.info.groups.get(group)` returns every table in a group — this is how the backend sweeps "all annotation
   tables" or "all entity tables" without hard-coding kinds.
 - A row's `entity_id` is the foreign key from an annotation to its entity.
 
@@ -296,7 +296,7 @@ lines, with no widget, scene, or queue edits.
 
 ---
 
-## 8. End-to-end flows
+## 7. End-to-end flows
 
 ### A) Load a record
 ```
@@ -364,7 +364,7 @@ reassignEntity(annotation, choice, ctx)
 
 ---
 
-## 9. Reactivity & rendering notes
+## 8. Reactivity & rendering notes
 
 - Stateful domain classes live in `.svelte.ts` files so the runes compiler picks
   up `$state`/`$derived`/`$effect` (`AnnotationCollection`, `MutationQueue`,
@@ -373,13 +373,16 @@ reassignEntity(annotation, choice, ctx)
   `annotations.items.length`, `annotations.selectedId`, and
   `manager.visibleEntityIds`; the renderer reconciles Konva nodes.
 - **3D**: `PointCloudScene` uses **Threlte on-demand rendering** — it redraws on
-  reactive invalidation. `allBboxes3d` (`$derived`) feeds the scene; the `BoxEditor`
-  owns pointer interaction and a reactive preview. (Implication: a thrown error in
-  a save-time recompute can stall the on-demand loop — see the freeze investigation.)
+  reactive invalidation. Nothing is pushed into the scene: it mounts one component
+  per `RENDERER_FACTORIES_3D` entry and each pulls its kind from
+  `ctx.collection.byKind(...)` (`BBox3DRenderer.svelte`). The `BoxEditor`
+  (`kinds/3d/bbox3d/boxEditor.svelte.ts`) owns pointer interaction and a reactive
+  preview. (Implication: a thrown error in a save-time recompute can stall the
+  on-demand loop — see the freeze investigation.)
 
 ---
 
-## 10. Where everything lives (file map)
+## 9. Where everything lives (file map)
 
 ```
 ui/apps/web/src/lib/
@@ -403,19 +406,22 @@ ui/apps/web/src/lib/
 │  │  ├─ registry2d.ts / registry3d.ts       TOOLS_*, RENDERER_FACTORIES_*
 │  │  ├─ sceneContext.ts                      SceneContextBase, Scene2DReadContext,
 │  │  │                                       Scene2DContext, Scene3DContext, MutationSink
+│  │  ├─ toolDefinition.ts                    ToolDefinition (shared 2D/3D metadata)
 │  │  ├─ renderer.ts / tool.ts                Renderer/Editor + Tool contracts
+│  │  ├─ selectTool2D.ts                      kind-agnostic select/delete tool
 │  │  └─ scene2dGeometry.ts                   pixel↔normalized helpers, PixelFrame
 │  └─ kinds/<2d|3d>/<kind>/                  per-kind: payloadBuilder, seedLoader,
 │                                            renderer, editor/tool (+ 3D: overlay/session/hud)
 └─ components/
    ├─ widgets/AnnotationToolbar.svelte        shared toolbar; sceneSeam.ts (buildSeam)
    ├─ widgets/image/ImageWidget.svelte        Konva host, builds Scene2DContext
-   └─ widgets/point-cloud/PointCloudWidget…   Threlte host; PointCloudScene, boxEditor
+   ├─ widgets/point-cloud/PointCloudWidget…   Threlte host; PointCloudScene, camera
+   └─ widgets/TextWidget.svelte               Tiptap host — display only, no seam yet
 ```
 
 ---
 
-## 11. Contracts cheat-sheet
+## 10. Contracts cheat-sheet
 
 | Contract | Defined in | Implemented / consumed by |
 |---|---|---|

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -28,11 +28,6 @@ accepted to keep the first version small — each is a decision, not an oversigh
   it onto. "Fit layout" does re-tile them on screen; they just are not persisted.
 - **Concurrent tabs: last writer wins.** No `storage` event listener, so two tabs
   on the same dataset overwrite each other's arrangement.
-- **UI strings are literals.** `ui/apps/web` has no i18n infrastructure at all
-  (no translation module, no `labelKey` usage), so the layout controls follow the
-  app's existing convention and violate CODING_STANDARDS.md's translation-key
-  rule along with every other component. Introducing i18n is its own piece of
-  work, tracked here rather than silently accepted.
 - **The arrangement no longer adapts to the viewport.** Before this feature every
   record opened with a placement recomputed for the current screen. Once a
   dataset has been arranged, its records replay cell coordinates captured on

--- a/docs/specs/e2e-checklist.md
+++ b/docs/specs/e2e-checklist.md
@@ -1,10 +1,15 @@
 # 0.8.0 Import/Export — Manual End-to-End Validation Checklist
 
-Companion to [data-import-export.md](./data-import-export.md). The redesign lands as a PR
-stack on `arch/data-import`; nothing merges to `main` until every checkpoint below has been
-validated by hand. Automated gates (full pytest suite locally and in CI on every PR) run
-first — this checklist covers what automation cannot: a human confirming the real app
-behaves correctly on real data.
+Companion to [data-import-export.md](./data-import-export.md).
+
+> **Status: completed.** The redesign shipped in 0.8.0; the `arch/data-import` PR stack is
+> merged and the branch is gone. This checklist is kept as the reusable manual-validation
+> procedure for the import/export path — re-run the relevant checkpoints when touching
+> `datasets/io/`, not as a gate on unmerged work.
+
+Automated gates (full pytest suite locally and in CI on every PR) run first — this
+checklist covers what automation cannot: a human confirming the real app behaves
+correctly on real data.
 
 **Always test on a COPY of a library, never the original.** Opening a dataset with 0.8.0
 code performs a one-time additive migration (stamps `spec_version: 2` in `info.json` and,


### PR DESCRIPTION
## Issue

<!--- Link to the issue related to this feature if it exists. -->

Fixes #

## Description

Docs only — no code changes, no behaviour change. Four commits bringing `docs/` and `AGENTS.md` back in line with what the branch actually contains.

The developer docs had drifted far enough to contradict each other and to send readers at code that no longer exists. Every correction below was verified against this branch's tree.

### 1. The translation-key rule the project never adopted

`CODING_STANDARDS.md` required UI text to go through translation keys, via a `labelKey` field on `ToolDefinition`. That field does not exist: `ToolDefinition` declares `label: string` ("Toolbar tooltip text"), `labelKey` appears nowhere in `ui/`, and neither app declares an i18n dependency or ships a translation module.

`OPEN_QUESTIONS.md` said the opposite in its own words — that the app has no i18n infrastructure at all and that every component therefore violates the rule. Two docs in the same directory disagreeing leaves a reader unable to tell which to follow.

The decision is that the project does not get an i18n layer, so the docs now state the real convention — literal strings, written where they are displayed. `OPEN_QUESTIONS.md` drops the entry rather than keeping it open, per its own header ("remove it once resolved, record the outcome in the relevant doc"), and the outcome is recorded in `AGENTS.md`.

### 2. References to code that moved or went away

- `FRONTEND_ARCHITECTURE.md` linked a companion `ARCHITECTURE.md` that is not in the repo (it is `ARCHITECTURE_TOOLING.md`), and advertised decisions D1–D6 where that document defines D1–D10.
- It described `allBboxes3d` feeding the point-cloud scene. That derivation and the `bboxes3d` prop were removed by the 2026-06-29 plugin-symmetry refactor — which `ARCHITECTURE_TOOLING.md` documents in the same directory. The two docs disagreed about how 3D rendering works.
- Its `SchemaGroup` list was missing `TIMESERIES`.
- Its section numbering skipped 7, left over from folding that section into 6. Sections 8–11 are renumbered 7–10; the two `§N` cross-references elsewhere point at sections 4 and 5 and are unaffected.
- Both docs put `ToolDefinition` in `scene/tool.ts`. It lives in `scene/toolDefinition.ts`; `tool.ts` only re-exports it.
- `CODING_STANDARDS.md` still put a kind at `kinds/<kind>/`, from before the 2d/3d split.

Both architecture docs use "a new medium, e.g. text" as their worked hypothetical, and a `TextWidget.svelte` has since appeared that is a display-only Tiptap host — no seam, no renderer, no tool. Left unremarked it reads as an implementation of the recipe, so each now says plainly that it is not one.

### 3. Branches that no longer exist

`ARCHITECTURE_TOOLING.md` said "Implemented on `refactor/annotation-tools`". `CODING_STANDARDS.md` said "Branch from `frontend/next-ui-init`", contradicting `AGENTS.md`. `specs/e2e-checklist.md` read as a gate on unmerged work on `arch/data-import`. All three branches are merged and deleted.

`CODING_STANDARDS.md` now points at the contributing guide instead of naming another branch that will go stale the same way, and says why. The e2e checklist is marked completed and repositioned as the reusable manual-validation procedure to re-run when touching `datasets/io/`.

### 4. AGENTS.md pointed at the wrong frontend app

This is the one most likely to have cost people time. `AGENTS.md` described `ui/apps/pixano` as the app to develop and pointed every command at it. `hatch_build.py` calls that one the "legacy frontend"; `ui/apps/web` is where the annotation architecture, its whole test suite, and all four `docs/` frontend documents live. Following `AGENTS.md` meant running the dev server and the tests for the app being migrated away from.

Also corrected there: `ui/packages/` was documented as holding shared component libraries (the directory does not exist, and the apps share no code — `restTypes.ts` / `apiClient.ts` are hand-copied); the tech stack listed one library set for both apps, naming `phosphor-svelte` for `apps/web` which imports `lucide-svelte` and never phosphor, and misspelling Threlte as "ThretleJS"; the release-build section told you to build the UI before `uv build`, which `hatch_build.py` already does for both apps; and the backend module list described `datasets` as holding the v1 folder builders, deleted in the 0.8.0 io redesign, while omitting `features`.

## Notes for review

**Scope was deliberately limited to what is true on this branch.** A further set of corrections applies only once the annotation-kind migration lands (the six-kind inventory, D5 being discharged, DEBT-3's `bboxRenderer2D.sync()` coverage, and the generic `listAnnotations` REST surface). Those are held back and travel with that work, so nothing here asserts anything this branch cannot back.

**Debt ledger left alone.** DEBT-6 (typed per-tool session contract, waiting on a second 3D tool — `TOOLS_3D` is still navigate + drawBBox3D) and DEBT-7 (3D boxes not selectable from an image view) were checked against the code and are genuinely still open.

**Two things found but not fixed here**, both arguably worth their own issue:
- `AnnotationKind` declares `"mask"` and `GeometryByKind.mask` is `unknown`, but no `kinds/2d/mask/` exists and mask appears in none of the registries. The union promises a kind nothing can serve, and that `unknown` sits awkwardly against the "precise geometry types" rule in `CODING_STANDARDS.md`.
- CI never type-checks `apps/web`. `frontend.yml` runs `pnpm -C apps/pixano run check`, with a comment saying apps/web is covered by Test and Build — but `vite build` is not `svelte-check`. Both architecture docs assert "`pnpm run check` must not add errors" as a rule for that app, and nothing enforces it.

**One copy could not be fixed:** `.claude/CLAUDE.md` carries the same app inversion and the same i18n rule, but `.gitignore` excludes `.claude/`, so it has to be corrected locally per machine.