### PR TITLE
docs: align the documentation with 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Docker](https://img.shields.io/docker/v/pixano/pixano?sort=semver&label=release&logo=docker&logoColor=white)](https://hub.docker.com/r/pixano/pixano/)
 [![Coverage](https://img.shields.io/codecov/c/github/pixano/pixano/main?logo=codecov&logoColor=white)](https://codecov.io/github/pixano/pixano)
 [![Tests](https://img.shields.io/github/actions/workflow/status/pixano/pixano/backend.yml?label=tests&branch=main)](https://github.com/pixano/pixano/actions/workflows/backend.yml)
-[![Documentation](https://img.shields.io/website?url=https%3A%2F%2Fpixano.github.io%2F&up_message=online&down_message=offline&label=docs)](https://pixano.github.io)
+[![Documentation](https://img.shields.io/website?url=https%3A%2F%2Fpixano.github.io%2Fpixano%2F&up_message=online&down_message=offline&label=docs)](https://pixano.github.io/pixano/)
 [![Python version](https://img.shields.io/pypi/pyversions/pixano?color=blue&logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-CeCILL--C-blue.svg)](LICENSE)
 
@@ -103,7 +103,7 @@ For more details on running Pixano locally (frontend setup, testing, formatting)
 
 # Using Pixano
 
-Please refer to our <a href="https://pixano.github.io/pixano/latest/getting_started/" target="_blank">Getting started</a> guide for information on how to launch and use the Pixano app, and how to create and use Pixano datasets.
+Please refer to our <a href="https://pixano.github.io/pixano/getting_started/" target="_blank">Getting started</a> guide for information on how to launch and use the Pixano app, and how to create and use Pixano datasets.
 
 # Contributing
 

--- a/docs-astro/src/components/Banner.astro
+++ b/docs-astro/src/components/Banner.astro
@@ -7,11 +7,11 @@
 <div class="banner" id="announcement-banner">
   <div class="banner-inner">
     <a
-      href="https://github.com/pixano/pixano/releases/tag/v0.7.2"
+      href="https://github.com/pixano/pixano/releases/tag/v0.8.0"
       target="_blank"
       rel="noopener noreferrer"
     >
-      Pixano v0.7.2 is out &mdash; see what's new!
+      Pixano v0.8.0 is out &mdash; see what's new!
     </a>
     <button
       class="banner-close"

--- a/docs-astro/src/config/navigation.ts
+++ b/docs-astro/src/config/navigation.ts
@@ -229,10 +229,6 @@ export const sidebarNav: Record<string, NavSection[]> = {
           href: "/api_reference/module/inference/registry/",
         },
         { title: "types", href: "/api_reference/module/inference/types/" },
-        {
-          title: "mask_generation",
-          href: "/api_reference/module/inference/mask_generation/",
-        },
       ],
     },
     {

--- a/docs-astro/src/pages/api_reference/index.astro
+++ b/docs-astro/src/pages/api_reference/index.astro
@@ -6,19 +6,31 @@ import Card from "../../components/Card.astro";
 
 <DocsLayout title="API Reference" section="api_reference">
   <h1>Pixano API reference</h1>
-  <p>Here you will find the documentation for all of our Python API.</p>
+  <p>
+    Reference for Pixano's Python API, generated from the source. Every module is
+    also reachable from the sidebar and through search.
+  </p>
 
   <CardGrid>
-    <Card title="App" href="/api_reference/app/" icon="api">
-      The Pixano application, REST API, and CLI entry points.
+    <Card title="Datasets" href="/api_reference/module/datasets/dataset/" icon="database">
+      The <code>Dataset</code> class: open a dataset, query records, and manipulate tables.
     </Card>
-    <Card title="Datasets" href="/api_reference/datasets/" icon="database">
-      Backend to construct, import, export, and manipulate datasets.
+    <Card title="Import & export" href="/api_reference/module/datasets/io/api/" icon="download">
+      The <code>analyze → plan → ingest</code> core shared by the CLI, the REST API, and Python.
     </Card>
-    <Card title="Features" href="/api_reference/features/" icon="code">
-      Schemas and data types for items, views, annotations, and more.
+    <Card title="Schemas" href="/api_reference/module/schemas/schema_group/" icon="code">
+      The schema groups and the record, view, entity, and annotation types built on them.
     </Card>
-    <Card title="Utils" href="/api_reference/utils/" icon="wrench">
+    <Card title="REST API" href="/api_reference/module/api/main/" icon="api">
+      The FastAPI application and its routers.
+    </Card>
+    <Card title="CLI" href="/api_reference/module/cli/data/" icon="target">
+      The <code>pixano data</code> commands: import, export, jobs, and migration.
+    </Card>
+    <Card title="Inference" href="/api_reference/module/inference/provider/" icon="robot">
+      Providers and tasks used to reach a pixano-inference server.
+    </Card>
+    <Card title="Utils" href="/api_reference/module/utils/python/" icon="wrench">
       Utility functions at the library level.
     </Card>
   </CardGrid>

--- a/docs-astro/src/pages/cookbook/entity_linking.mdx
+++ b/docs-astro/src/pages/cookbook/entity_linking.mdx
@@ -27,11 +27,16 @@ An entity-linking dataset has an image and a text document per item. Organize yo
 
 ```
 mel_source/
+  dataset.yaml
   train/
-    image_001.jpg
-    image_002.jpg
+    images/
+      image_001.jpg
+      image_002.jpg
     metadata.jsonl
 ```
+
+Media paths in `metadata.jsonl` are relative to the split folder, so `images/image_001.jpg`
+below resolves to `mel_source/train/images/image_001.jpg`.
 
 Each line in `metadata.jsonl` describes one item with both an image view and a text view, plus entities that link regions across both:
 
@@ -85,7 +90,7 @@ Key elements:
 - `text_span` is the annotation kind that marks character ranges in the text.
 - Entities can be linked to both a `bbox` (on the image) and a `text_span` (on the text).
 
-See [Importing Data](/getting_started/importing_data/) for the full reference.
+See [Importing Data](/pixano/getting_started/importing_data/) for the full reference.
 
 ### Run the import
 
@@ -103,30 +108,31 @@ pixano server run ./my_data
 
 ## Explore in the UI
 
-### Item page — entity linking mode
+### Workspace — entity linking mode
 
-When you open an item from an entity-linking dataset, you see:
+When you open a record from an entity-linking dataset, you see:
 
 - **Image** in the center — with bounding boxes and masks drawn on it.
-- **Text panel** on the left — displaying the full text with color-coded spans. Each text span is highlighted with the same color as its linked entity's bounding box.
+- **Text panel** on the side — displaying the full text with color-coded spans. Each text span is highlighted with the same color as its linked entity's bounding box.
 
 #### Text panel interactions
 
-- **Click a text span** to select the corresponding entity. The entity's bounding box highlights on the image, and its object card opens in the right panel.
-- **Select text and click "Tag Selected Text"** to create a new text span annotation. The creation panel opens so you can assign it to an existing entity or create a new one.
+- **Click a text span** to select the corresponding entity. The entity's bounding box highlights on the image, and its card opens in the right panel.
+- **Select text and click "Tag selection"** to create a new text span annotation. The creation form opens so you can assign it to an existing entity or create a new one.
 
-#### Object panel
+#### Entities tab
 
-The Object panel on the right shows all entities. Expand an entity card to see:
+The **Entities** tab on the right lists every entity in the record. Expand an entity card to see:
 
-- **Features** — entity attributes (name, etc.).
-- **Objects** — sub-objects (bounding boxes, masks, text spans).
-- **Text spans** — a table showing each text span's features alongside the highlighted text.
+- **Attributes** — the entity's fields (name, category, and anything else your schema declares).
+- **Annotations** — every annotation attached to it (bounding boxes, masks, text spans), with each text span showing its highlighted text.
+
+The neighbouring **Record** tab holds record-level information: status, record attributes, and per-view metadata.
 
 <Callout type="tip" title="Linking workflow">
-1. Select text in the text panel and click "Tag Selected Text".
-2. In the creation prompt, choose an existing entity (or create a new one).
-3. Draw a bounding box on the image for the same entity.
+1. Select text in the text panel and click **Tag selection**.
+2. In the creation form, pick an existing entity under **Parent entity**, or keep **Create new entity**.
+3. Draw a bounding box on the image and link it to the same entity.
 4. Both annotations are now linked through the shared entity.
 </Callout>
 
@@ -138,11 +144,11 @@ Use the **bounding box tool** on the image to draw regions around the entity. Wh
 
 ### Text spans
 
-Select text in the text panel and click **"Tag Selected Text"**. Choose the same entity that has the bounding box annotation.
+Select text in the text panel and click **Tag selection**. Choose the same entity that has the bounding box annotation.
 
 ### Masks
 
-If your dataset includes `CompressedRLE` masks, you can also use the polygon tool or SAM to create segmentation masks linked to entities.
+If your schema lists `mask`, you can also use the polygon tool or smart segmentation to create segmentation masks linked to entities.
 
 ## Next steps
 

--- a/docs-astro/src/pages/cookbook/multi_view_detection.mdx
+++ b/docs-astro/src/pages/cookbook/multi_view_detection.mdx
@@ -104,7 +104,7 @@ schema:
   annotations: [bbox]
 ```
 
-Note `views` has two entries: `"rgb"` and `"thermal"`, both images. This tells Pixano to display them side by side. See [Importing Data](/getting_started/importing_data/) for the full reference.
+Note `views` has two entries: `"rgb"` and `"thermal"`, both images. This tells Pixano to display them side by side. See [Importing Data](/pixano/getting_started/importing_data/) for the full reference.
 
 Import:
 
@@ -208,10 +208,10 @@ You can annotate objects in both the RGB and thermal views. Create a bounding bo
 All annotation tools work the same as in single-view mode:
 
 - **Bounding boxes** — click and drag on any view.
-- **Polygons and keypoints** — available per view.
-- **Smart segmentation** — if SAM embeddings are precomputed for a view, the magic wand tool works on that view.
+- **Polygons, polylines and brush** — available per view.
+- **Smart segmentation** — with a [pixano-inference](https://github.com/pixano/pixano-inference) server connected and a segmentation model available, the magic wand works on any view.
 
-In video mode, the associate tool lets you merge tracks across frames, just as with single-view video datasets.
+Every annotation you draw is linked to an entity, so the same entity can carry boxes in several views at once.
 
 ## Next steps
 

--- a/docs-astro/src/pages/cookbook/object_detection.mdx
+++ b/docs-astro/src/pages/cookbook/object_detection.mdx
@@ -79,7 +79,7 @@ Let's look at each piece:
 
 - **`workspace: image`** — Provides the single-image view named `"image"` and tells the UI to use the single-image viewer with annotation tools.
 
-See [Importing Data](/getting_started/importing_data/) for the full `dataset.yaml` and JSONL reference.
+See [Importing Data](/pixano/getting_started/importing_data/) for the full `dataset.yaml` and JSONL reference.
 
 ## Import the dataset
 
@@ -99,6 +99,7 @@ This produces a source folder organized by splits:
 
 ```
 voc_sample/
+  dataset.yaml
   train/
     000032.jpg
     000045.jpg
@@ -109,6 +110,9 @@ voc_sample/
     ...
     metadata.jsonl
 ```
+
+`dataset.yaml` sits at the root of the source folder — that is where `pixano data import`
+looks for it.
 
 ### What's inside metadata.jsonl
 
@@ -161,7 +165,7 @@ Open **http://127.0.0.1:7492** in your browser. You will see the Pixano library 
 
 The core annotation tool for object detection. In the annotation workspace, you draw rectangles over objects in the image. Each bounding box is linked to an entity, which carries the object's category and any custom fields you defined.
 
-Because annotations and entities are stored separately, you can attach multiple annotations to the same entity. For example, you could have a bounding box *and* a segmentation mask for the same "car" — each stored in its own table, both linked to the same entity. This is exactly why we included `CompressedRLE` in the schema even though VOC only provides bounding boxes.
+Because annotations and entities are stored separately, you can attach multiple annotations to the same entity. For example, you could have a bounding box *and* a segmentation mask for the same "car" — each stored in its own table, both linked to the same entity. This is exactly why we listed `mask` alongside `bbox` in the schema even though VOC only provides bounding boxes.
 
 ### Interactive segmentation with SAM
 

--- a/docs-astro/src/pages/cookbook/video_tracking.mdx
+++ b/docs-astro/src/pages/cookbook/video_tracking.mdx
@@ -99,7 +99,7 @@ Compared to the image dataset schema, several things are new:
 
 - **`mask`** — Segmentation masks in compressed run-length encoding. Each mask is a per-frame annotation linked to a tracklet and entity.
 
-You could also add per-frame entity state (e.g. `entity_dynamic_state: { attrs: { occluded: { type: bool, default: false } } }`) — DAVIS doesn't need it beyond the mask itself. See [Importing Data](/getting_started/importing_data/) for the full reference.
+You could also add per-frame entity state (e.g. `entity_dynamic_state: { attrs: { occluded: { type: bool, default: false } } }`) — DAVIS doesn't need it beyond the mask itself. See [Importing Data](/pixano/getting_started/importing_data/) for the full reference.
 
 ## Import the dataset
 
@@ -179,13 +179,13 @@ Pixano validates every line first and prints a plan; use `--dry-run` to only val
 pixano server run ./my_library
 ```
 
-Open **http://127.0.0.1:7492** and click the DAVIS dataset card. When you open a video item, the UI switches to video mode: the current frame is displayed in the center, and the **Video Inspector** panel appears at the bottom with a timeline, track bars for each entity, and playback controls.
+Open **http://127.0.0.1:7492** and click the DAVIS dataset card. When you open a video record, the UI switches to video mode: the current frame is displayed in the center, and the **Video Inspector** appears at the bottom with the timeline and playback controls.
 
 ## Key Pixano features for video tracking
 
 ### Tracklets
 
-A tracklet is the core concept that connects single-frame annotations into a temporal identity. In the Video Inspector, each entity's track is displayed as a horizontal bar along the timeline. Colored segments within the bar represent tracklets — continuous periods where the entity is visible.
+A tracklet is the core concept that connects single-frame annotations into a temporal identity. Select an entity in the **Entities** tab to reveal its track as a horizontal bar along the timeline; you can pin up to two entities to compare them side by side. Colored segments within a bar represent tracklets — continuous periods where the entity is visible.
 
 Keyframes (frames with real annotations) are shown as dots on the tracklet. Frames between keyframes can be interpolated automatically for bounding boxes and keypoints.
 

--- a/docs-astro/src/pages/cookbook/vqa.mdx
+++ b/docs-astro/src/pages/cookbook/vqa.mdx
@@ -88,7 +88,7 @@ Let's break this down:
 
 - **`workspace: image_vqa`** — Provides the single-image view and switches the UI to VQA mode: the image is displayed alongside a conversation panel for managing questions and answers.
 
-See [Importing Data](/getting_started/importing_data/) for the full `dataset.yaml` and JSONL reference.
+See [Importing Data](/pixano/getting_started/importing_data/) for the full `dataset.yaml` and JSONL reference.
 
 ## Import the dataset
 
@@ -191,7 +191,7 @@ The `entity_ids` field on messages lets you link a question to specific entities
 
 This is where Pixano differs from typical VQA annotation tools. Most VQA platforms only handle questions and answers — the visual content is view-only. Pixano treats VQA images as full annotation workspaces.
 
-Because the schema includes `BBox` and `CompressedRLE` alongside `Message`, you can:
+Because the schema lists `bbox` and `mask` alongside `message`, you can:
 
 - **Draw bounding boxes** around the objects that questions refer to
 - **Create segmentation masks** for precise spatial grounding
@@ -225,7 +225,7 @@ Let's connect the dots:
 
 - **VQAv2** is a visual question answering benchmark where each image is paired with natural language questions and multiple human answers, designed to test whether models truly ground their reasoning in visual content.
 - In Pixano, questions and answers are stored as **Message** annotations with types (`QUESTION`, `ANSWER`), grouped by `conversation_id`. The `IMAGE_VQA` workspace provides a dedicated conversation panel alongside the image.
-- Pixano's unique strength is **combining Q&A with spatial annotation**: by including `BBox` and `CompressedRLE` in the schema, you can annotate the entities that questions refer to, creating grounded VQA datasets.
+- Pixano's unique strength is **combining Q&A with spatial annotation**: by listing `bbox` and `mask` in the schema, you can annotate the entities that questions refer to, creating grounded VQA datasets.
 - **VLM integration** enables a human-in-the-loop workflow where models generate draft questions and answers that annotators review and correct.
 
 ## Next steps

--- a/docs-astro/src/pages/getting_started/custom_importers.mdx
+++ b/docs-astro/src/pages/getting_started/custom_importers.mdx
@@ -110,6 +110,6 @@ my_format = "my_package.importer:MY_FORMAT"
 </Callout>
 
 <PrevNext
-  prev={{ href: "/getting_started/importing_data/", label: "Importing Data" }}
-  next={{ href: "/cookbook/", label: "Cookbook" }}
+  prev={{ title: "Importing Data", href: "/getting_started/importing_data/" }}
+  next={{ title: "Cookbook", href: "/cookbook/" }}
 />

--- a/docs-astro/src/pages/getting_started/importing_data.mdx
+++ b/docs-astro/src/pages/getting_started/importing_data.mdx
@@ -15,7 +15,7 @@ Pixano 0.8 imports and exports datasets as plain files — no Python required. Y
 
 - **Importing**: the folder layout, the `metadata.jsonl` line format (JSONL v2), the `dataset.yaml` schema spec, and media storage options
 - **Exporting**: how to export a dataset, including record base fields with `--include-record-field`
-- The CLI: `import`, `export`, `formats`, and `migrate-jsonl`
+- The CLI: `import`, `export`, `formats`, `jobs`, `migrate-jsonl`, `optimize`, and `fix-creation-dates`
 
 </Callout>
 
@@ -227,6 +227,28 @@ Pixano stores media one of two ways (spec §6):
 
 Mixed datasets are legal: local images embed while, say, LeRobot episode videos stay as `https://` URIs. The dataset records itself as `mixed`.
 
+## Other import formats
+
+Besides JSONL v2, Pixano ships importers for two common formats. They are detected
+automatically, so the `import` command is the same — only the extra dependency differs.
+
+| Format | Install | Notes |
+|--------|---------|-------|
+| **COCO** | `pip install "pixano[coco]"` | Object-detection style JSON. Streamed in two passes, so very large annotation files work. |
+| **LeRobot** (v2.1 and v3) | `pip install "pixano[lerobot]"` | Robotics episodes become annotatable frame sequences; `action` and `observation.state` land in a `timeseries` table. |
+
+LeRobot datasets can be pulled straight from the Hugging Face Hub, downloading only the
+episodes you ask for:
+
+```sh
+pixano data import /path/to/data_dir org/dataset-name --episodes '0:4'
+```
+
+Use `--episodes '0:4'` or `--episodes '1,3'` to select a subset, and `--max-frames` to cap the
+number of frames per episode.
+
+Run `pixano data formats` to list every format available in your installation.
+
 ## Exporting Data
 
 ### General
@@ -238,6 +260,18 @@ pixano data export /path/to/data_dir <dataset_name> <dest>
 ```
 
 produces a self-contained source folder (JSONL files + `dataset.yaml`) ready for re-import or sharing.
+
+Two options control the output:
+
+| Option | Description |
+|--------|-------------|
+| `--format` | `pixano_jsonl` (default) or `coco`. |
+| `--media` | `files` (default — write embedded media out as files) or `uris` (write the stored URIs verbatim). |
+
+```sh
+# Export to COCO instead of JSONL v2
+pixano data export /path/to/data_dir my_dataset ./out --format coco
+```
 
 The exported JSONL contains every field Pixano stores — views, entities, annotations, and their ids — in the exact format described in the [Importing Data](#importing-data) section above.
 
@@ -350,6 +384,6 @@ Everything 0.7 silently guessed — bbox normalization from value ranges, mentio
 </Callout>
 
 <PrevNext
-  prev={{ href: "/getting_started/key_concepts/", label: "Key Concepts" }}
-  next={{ href: "/cookbook/", label: "Cookbook" }}
+  prev={{ title: "Key Concepts", href: "/getting_started/key_concepts/" }}
+  next={{ title: "Cookbook", href: "/cookbook/" }}
 />

--- a/docs-astro/src/pages/getting_started/index.astro
+++ b/docs-astro/src/pages/getting_started/index.astro
@@ -14,13 +14,19 @@ import Card from "../../components/Card.astro";
 
   <CardGrid>
     <Card title="Installation" href="/getting_started/installing_pixano/" icon="download">
-      Install Pixano with pip in a virtual environment.
+      Install Pixano and the optional format extras.
     </Card>
     <Card title="Quickstart" href="/getting_started/quickstart/" icon="rocket">
-      Import a dataset with pre-annotations and launch the app in minutes.
+      Define a schema, import your own images, and launch the app in minutes.
     </Card>
     <Card title="Key Concepts" href="/getting_started/key_concepts/" icon="lightbulb">
-      Understand the data model: items, views, entities, annotations, and more.
+      Understand the data model: records, views, entities, annotations, and more.
+    </Card>
+    <Card title="Importing & Exporting Data" href="/getting_started/importing_data/" icon="download">
+      The JSONL v2 format, the <code>pixano data</code> CLI, and round-trip export.
+    </Card>
+    <Card title="Custom Importers" href="/getting_started/custom_importers/" icon="code">
+      Write a <code>DatasetImporter</code> for a format Pixano does not ship.
     </Card>
   </CardGrid>
 

--- a/docs-astro/src/pages/getting_started/installing_pixano.mdx
+++ b/docs-astro/src/pages/getting_started/installing_pixano.mdx
@@ -18,23 +18,65 @@ import PrevNext from '../../components/PrevNext.astro'
 Pixano is tested on Linux and macOS. It should work on Windows but is not officially tested.
 </Callout>
 
+## Install with uv (recommended)
+
+Pixano depends on `pixano-inference-client`, which is not published to PyPI yet — it is
+pulled from git. [uv](https://docs.astral.sh/uv/) resolves that automatically, so it is the
+simplest way to install:
+
+```bash
+uv venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+uv pip install pixano
+```
+
 ## Install with pip
 
-We recommend installing Pixano in a virtual environment to keep dependencies isolated:
+pip does not read the git source declared in Pixano's metadata, so install that one
+dependency explicitly first:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install "pixano-inference-client @ git+https://github.com/pixano/pixano-inference@production-hardening#subdirectory=packages/pixano-inference-client"
 pip install pixano
 ```
 
-Verify the installation:
+<Callout type="note" title="Why the extra step?">
+`pixano-inference-client` is the client library Pixano uses to talk to a
+[pixano-inference](https://github.com/pixano/pixano-inference) server. Once it is published to
+PyPI, a plain `pip install pixano` will be enough.
+</Callout>
+
+## Optional format extras
+
+The COCO and LeRobot importers need extra dependencies. Install the ones you need:
+
+```bash
+pip install "pixano[coco]"      # COCO import/export (ijson)
+pip install "pixano[lerobot]"   # LeRobot datasets, incl. Hugging Face Hub (huggingface_hub)
+pip install "pixano[coco,lerobot]"
+```
+
+Pixano tells you which extra is missing if you try to import one of these formats without it.
+
+## Install from source
+
+To work on Pixano itself, or to get the latest unreleased changes:
+
+```bash
+git clone https://github.com/pixano/pixano.git
+cd pixano
+uv sync
+```
+
+## Verify the installation
 
 ```bash
 pip show pixano
 ```
 
-You should see output including `Name: pixano` and `Version: 0.7.x`.
+You should see output including `Name: pixano` and `Version: 0.8.x`.
 
 You can also check that the CLI is available:
 
@@ -52,6 +94,11 @@ docker pull pixano/pixano:stable
 ```
 
 If you need to pin a specific release, use the corresponding version tag instead of `stable`.
+
+<Callout type="note" title="Image availability">
+Official images are built per release. Until `pixano-inference-client` is on PyPI, an image for a
+given version is only available once that release has been built successfully.
+</Callout>
 
 Run the container with a mounted library directory:
 
@@ -73,7 +120,9 @@ container restarts or upgrades.
 
 | Problem | Solution |
 |---------|----------|
-| `pip install pixano` fails with build errors | Make sure you have Python 3.10+ and an up-to-date pip: `pip install --upgrade pip` |
+| `pip install pixano` cannot resolve `pixano-inference-client` | Install it from git first (see [Install with pip](#install-with-pip)), or use `uv` |
+| `pip install pixano` fails with build errors | Make sure you have Python 3.10-3.13 and an up-to-date pip: `pip install --upgrade pip` |
+| `No module named 'ijson'` / `huggingface_hub` on import | Install the matching extra: `pip install "pixano[coco]"` or `"pixano[lerobot]"` |
 | `pixano` command not found after install | Activate your virtual environment: `source .venv/bin/activate` |
 | Port 7492 already in use | Use `--port 8000` or stop the other process |
 | Docker container exits immediately | Check logs with `docker logs pixano`, then verify that the mounted host directory exists and is writable |

--- a/docs-astro/src/pages/getting_started/key_concepts.mdx
+++ b/docs-astro/src/pages/getting_started/key_concepts.mdx
@@ -22,16 +22,17 @@ Run the full stack with `pixano server run`, or use the Python backend directly 
 
 ## How data is organized
 
-A Pixano dataset is a collection of **tables** stored in a [LanceDB](https://lancedb.github.io/lancedb/) database. Each table belongs to one of six **schema groups**:
+A Pixano dataset is a collection of **tables** stored in a [LanceDB](https://lancedb.github.io/lancedb/) database. Each table belongs to one of seven **schema groups**:
 
 | Group | Purpose | Schema classes |
 |-------|---------|----------------|
 | **Record** | One row per dataset sample. Holds metadata, split, and workflow status. | `Record` |
 | **View** | Media files attached to a record. | `Image`, `Video`, `SequenceFrame`, `Text` |
 | **Entity** | An object observable in one or more views (e.g. a car, a person). | `Entity` |
-| **Annotation** | Labels attached to entities (bounding boxes, masks, keypoints, etc.). | `BBox`, `CompressedRLE`, `KeyPoints`, `TextSpan`, `Message`, `Tracklet` |
+| **Annotation** | Labels attached to entities (bounding boxes, masks, keypoints, etc.). | `BBox`, `CompressedRLE`, `KeyPoints`, `MultiPath`, `Classification`, `TextSpan`, `Message`, `Tracklet` |
 | **EntityDynamicState** | Per-frame state of an entity in video (e.g. visibility, pose). | `EntityDynamicState` |
-| **Embedding** | Vectors for semantic search. | `ViewEmbedding` |
+| **Timeseries** | Numeric signals sampled alongside a record (e.g. robot state). | `Timeseries` |
+| **Embedding** | Vectors for semantic search. | `RecordEmbedding` (record-level, used by the app), `ViewEmbedding` (legacy, per-view) |
 
 All schema classes live in `pixano.schemas` and are Pydantic models backed by LanceDB. You can subclass them to add custom fields.
 
@@ -63,7 +64,7 @@ schema:
   annotations: [bbox]
 ```
 
-The `workspace` selects the UI layout and provides default views. The `annotations` list determines which annotation tables are created in the database. See [Importing Data](/getting_started/importing_data/) for the full reference.
+The `workspace` selects the UI layout and provides default views. The `annotations` list determines which annotation tables are created in the database. See [Importing Data](/pixano/getting_started/importing_data/) for the full reference.
 
 ### Custom fields
 
@@ -93,7 +94,7 @@ The base `Record` class provides these fields out of the box:
 | `created_at` | `datetime` | now | Creation timestamp |
 | `updated_at` | `datetime` | now | Last modification timestamp |
 
-The `status` field is central to annotation campaigns: filter the dataset explorer by status to see which items still need work, and use the dashboard to track overall progress. You can set `status` in `metadata.jsonl` during import (e.g. `"status": "validated"` for ground truth).
+The `status` field is central to annotation campaigns: filter the dataset explorer by status to see which records still need work, and the Split and Status facets show how many fall into each bucket. You can set `status` in `metadata.jsonl` during import (e.g. `"status": "validated"` for ground truth).
 
 ## Annotation provenance
 
@@ -130,7 +131,8 @@ library/<dataset>/
   info.json               # Name, description, workspace type, schema
   features_values.json    # Value constraints for fields
   stats.json              # Dataset statistics
-  preview.png             # Thumbnail for the UI
+  embeddings.json         # Semantic-search sidecar (model, dimension, metric)
+  previews/               # Generated thumbnails for the UI
   db/                     # LanceDB tables (one per schema)
 ```
 
@@ -152,8 +154,9 @@ images = ds.get_data("image", limit=5)
 # Add annotations
 ds.add_data("bboxes", [bbox1, bbox2])
 
-# Semantic search (requires precomputed embeddings)
-records, distances, record_ids = ds.semantic_search("car on road", "image_embedding", limit=50)
+# Semantic search over record embeddings. The query vector comes from the
+# inference server; the app does this for you from the explorer's search bar.
+records, distances = ds.search_records(query_vector, k=50)
 ```
 
 ## Next steps

--- a/docs-astro/src/pages/getting_started/quickstart.mdx
+++ b/docs-astro/src/pages/getting_started/quickstart.mdx
@@ -25,13 +25,14 @@ By the end of this page, you will have imported your own images into Pixano and 
 
 ## Step 1 — Initialize Pixano
 
-First, bootstrap Pixano by creating a **library** — the place where all your datasets will be stored:
+First, create a **data directory** — the place Pixano keeps everything it manages:
 
 ```bash
-pixano init ./my_library
+pixano init ./my_data
 ```
 
-This sets up your dataset library and runs all internal setup. From now on, `./my_library` is where Pixano manages your datasets and everything it needs to operate.
+This creates `library/` (your datasets), `media/`, and `models/` inside `./my_data`. Every other
+command takes this directory as its first argument.
 
 ## Step 2 — Define your dataset schema
 
@@ -100,14 +101,14 @@ Without a `metadata.jsonl` file, Pixano auto-discovers all supported images in e
 Now bring everything together:
 
 ```bash
-pixano data import ./my_library ./my_images
+pixano data import ./my_data ./my_images
 ```
 
 Here is what this command does:
 
 1. Reads your schema from `my_images/dataset.yaml`
 2. Scans `my_images/` for split folders and images, validates everything, and prints a plan
-3. After you confirm, creates a new dataset in `./my_library` with the tables you defined
+3. After you confirm, creates a new dataset in `./my_data` with the tables you defined
 4. Stores each image as a record with its associated view — media bytes embedded, fully self-contained
 
 Common import options:
@@ -117,21 +118,23 @@ Common import options:
 | `--spec` | Path to a `dataset.yaml` outside the source folder. |
 | `--name`, `--workspace` | Override the yaml (or replace it entirely for simple datasets). |
 | `--mode` | `create` (default), `overwrite`, or `add`. |
+| `--media` | `embed` (default, self-contained) or `uri` (store datalake URIs verbatim). |
 | `--dry-run` | Validate and print the plan without creating the dataset. |
+| `--yes`, `-y` | Skip the confirmation prompt — use this in scripts and CI. |
 
-To attach annotations at import time, add a `metadata.jsonl` per split — see [Importing Data](/getting_started/importing_data/).
+To attach annotations at import time, add a `metadata.jsonl` per split — see [Importing Data](/pixano/getting_started/importing_data/).
 
 ## Step 5 — Launch and explore
 
 Start the Pixano server:
 
 ```bash
-pixano server run ./my_library
+pixano server run ./my_data
 ```
 
 Open **http://127.0.0.1:7492** in your browser.
 
-You will see the Pixano home page with a card for your dataset. Click it to enter the dataset explorer, where you can browse your images, see their split and status, and open any image in the annotation workspace.
+You will see the Pixano **Library** with a card for your dataset. Click it to enter the dataset explorer, where you can browse your records, filter them by split and status, and open any one of them in the annotation workspace.
 
 Server options:
 
@@ -139,6 +142,7 @@ Server options:
 |--------|-------------|---------|
 | `--host` | Bind address (e.g. `0.0.0.0` for network access) | `127.0.0.1` |
 | `--port` | Port number | `7492` |
+| `--pixano-inference-url` | URL of a [pixano-inference](https://github.com/pixano/pixano-inference) server, which powers smart segmentation and semantic search | none |
 
 ## What just happened?
 
@@ -147,7 +151,7 @@ Let's connect the dots between what you did and how Pixano sees your data:
 - The **dataset.yaml** you wrote became a set of **database tables** — one for records, one for image views, one for entities, one for bounding boxes, and one for masks.
 - Each image you placed in `my_images/train/` became a **record** in the `train` split, with an associated **image view**.
 - The **entity** and **annotation** tables are empty for now — they will be populated as you (or a model) annotate objects in the UI.
-- Because you declared `BBox` and `CompressedRLE` in your schema, the annotation workspace knows to offer both bounding box and mask tools when you start labeling.
+- Because you declared `bbox` and `mask` in your schema, the annotation workspace knows to offer both bounding box and mask tools when you start labeling.
 
 You will learn more about this data model in [Key Concepts](/pixano/getting_started/key_concepts/).
 

--- a/docs-astro/src/pages/index.astro
+++ b/docs-astro/src/pages/index.astro
@@ -29,13 +29,12 @@ import Card from "../components/Card.astro";
 
   <h2>Cookbook</h2>
   <p>
-    Each guide walks you end-to-end through a real dataset: import, explore in
-    the UI, annotate, and use advanced features like pre-annotation and
-    semantic search.
+    Each guide walks you end-to-end through a real dataset: define the schema,
+    import it, explore it in the app, and annotate it.
   </p>
   <CardGrid columns={3}>
     <Card title="Object Detection" href="/cookbook/object_detection/" icon="target">
-      Pascal VOC 2007 with bounding boxes, YOLO pre-annotation, and semantic search.
+      Pascal VOC 2007 with bounding boxes, SAM-assisted masks, and annotation provenance.
     </Card>
     <Card title="Video Object Tracking" href="/cookbook/video_tracking/" icon="video">
       DAVIS 2017 with timeline annotations, tracklets, and SAM segmentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/pixano/pixano#readme"
+Documentation = "https://pixano.github.io/pixano/"
 Issues = "https://github.com/pixano/pixano/issues"
 Source = "https://github.com/pixano/pixano"
 


### PR DESCRIPTION
Correctness pass from the adversarial documentation review. Every change below is backed by code evidence; nothing here is a rewrite or a restructure.

**Why now:** the docs froze on 2026-07-22, and the whole UI redesign landed 07-25 → 07-27. `installing_pixano.mdx` had not been touched since 2026-03-27 — before both the import redesign and the inference rewrite.

## Broken (docs told users to do things that fail)

- **7 dead links.** Every "Importing Data" cross-reference omitted the `/pixano` base and 404s in production. MDX links are not base-rewritten by Astro; 30 other links had it right. Fixed in `quickstart`, `key_concepts` and all 5 cookbook pages.
- **The API reference was unreachable from its own index.** All four cards on `api_reference/index.astro` pointed at `/api_reference/app|datasets|features|utils/` — routes that do not exist (only `/api_reference/module/[...slug]` does), and `app` is a pre-0.7 module name. Replaced with seven cards pointing at real generated pages, including the `datasets.io` core.
- **Dead sidebar entry** — `navigation.ts` linked `inference/mask_generation`, removed by the inference rewrite.
- **`PrevNext` rendered empty links** on `importing_data` and `custom_importers`: they passed `label:` where the component reads `title:`.
- **`pip install pixano` does not work on its own.** `pixano-inference-client` is a hard runtime dependency resolved only through `[tool.uv.sources]` git — pip ignores that and the package is not on PyPI. The page now leads with `uv`, and documents the explicit git install for pip users.
- **Advertised docs URL was dead.** `README.md` pointed at `.../pixano/latest/getting_started/`; `/latest/` was the mkdocs `mike` alias and the Astro site has no version segment. Also repointed the docs badge and `pyproject.toml`'s `Documentation` URL, which sent PyPI visitors to the README instead of the docs.

## Stale (described superseded behavior)

- **Version**: banner announced "Pixano v0.7.2 is out" on every page; install page said `Version: 0.7.x`.
- **`key_concepts`**: "six schema groups" is now seven (`TIMESERIES`); the Embedding row named only the legacy `ViewEmbedding` (0.8 adds `RecordEmbedding` + the `embeddings.json` sidecar); the Python example called `ds.semantic_search(...)`, which now rejects anything but a ViewEmbedding table; the dataset layout omitted `previews/` and `embeddings.json`; annotation classes omitted `Classification`/`MultiPath`; and it referenced a **dashboard that no longer exists**.
- **`quickstart`**: `pixano init ./my_library` taught the wrong mental model — `init` creates `library/`, `media/`, `models/` *inside* the argument, and every other command calls it the data directory. Option tables gained `--yes` (there was no documented non-interactive path), `--media`, and `--pixano-inference-url`.
- **UI terminology**, corrected against the Svelte source: "Object panel" → **Entities** tab, entity-card sub-sections → **Attributes / Annotations**, "Tag Selected Text" → **Tag selection**, "home page" → **Library**, item → record.
- **Video timeline**: docs said every entity's track is shown; it now shows the focused entity, with up to two pinned for comparison.
- **Removed two tools the docs promised.** `KeyPointsSelectionTool.svelte` and `FusionTool.svelte` have **zero importers** — the keypoints and associate tools have no entry point in the 0.8 UI, so `multi_view_detection` no longer claims them. Flagged below as a code issue.
- **Smart segmentation** no longer needs precomputed local embeddings — it needs a connected inference server.
- **Overclaims**: the landing page advertised "YOLO pre-annotation, and semantic search" for a cookbook that covers neither, and the getting-started card promised a quickstart "with pre-annotations" that imports plain images.

## Gaps filled

- `importing_data`: the CLI is seven commands, not four; export gained the `--format coco` / `--media` table; **COCO and LeRobot import are now documented** (extras, Hub import, `--episodes`) — two of the three shipped importers previously appeared nowhere.
- `installing_pixano`: optional extras and the from-source `uv sync` path that the README and landing page already advertised.
- `getting_started/index.astro`: added cards for Importing Data and Custom Importers.

## Not in this PR

Screenshots (all 18 in the legacy tree are stale) and the new UI/semantic-search/inference pages are the next step. The API reference still has ~86 generated module pages with no nav entry — a separate fix.

**Code issues surfaced, for the UI owners:** the keypoints and associate tools are unreachable (components mounted nowhere) though their downstream logic still exists; `KeyboardShortcuts.svelte` advertises `Shift+A`/`Shift+D` but only the arrow keys are handled.

## Checks

`pnpm run build` green (141 pages, generate-api + pagefind). Verified after the build: **0** links missing the `/pixano` base, **0** dead `navigation.ts` API hrefs, all 7 new card targets present in `dist/`, banner renders v0.8.0, and the previously-empty PrevNext labels now render. `prettier --check ./*.md` clean under the 2.8.8 that CI gates with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)