### PR TITLE
fix(ci): restore the release docs publish after the pnpm migration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,10 +30,11 @@ permissions:
   pages: write
   id-token: write
 
-# One queue per ref: deploys from main are serialized and never cancelled,
-# while pull request builds run in their own group and supersede themselves.
+# Deploys share the "pages" queue with publish.yml so two workflows can never
+# publish to GitHub Pages at once; pull request builds get their own
+# cancellable group and never block a deploy.
 concurrency:
-  group: pages-${{ github.ref }}
+  group: ${{ github.event_name == 'pull_request' && github.ref || 'pages' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,12 +66,18 @@ jobs:
         with:
           ref: main
 
+      # Version comes from "packageManager" in docs-astro/package.json.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: docs-astro/package.json
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: docs-astro/package-lock.json
+          cache: pnpm
+          cache-dependency-path: docs-astro/pnpm-lock.yaml
 
       - name: Setup Python 3.12
         uses: actions/setup-python@v6
@@ -85,18 +91,18 @@ jobs:
         run: uv sync --group docs
 
       - name: Install Node dependencies
-        run: npm ci
+        run: pnpm i --frozen-lockfile
         working-directory: docs-astro
 
       - name: Generate API reference
         run: uv run python docs-astro/scripts/generate_api_docs.py
 
       - name: Build Astro site
-        run: npx astro build
+        run: pnpm exec astro build
         working-directory: docs-astro
 
       - name: Run Pagefind
-        run: npx pagefind --site dist
+        run: pnpm exec pagefind --site dist
         working-directory: docs-astro
 
       - name: Upload artifact


### PR DESCRIPTION
Regression from #722, found while reviewing the documentation for 0.8. **This would have broken the docs deploy for the 0.8.0 release itself.**

## The bug

#722 standardized `docs-astro` on pnpm and deleted `docs-astro/package-lock.json`. It migrated `.github/workflows/docs.yml` — but `publish.yml` contains a **second, duplicate docs build+deploy job** (`publish_docs`) that was left on npm:

```
cache: npm
cache-dependency-path: docs-astro/package-lock.json   # deleted in #722
run: npm ci                                            # no lockfile → fails
run: npx astro build
run: npx pagefind --site dist
```

That job triggers on `release: types: [published]` and checks out `ref: main`. The file still exists on `main` today, so nothing is broken *yet* — it breaks the moment `releases/0.8` merges to `main` and 0.8.0 is published, which is the next step in the release. I migrated `docs.yml` without grepping for other consumers of the lockfile; that was my miss.

## Fix

`publish_docs` now mirrors `docs.yml` step for step: `pnpm/action-setup@v4` reading the version from `docs-astro/package.json`'s `packageManager`, `cache: pnpm` against `pnpm-lock.yaml`, `pnpm i --frozen-lockfile`, `pnpm exec astro build`, `pnpm exec pagefind --site dist`. Verified by diffing both step lists: they are now identical apart from the deliberate `ref: main` checkout pin and the extra deploy step.

## Also fixed: the two workflows could deploy Pages concurrently

#722 also changed `docs.yml`'s concurrency group to `pages-${{ github.ref }}`, while `publish.yml` still uses `pages`. Different groups means a release publish and a push-to-main docs deploy were no longer serialized against each other — two workflows could publish to the same Pages site at once.

`docs.yml` now uses `pages` for push/dispatch (sharing publish.yml's queue again) and a per-ref cancellable group only for pull requests, so PR builds still never block a deploy.

## Notes

The duplication itself is the underlying hazard — two hand-synced definitions of the same pipeline. Consolidating them (a `workflow_call` reusable workflow) is worth a follow-up; this PR only makes them agree again.

## Checks

Ran the publish job's exact sequence locally: `pnpm i --frozen-lockfile` → generate-api → `pnpm exec astro build` (141 pages) → `pnpm exec pagefind` (141 indexed). Both workflows parse, and `prettier --check` is clean under 3.x and the 2.8.8 that `backend.yml` gates workflow YAML with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)